### PR TITLE
Prevent auto focus on system items

### DIFF
--- a/Maccy/Menu.swift
+++ b/Maccy/Menu.swift
@@ -47,7 +47,9 @@ class Menu: NSMenu, NSMenuDelegate {
       }
     }
 
-    highlight(highlightableItems(items).first)
+    // do not highlight system items on search
+    let highlightable = highlightableItems(items).filter { !isSystemItem(item: $0) }.first
+    highlight(highlightable)
   }
 
   func select() {


### PR DESCRIPTION
The new release partially fixed issue #16. The proposed changes will prevent the focus on "Clear" item on search if has no result.