### PR TITLE
Native status icon hiding & the beginning of normal settings

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -16,4 +16,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     maccy.start()
     hotKey.handler = { self.maccy.popUp() }
   }
+  func applicationShouldHandleReopen(_ sender: NSApplication,
+                                   hasVisibleWindows flag: Bool) -> Bool {
+    maccy.statusItem.isVisible = true
+    return true
+  }
 }

--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -2,14 +2,26 @@ import Cocoa
 
 class Maccy {
   private let about = About()
-  private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+  let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
   private let menu = Menu(title: "Maccy")
 
-  private let showInStatusBar = "showInStatusBar"
   private let pasteByDefault = "pasteByDefault"
 
   private let history: History
   private let clipboard: Clipboard
+    
+  private var pasteByDefaultItem: NSMenuItem {
+    let pasteByDefault = UserDefaults.standard.bool(forKey: self.pasteByDefault)
+    let item = NSMenuItem(title: "Paste by Default", action: #selector(togglePasteByDefault), keyEquivalent: "")
+    item.target = self
+    item.indentationLevel = 1
+    if pasteByDefault {
+      item.state = .on
+    } else {
+      item.state = .off
+    }
+    return item
+  }
 
   private var clearItem: NSMenuItem {
     let item = NSMenuItem(title: "Clear", action: #selector(clear), keyEquivalent: "")
@@ -27,14 +39,13 @@ class Maccy {
     self.history = history
     self.clipboard = clipboard
 
-    UserDefaults.standard.register(defaults: [showInStatusBar: true, pasteByDefault: false])
+    UserDefaults.standard.register(defaults: [pasteByDefault: false])
   }
 
   func start() {
-    if UserDefaults.standard.bool(forKey: showInStatusBar) {
-      statusItem.button!.image = NSImage(named: "StatusBarMenuImage")
-      statusItem.menu = menu
-    }
+    statusItem.button!.image = NSImage(named: "StatusBarMenuImage")
+    statusItem.menu = menu
+    statusItem.behavior = .removalAllowed
 
     refresh()
 
@@ -74,6 +85,10 @@ class Maccy {
     menu.addItem(NSMenuItem.separator())
     menu.addItem(clearItem)
     menu.addItem(aboutItem)
+    menu.addItem(NSMenuItem.separator())
+    menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ""))
+    menu.addItem(pasteByDefaultItem)
+    menu.addItem(NSMenuItem.separator())
     menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApp.stop), keyEquivalent: "q"))
   }
 
@@ -113,6 +128,18 @@ class Maccy {
   @objc
   func clear(_ sender: NSMenuItem) {
     history.clear()
+    refresh()
+  }
+    
+  @objc func togglePasteByDefault(_ sender: NSMenuItem) {
+    let pasteState = UserDefaults.standard.bool(forKey: self.pasteByDefault)
+    if pasteState {
+      UserDefaults.standard.set(false, forKey: pasteByDefault)
+      sender.state = .off
+    } else {
+      UserDefaults.standard.set(true, forKey: pasteByDefault)
+      sender.state = .on
+    }
     refresh()
   }
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and lets you easily navigate, search and use previous clipboard contents.
   * [Change Default Settings](#change-default-settings)
     * [Popup Hotkey](#popup-hotkey)
     * [History Size](#history-size)
-    * [Show/Hide Icon in Status Bar](#show/hide-icon-in-status-bar)
+    * [Hide Icon in Status Bar](#hide-icon-in-status-bar)
     * [Automatically Paste by Default](#automatically-paste-by-default)
 * [Update](#update)
 * [Why Yet Another Clipboard Manager](#why-yet-another-clipboard-manager)
@@ -39,13 +39,13 @@ and lets you easily navigate, search and use previous clipboard contents.
 
 Download the latest version from the [releases](https://github.com/p0deje/Maccy/releases/latest) page, or use [Homebrew](https://brew.sh/):
 
-```bash
+```sh
 brew cask install maccy
 ```
 
 ## Usage
 
-1. ⌘+⇧+C to popup Maccy or click on its icon in menu bar.
+1. <kbd>⌘</kbd>+<kbd>⇧</kbd>+<kbd>C</kbd> to popup Maccy or click on its icon in menu bar.
 2. Type what you want to find.
 3. To select the history item you want to copy, press Enter, or click the item, or use ⌘+n shortcut.
 4. To select the history item and paste, press ⌥+Enter, or ⌥+click the item, or use ⌥+n shortcut.
@@ -62,33 +62,31 @@ To change default settings, use the following commands from Terminal.
 
 #### Popup Hotkey
 
-```bash
+```powershell
 defaults write org.p0deje.Maccy hotKey control+option+m # default is command+shift+c
 ```
 
 #### History Size
 
-```bash
+```powershell
 defaults write org.p0deje.Maccy historySize 100 # default is 999
 ```
 
-#### Show/Hide Icon in Status Bar
+#### Hide Icon in Status Bar
 
-```bash
-defaults write org.p0deje.Maccy showInStatusBar false # default is true
-```
+1. Drag it away from status bar holding <kbd>⌘</kbd> until you see a cross.
+2. Let it go.
+> To recover the icon, open `Maccy` when it's already running.
 
 #### Automatically Paste by Default
 
-```bash
-defaults write org.p0deje.Maccy pasteByDefault true # default is false
-```
+You can change this behavior right in the popup.
 
 ## Update
 
 Download and reinstall the latest version from the [releases](https://github.com/p0deje/Maccy/releases/latest) page, or use [Homebrew](https://brew.sh/):
 
-```bash
+```powershell
 brew update
 brew cask upgrade maccy
 killall Maccy # closes the app if is running


### PR DESCRIPTION
## No more terminal for hiding status bar item. And for "Paste by Default" setting.

### To hide the status bar icon
1. Drag it away from status bar holding <kbd>Command</kbd> until you see a cross.
2. Let it go.
> To recover the icon, open Maccy when it's already running.

### Settings: The Beginning

Hey, it would be nice to add all the settings here. I've added just one — "Paste by Default" — and that's already cool.

<img width="426" alt="new Settings" src="https://user-images.githubusercontent.com/46137336/62781658-20028000-bac1-11e9-9d64-374951eba854.png">

![Hiding status bar item](https://user-images.githubusercontent.com/46137336/62781666-23960700-bac1-11e9-9ec9-2a9c5b53f10a.gif)

![Recovering status bar item](https://user-images.githubusercontent.com/46137336/62781673-27c22480-bac1-11e9-93bb-c87b3edc7aa5.gif)
