### PR TITLE
initial maccy obj once

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -6,10 +6,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   let history = History()
   let hotKey = GlobalHotKey()
 
-  var maccy: Maccy {
-    return Maccy(history: history, clipboard: clipboard)
-  }
+  var maccy: Maccy
 
+  override init() {
+    self.maccy = Maccy(history: history, clipboard: clipboard)
+    super.init()
+  }
   func applicationDidFinishLaunching(_ aNotification: Notification) {
     maccy.start()
     hotKey.handler = { self.maccy.popUp() }

--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -45,7 +45,7 @@ class Maccy {
   }
 
   func popUp() {
-    refresh()
+//    refresh()
     menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
   }
 


### PR DESCRIPTION
initial maccy obj at init(). other wise 'maccy.stgart()' and  'maccy.popUp()' is not same obj.
fix it , and then 'refresh() at Maccy#popUp()' is unnecessary.