### PR TITLE
Slightly better settings

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -16,4 +16,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     maccy.start()
     hotKey.handler = { self.maccy.popUp() }
   }
+  func applicationShouldHandleReopen(_ sender: NSApplication,
+                                     hasVisibleWindows flag: Bool) -> Bool {
+    maccy.statusItem.isVisible = true
+    UserDefaults.standard.removeObject(forKey: "showInStatusBar")
+    return true
+  }
 }

--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -12,58 +12,11 @@ class Maccy {
   private let clipboard: Clipboard
 
   private var clearItem: NSMenuItem {
-    let item = NSMenuItem(title: "Clear", action: #selector(clear), keyEquivalent: "⌦")
-    item.keyEquivalentModifierMask = .control
+    let item = NSMenuItem(title: "Clear", action: #selector(clear), keyEquivalent: "")
     item.target = self
     return item
   }
-  
-  private var prefItem: NSMenuItem {
-    let item = NSMenuItem(title: "Preferences", action: nil, keyEquivalent: "")
-    let prefMenu = NSMenu()
-    prefMenu.addItem(pasteByDefaultItem)
-    prefMenu.addItem(NSMenuItem.separator())
-    prefMenu.addItem(historySizeItem)
-    prefMenu.addItem(hotKeyItem)
-    prefMenu.addItem(howToItem)
-    item.submenu = prefMenu
-    item.target = self
-    return item
-  }
-  
-  private var pasteByDefaultItem: NSMenuItem {
-    let item = NSMenuItem(title: "Paste by Default", action: #selector(togglePasteByDefault), keyEquivalent: "")
-    item.target = self
-    if UserDefaults.standard.bool(forKey: pasteByDefault) {
-      item.state = .on
-    } else {
-      item.state = .off
-    }
-    return item
-  }
-  private var howToItem: NSMenuItem {
-    let item = NSMenuItem()
-    item.title = "How to configure?"
-    item.action = #selector(openHowToConfig)
-    item.indentationLevel = 1
-    item.target = self
-    return item
-  }
-  private var historySizeItem: NSMenuItem {
-    let historySize = UserDefaults.standard.integer(forKey: "historySize")
-    let item = NSMenuItem()
-    item.title = "History Size: " + String(historySize)
-    item.target = self
-    return item
-  }
-  private var hotKeyItem: NSMenuItem {
-    let hotKey = UserDefaults.standard.string(forKey: "hotKey")
-    let item = NSMenuItem()
-    item.title = "Hotkey: " + hotKey!
-    item.target = self
-    return item
-  }
-  
+
   private var aboutItem: NSMenuItem {
     let item = NSMenuItem(title: "About", action: #selector(about.openAbout), keyEquivalent: "")
     item.target = about
@@ -123,7 +76,6 @@ class Maccy {
   private func populateFooter() {
     menu.addItem(NSMenuItem.separator())
     menu.addItem(clearItem)
-    menu.addItem(prefItem)
     menu.addItem(aboutItem)
     menu.addItem(NSMenuItem(title: "Quit", action: #selector(NSApp.stop), keyEquivalent: "q"))
   }
@@ -165,22 +117,5 @@ class Maccy {
   func clear(_ sender: NSMenuItem) {
     history.clear()
     refresh()
-  }
-  
-  @objc
-  func togglePasteByDefault(_ sender: NSMenuItem) {
-    let pasteState = UserDefaults.standard.bool(forKey: pasteByDefault)
-    UserDefaults.standard.set(!pasteState, forKey: pasteByDefault)
-    if pasteState {
-      sender.state = .off
-    } else {
-      sender.state = .on
-    }
-    refresh()
-  }
-  
-  @objc
-  func openHowToConfig(_ sender: NSMenuItem) {
-    NSWorkspace.shared.open(URL(string: "https://github.com/p0deje/Maccy#customization")!)
   }
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and lets you easily navigate, search and use previous clipboard contents.
   * [Change Default Settings](#change-default-settings)
     * [Popup Hotkey](#popup-hotkey)
     * [History Size](#history-size)
-    * [Show/Hide Icon in Status Bar](#show/hide-icon-in-status-bar)
+    * [Hide Icon in Status Bar](#hide-icon-in-status-bar)
     * [Automatically Paste by Default](#automatically-paste-by-default)
 * [Update](#update)
 * [Why Yet Another Clipboard Manager](#why-yet-another-clipboard-manager)
@@ -72,17 +72,15 @@ defaults write org.p0deje.Maccy hotKey control+option+m # default is command+shi
 defaults write org.p0deje.Maccy historySize 100 # default is 999
 ```
 
-#### Show/Hide Icon in Status Bar
+#### Hide Icon in Status Bar
 
-```bash
-defaults write org.p0deje.Maccy showInStatusBar false # default is true
-```
+1. Drag it away from status bar holding <kbd>⌘</kbd> until you see a cross.
+2. Let it go.
+> To recover the icon, open `Maccy` when it's already running.
 
 #### Automatically Paste by Default
 
-```bash
-defaults write org.p0deje.Maccy pasteByDefault true # default is false
-```
+You can change this behavior using `Preferences` right in the popup.
 
 ## Update
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ defaults write org.p0deje.Maccy historySize 100 # default is 999
 
 #### Automatically Paste by Default
 
-You can change this behavior using `Preferences` right in the popup.
+```bash
+defaults write org.p0deje.Maccy pasteByDefault true # default is false
+```
 
 ## Update
 


### PR DESCRIPTION
# That's already cool. No more terminal for hiding status bar item. And for "Paste by Default" setting.

#### Native status bar icon hiding (respecting old `showInStatusBar` setting)
1. Drag it away from status bar holding Command until you see a cross.
2. Let it go.
> To recover the icon, open Maccy when it's already running.

`showInStatusBar` still exists. And still, unlike the native function, it requires a relaunch.
The new (quick, and native) `statusItem.isVisible` will inherit `showInStatusBar` state.

![hiding](https://user-images.githubusercontent.com/46137336/63064924-767e1d00-bf0c-11e9-8aa9-7351bd565d2c.gif)

---
`Paste by Default` preference,
Info about other settings with `How to` button leading to [#customization](//github.com/p0deje/Maccy#customization)
> Realised that it's hard to make slider and input right here, in the menu.
Would be cool, but it's over my level. Just have no time to learn it for now.

<kbd>Fn</kbd>+<kbd>Ctrl</kbd>+<kbd>Backspace</kbd> shortcut for `Clear` menu item

<img width="682" alt="screenshot" src="https://user-images.githubusercontent.com/46137336/63063952-7c253400-bf07-11e9-881c-bfa53ef63460.png">