### PR TITLE
Add support for PasteboardType.png in Clipboard

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -56,5 +56,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       })
       UserDefaults.standard.migrations["2020-02-22-history-item-add-number-of-copies"] = true
     }
+
+    if UserDefaults.standard.migrations["2020-03-18-store-pasteboard-type"] != true {
+      UserDefaults.standard.storage = UserDefaults.standard.storage.map({ item in
+        let migratedItem = item
+        if let _ = NSImage(data: item.value) {
+          migratedItem.types = [.tiff]
+        } else {
+          migratedItem.types = [.string]
+        }
+        return migratedItem
+      })
+      UserDefaults.standard.migrations["2020-03-18-store-pasteboard-type"] = true
+    }
   }
 }

--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -61,9 +61,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       UserDefaults.standard.storage = UserDefaults.standard.storage.map({ item in
         let migratedItem = item
         if NSImage(data: item.value) != nil {
-          migratedItem.types = [.tiff]
+          migratedItem.type = .tiff
         } else {
-          migratedItem.types = [.string]
+          migratedItem.type = .string
         }
         return migratedItem
       })

--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -60,7 +60,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if UserDefaults.standard.migrations["2020-03-18-store-pasteboard-type"] != true {
       UserDefaults.standard.storage = UserDefaults.standard.storage.map({ item in
         let migratedItem = item
-        if let _ = NSImage(data: item.value) {
+        if NSImage(data: item.value) != nil {
           migratedItem.types = [.tiff]
         } else {
           migratedItem.types = [.string]

--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       if let oldStorage = UserDefaults.standard.array(forKey: UserDefaults.Keys.storage) as? [String] {
         UserDefaults.standard.storage = oldStorage.compactMap({ item in
           if let data = item.data(using: .utf8) {
-            return HistoryItem(value: data)
+            return HistoryItem(typesWithData: [.string: data])
           } else {
             return nil
           }
@@ -60,10 +60,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     if UserDefaults.standard.migrations["2020-03-18-store-pasteboard-type"] != true {
       UserDefaults.standard.storage = UserDefaults.standard.storage.map({ item in
         let migratedItem = item
-        if NSImage(data: item.value) != nil {
-          migratedItem.type = .tiff
+        if item.value != nil && NSImage(data: item.value!) != nil {
+          migratedItem.typesWithData = [.tiff: item.value!]
         } else {
-          migratedItem.type = .string
+          migratedItem.typesWithData = [.string: item.value!]
         }
         return migratedItem
       })

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -6,6 +6,7 @@ class Clipboard {
 
   private let pasteboard = NSPasteboard.general
   private let timerInterval = 1.0
+  private let supportedTypes: [NSPasteboard.PasteboardType] = [.tiff, .png, .string]
 
   // See http://nspasteboard.org for more details.
   private let ignoredTypes: Set = [
@@ -78,25 +79,13 @@ class Clipboard {
     // See https://github.com/p0deje/Maccy/issues/78.
     pasteboard.pasteboardItems?.forEach({ item in
       if !shouldIgnore(item.types) {
-        if item.types.contains(.tiff) {
-          if let data = item.data(forType: .tiff) {
-            let historyItem = HistoryItem(value: data)
-            historyItem.type = .image
-            historyItem.imageType = .tiff
-            onNewCopyHooks.forEach({ $0(historyItem) })
-          }
-        } else if item.types.contains(.png) {
-          if let data = item.data(forType: .png) {
-            let historyItem = HistoryItem(value: data)
-            historyItem.type = .image
-            historyItem.imageType = .png
-            onNewCopyHooks.forEach({ $0(historyItem) })
-          }
-        } else {
-          if let data = item.data(forType: .string) {
-            let historyItem = HistoryItem(value: data)
-            historyItem.type = .string
-            onNewCopyHooks.forEach({ $0(historyItem) })
+        for type in supportedTypes {
+          if item.types.contains(type) {
+            if let data = item.data(forType: type) {
+              let historyItem = HistoryItem(value: data)
+              historyItem.types = item.types
+              onNewCopyHooks.forEach({ $0(historyItem) })
+            }
           }
         }
       }

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -82,12 +82,14 @@ class Clipboard {
           if let data = item.data(forType: .tiff) {
             let historyItem = HistoryItem(value: data)
             historyItem.type = .image
+            historyItem.imageType = .tiff
             onNewCopyHooks.forEach({ $0(historyItem) })
           }
         } else if item.types.contains(.png) {
           if let data = item.data(forType: .png) {
             let historyItem = HistoryItem(value: data)
             historyItem.type = .image
+            historyItem.imageType = .png
             onNewCopyHooks.forEach({ $0(historyItem) })
           }
         } else {

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -84,6 +84,12 @@ class Clipboard {
             historyItem.type = .image
             onNewCopyHooks.forEach({ $0(historyItem) })
           }
+        } else if item.types.contains(.png) {
+          if let data = item.data(forType: .png) {
+            let historyItem = HistoryItem(value: data)
+            historyItem.type = .image
+            onNewCopyHooks.forEach({ $0(historyItem) })
+          }
         } else {
           if let data = item.data(forType: .string) {
             let historyItem = HistoryItem(value: data)

--- a/Maccy/History.swift
+++ b/Maccy/History.swift
@@ -24,7 +24,7 @@ class History {
       return
     }
 
-    if item.type == .string, let string = String(data: item.value, encoding: .utf8) {
+    if item.types.contains(.string), let string = String(data: item.value, encoding: .utf8) {
       if string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         return
       }

--- a/Maccy/History.swift
+++ b/Maccy/History.swift
@@ -24,7 +24,7 @@ class History {
       return
     }
 
-    if item.type == .string, let string = String(data: item.value, encoding: .utf8) {
+    if item.typesWithData[.string] != nil, let string = String(data: item.typesWithData[.string]!, encoding: .utf8) {
       if string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         return
       }

--- a/Maccy/History.swift
+++ b/Maccy/History.swift
@@ -24,7 +24,7 @@ class History {
       return
     }
 
-    if item.types.contains(.string), let string = String(data: item.value, encoding: .utf8) {
+    if item.type == .string, let string = String(data: item.value, encoding: .utf8) {
       if string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         return
       }

--- a/Maccy/HistoryItem.swift
+++ b/Maccy/HistoryItem.swift
@@ -57,7 +57,12 @@ public class HistoryItem: Equatable, Codable {
     }
   }
 
-  convenience init(typesWithData: [NSPasteboard.PasteboardType: Data], firstCopiedAt: Date, lastCopiedAt: Date, numberOfCopies: Int) {
+  convenience init(
+    typesWithData: [NSPasteboard.PasteboardType: Data],
+    firstCopiedAt: Date,
+    lastCopiedAt: Date,
+    numberOfCopies: Int
+  ) {
     self.init(typesWithData: typesWithData)
 
     self.firstCopiedAt = firstCopiedAt

--- a/Maccy/HistoryItem.swift
+++ b/Maccy/HistoryItem.swift
@@ -1,37 +1,24 @@
 import AppKit
 
 public class HistoryItem: Equatable, Codable {
-  public enum Types: String, Codable {
-    case string
-    case image
-  }
-
-  public enum ImageTypes: String, Codable {
-    case png
-    case tiff
-  }
-
   public let value: Data!
   public var firstCopiedAt: Date!
   public var lastCopiedAt: Date!
   public var numberOfCopies: Int!
   public var pin: String?
-  public var type: Types!
-  public var imageType: ImageTypes?
+  public var types: [NSPasteboard.PasteboardType] = []
+
+  private enum CodingKeys: String, CodingKey {
+    case value
+    case firstCopiedAt
+    case lastCopiedAt
+    case numberOfCopies
+    case pin
+    case types
+  }
 
   public static func == (lhs: HistoryItem, rhs: HistoryItem) -> Bool {
     return lhs.value == rhs.value
-  }
-
-  public func getPasteboardType() -> NSPasteboard.PasteboardType {
-    if self.type == .image {
-      switch self.imageType {
-      case .tiff: return .tiff
-      case .png: return .png
-      default: return .tiff
-      }
-    }
-    return .string
   }
 
   init(value: Data) {
@@ -39,6 +26,34 @@ public class HistoryItem: Equatable, Codable {
     self.firstCopiedAt = Date()
     self.lastCopiedAt = firstCopiedAt
     self.numberOfCopies = 1
+  }
+
+  public func getPasteboardType() -> NSPasteboard.PasteboardType {
+    if types.contains(.tiff) { return .tiff }
+    if types.contains(.png) { return .png }
+    return .string
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var values = encoder.container(keyedBy: CodingKeys.self)
+    try values.encode(value, forKey: .value)
+    try values.encode(firstCopiedAt, forKey: .firstCopiedAt)
+    try values.encode(lastCopiedAt, forKey: .lastCopiedAt)
+    try values.encode(numberOfCopies, forKey: .numberOfCopies)
+    try values.encode(pin, forKey: .pin)
+    try values.encode(types.map({ $0.rawValue }), forKey: .types)
+  }
+
+  public required init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    value = try values.decode(Data.self, forKey: .value)
+    firstCopiedAt = try values.decode(Date.self, forKey: .firstCopiedAt)
+    lastCopiedAt = try values.decode(Date.self, forKey: .lastCopiedAt)
+    numberOfCopies = try values.decode(Int.self, forKey: .numberOfCopies)
+    pin = try values.decodeIfPresent(String.self, forKey: .pin)
+    // Backwards compatibility because migrations are executed after storage initialization
+    let rawTypes = try values.decodeIfPresent([String].self, forKey: .types) ?? []
+    types = rawTypes.map({ NSPasteboard.PasteboardType.init(rawValue: $0) })
   }
 
   convenience init(value: Data, firstCopiedAt: Date, lastCopiedAt: Date, numberOfCopies: Int) {

--- a/Maccy/HistoryItem.swift
+++ b/Maccy/HistoryItem.swift
@@ -8,6 +8,21 @@ public class HistoryItem: Equatable, Codable {
   public var pin: String?
   public var types: [NSPasteboard.PasteboardType] = []
 
+  public var type: NSPasteboard.PasteboardType {
+    get {
+      if types.contains(.tiff) {
+        return .tiff
+      }
+      if types.contains(.png) {
+        return .png
+      }
+      return .string
+    }
+    set(value) {
+      types = [value]
+    }
+  }
+
   private enum CodingKeys: String, CodingKey {
     case value
     case firstCopiedAt
@@ -26,12 +41,6 @@ public class HistoryItem: Equatable, Codable {
     self.firstCopiedAt = Date()
     self.lastCopiedAt = firstCopiedAt
     self.numberOfCopies = 1
-  }
-
-  public func getPasteboardType() -> NSPasteboard.PasteboardType {
-    if types.contains(.tiff) { return .tiff }
-    if types.contains(.png) { return .png }
-    return .string
   }
 
   public func encode(to encoder: Encoder) throws {

--- a/Maccy/HistoryItem.swift
+++ b/Maccy/HistoryItem.swift
@@ -6,15 +6,32 @@ public class HistoryItem: Equatable, Codable {
     case image
   }
 
+  public enum ImageTypes: String, Codable {
+    case png
+    case tiff
+  }
+
   public let value: Data!
   public var firstCopiedAt: Date!
   public var lastCopiedAt: Date!
   public var numberOfCopies: Int!
   public var pin: String?
   public var type: Types!
+  public var imageType: ImageTypes?
 
   public static func == (lhs: HistoryItem, rhs: HistoryItem) -> Bool {
     return lhs.value == rhs.value
+  }
+
+  public func getPasteboardType() -> NSPasteboard.PasteboardType {
+    if self.type == .image {
+      switch self.imageType {
+      case .tiff: return .tiff
+      case .png: return .png
+      default: return .tiff
+      }
+    }
+    return .string
   }
 
   init(value: Data) {

--- a/Maccy/HistoryMenuItem.swift
+++ b/Maccy/HistoryMenuItem.swift
@@ -8,6 +8,8 @@ class HistoryMenuItem: NSMenuItem {
 
   private let showMaxLength = 50
   private let imageMaxWidth: CGFloat = 340.0
+  
+  private let showImagesForTypes: [NSPasteboard.PasteboardType] = [.png, .tiff]
 
   private var onSelected: [Callback] = []
 
@@ -25,7 +27,7 @@ class HistoryMenuItem: NSMenuItem {
     self.onStateImage = NSImage(named: "PinImage")
     self.target = self
 
-    if item.type == .image {
+    if item.types.contains(where: showImagesForTypes.contains) {
       loadImage(item)
     } else {
       loadString(item)

--- a/Maccy/HistoryMenuItem.swift
+++ b/Maccy/HistoryMenuItem.swift
@@ -8,7 +8,6 @@ class HistoryMenuItem: NSMenuItem {
 
   private let showMaxLength = 50
   private let imageMaxWidth: CGFloat = 340.0
-  
   private let showImagesForTypes: [NSPasteboard.PasteboardType] = [.png, .tiff]
 
   private var onSelected: [Callback] = []

--- a/Maccy/HistoryMenuItem.swift
+++ b/Maccy/HistoryMenuItem.swift
@@ -107,7 +107,7 @@ class HistoryMenuItem: NSMenuItem {
                    Press ⌥+p to (un)pin.
                    """
 
-    if self.shouldSetTitle && item.typesWithData[.fileURL] != nil {
+    if self.shouldDisplayTitle && item.typesWithData[.fileURL] != nil {
       let fileURL = item.typesWithData[.fileURL]!
       if let url = URL(dataRepresentation: fileURL, relativeTo: nil) {
         let pathInfo = humanizedPath(url)

--- a/Maccy/HistoryMenuItem.swift
+++ b/Maccy/HistoryMenuItem.swift
@@ -26,7 +26,7 @@ class HistoryMenuItem: NSMenuItem {
     self.onStateImage = NSImage(named: "PinImage")
     self.target = self
 
-    if item.types.contains(where: showImagesForTypes.contains) {
+    if showImagesForTypes.contains(item.type) {
       loadImage(item)
     } else {
       loadString(item)

--- a/Maccy/Menu.swift
+++ b/Maccy/Menu.swift
@@ -222,7 +222,7 @@ class Menu: NSMenu, NSMenuDelegate {
   }
 
   private func copy(_ item: HistoryMenuItem) {
-    clipboard.copy(item.item.value, item.item.getPasteboardType())
+    clipboard.copy(item.item.value, item.item.type)
   }
 
   private func copyAndPaste(_ item: HistoryMenuItem) {

--- a/Maccy/Menu.swift
+++ b/Maccy/Menu.swift
@@ -222,11 +222,7 @@ class Menu: NSMenu, NSMenuDelegate {
   }
 
   private func copy(_ item: HistoryMenuItem) {
-    if item.item.type == .image {
-      clipboard.copy(item.item.value, .tiff)
-    } else {
-      clipboard.copy(item.item.value, .string)
-    }
+    clipboard.copy(item.item.value, item.item.getPasteboardType())
   }
 
   private func copyAndPaste(_ item: HistoryMenuItem) {

--- a/Maccy/Menu.swift
+++ b/Maccy/Menu.swift
@@ -222,7 +222,7 @@ class Menu: NSMenu, NSMenuDelegate {
   }
 
   private func copy(_ item: HistoryMenuItem) {
-    clipboard.copy(item.item.value, item.item.type)
+    clipboard.copy(item.item.typesWithData)
   }
 
   private func copyAndPaste(_ item: HistoryMenuItem) {

--- a/Maccy/Search.swift
+++ b/Maccy/Search.swift
@@ -20,7 +20,7 @@ class Search {
 
   private func fuzzySearch(string: String, within: Searchable) -> Searchable {
     let searchResults = within.map({ historyItem in
-      let itemString = String(data: historyItem.item.value, encoding: .utf8) ?? ""
+      let itemString = String(data: historyItem.item.typesWithData[.string]!, encoding: .utf8) ?? ""
       return (score: self.fuse.search(string, in: itemString)?.score, object: historyItem)
     } as (HistoryMenuItem) -> (score: Double?, object: HistoryMenuItem))
     let matchedResults = searchResults.filter({ $0.score != nil })
@@ -30,7 +30,7 @@ class Search {
 
   private func simpleSearch(string: String, within: Searchable) -> Searchable {
     return within.filter({ item in
-      let value = String(data: item.item.value, encoding: .utf8) ?? ""
+      let value = String(data: item.item.typesWithData[.string]!, encoding: .utf8) ?? ""
       let range = value.range(
         of: string,
         options: .caseInsensitive,

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -45,7 +45,7 @@ class ClipboardTests: XCTestCase {
     clipboard.copy(data!, .tiff)
     XCTAssertEqual(pasteboard.data(forType: .tiff), data)
   }
-  
+
   func testCopyPngImage() {
     let cgImage = NSImage(named: "NSInfo")?.cgImage(forProposedRect: nil, context: nil, hints: nil)
     let imageRep = NSBitmapImageRep(cgImage: cgImage!)

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -36,13 +36,13 @@ class ClipboardTests: XCTestCase {
   }
 
   func testCopyString() {
-    clipboard.copy("foo".data(using: .utf8)!, .string)
+    clipboard.copy([.string: "foo".data(using: .utf8)!])
     XCTAssertEqual(pasteboard.string(forType: .string), "foo")
   }
 
   func testCopyTiffImage() {
     let data = NSImage(named: "NSInfo")?.tiffRepresentation
-    clipboard.copy(data!, .tiff)
+    clipboard.copy([.tiff: data!])
     XCTAssertEqual(pasteboard.data(forType: .tiff), data)
   }
 
@@ -50,7 +50,7 @@ class ClipboardTests: XCTestCase {
     let cgImage = NSImage(named: "NSInfo")?.cgImage(forProposedRect: nil, context: nil, hints: nil)
     let imageRep = NSBitmapImageRep(cgImage: cgImage!)
     let data = imageRep.representation(using: .png, properties: [:])
-    clipboard.copy(data!, .png)
+    clipboard.copy([.png: data!])
     XCTAssertEqual(pasteboard.data(forType: .png), data)
   }
 }

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -40,9 +40,17 @@ class ClipboardTests: XCTestCase {
     XCTAssertEqual(pasteboard.string(forType: .string), "foo")
   }
 
-  func testCopyImage() {
+  func testCopyTiffImage() {
     let data = NSImage(named: "NSInfo")?.tiffRepresentation
     clipboard.copy(data!, .tiff)
     XCTAssertEqual(pasteboard.data(forType: .tiff), data)
+  }
+  
+  func testCopyPngImage() {
+    let cgImage = NSImage(named: "NSInfo")?.cgImage(forProposedRect: nil, context: nil, hints: nil)
+    let imageRep = NSBitmapImageRep(cgImage: cgImage!)
+    let data = imageRep.representation(using: .png, properties: [:])
+    clipboard.copy(data!, .png)
+    XCTAssertEqual(pasteboard.data(forType: .png), data)
   }
 }

--- a/MaccyTests/HistoryMenuItemTests.swift
+++ b/MaccyTests/HistoryMenuItemTests.swift
@@ -94,14 +94,12 @@ class HistoryMenuItemTests: XCTestCase {
   }
 
   private func historyMenuItem(_ value: String) -> HistoryMenuItem {
-    let item = HistoryItem(value: value.data(using: .utf8)!)
-    item.type = .string
+    let item = HistoryItem(typesWithData: [.string: value.data(using: .utf8)!])
     return HistoryMenuItem(item: item, onSelected: { _ in })
   }
 
   private func historyMenuItem(_ value: NSImage) -> HistoryMenuItem {
-    let item = HistoryItem(value: value.tiffRepresentation!)
-    item.type = .tiff
+    let item = HistoryItem(typesWithData: [.tiff: value.tiffRepresentation!])
     return HistoryMenuItem(item: item, onSelected: { _ in })
   }
 

--- a/MaccyTests/HistoryMenuItemTests.swift
+++ b/MaccyTests/HistoryMenuItemTests.swift
@@ -95,13 +95,13 @@ class HistoryMenuItemTests: XCTestCase {
 
   private func historyMenuItem(_ value: String) -> HistoryMenuItem {
     let item = HistoryItem(value: value.data(using: .utf8)!)
-    item.type = .string
+    item.types = [.string]
     return HistoryMenuItem(item: item, onSelected: { _ in })
   }
 
   private func historyMenuItem(_ value: NSImage) -> HistoryMenuItem {
     let item = HistoryItem(value: value.tiffRepresentation!)
-    item.type = .image
+    item.types = [.tiff]
     return HistoryMenuItem(item: item, onSelected: { _ in })
   }
 

--- a/MaccyTests/HistoryMenuItemTests.swift
+++ b/MaccyTests/HistoryMenuItemTests.swift
@@ -95,13 +95,13 @@ class HistoryMenuItemTests: XCTestCase {
 
   private func historyMenuItem(_ value: String) -> HistoryMenuItem {
     let item = HistoryItem(value: value.data(using: .utf8)!)
-    item.types = [.string]
+    item.type = .string
     return HistoryMenuItem(item: item, onSelected: { _ in })
   }
 
   private func historyMenuItem(_ value: NSImage) -> HistoryMenuItem {
     let item = HistoryItem(value: value.tiffRepresentation!)
-    item.types = [.tiff]
+    item.type = .tiff
     return HistoryMenuItem(item: item, onSelected: { _ in })
   }
 

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -101,13 +101,13 @@ class HistoryTests: XCTestCase {
 
   private func historyItem(_ value: String) -> HistoryItem {
     let item = HistoryItem(value: value.data(using: .utf8)!)
-    item.types = [.string]
+    item.type = .string
     return item
   }
 
   private func historyItem(_ value: NSImage) -> HistoryItem {
     let item = HistoryItem(value: value.tiffRepresentation!)
-    item.types = [.tiff]
+    item.type = .tiff
     return item
   }
 }

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -100,14 +100,12 @@ class HistoryTests: XCTestCase {
   }
 
   private func historyItem(_ value: String) -> HistoryItem {
-    let item = HistoryItem(value: value.data(using: .utf8)!)
-    item.type = .string
+    let item = HistoryItem(typesWithData: [.string: value.data(using: .utf8)!])
     return item
   }
 
   private func historyItem(_ value: NSImage) -> HistoryItem {
-    let item = HistoryItem(value: value.tiffRepresentation!)
-    item.type = .tiff
+    let item = HistoryItem(typesWithData: [.png: value.tiffRepresentation!])
     return item
   }
 }

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -101,13 +101,13 @@ class HistoryTests: XCTestCase {
 
   private func historyItem(_ value: String) -> HistoryItem {
     let item = HistoryItem(value: value.data(using: .utf8)!)
-    item.type = .string
+    item.types = [.string]
     return item
   }
 
   private func historyItem(_ value: NSImage) -> HistoryItem {
     let item = HistoryItem(value: value.tiffRepresentation!)
-    item.type = .image
+    item.types = [.tiff]
     return item
   }
 }

--- a/MaccyTests/MenuTests.swift
+++ b/MaccyTests/MenuTests.swift
@@ -6,9 +6,9 @@ class MenuTests: XCTestCase {
   let clipboard = Clipboard()
   let history = History()
   let historyItems = [
-    HistoryItem(value: "foo".data(using: .utf8)!),
-    HistoryItem(value: "bar".data(using: .utf8)!),
-    HistoryItem(value: "baz".data(using: .utf8)!)
+    HistoryItem(typesWithData: [.string: "foo".data(using: .utf8)!]),
+    HistoryItem(typesWithData: [.string: "bar".data(using: .utf8)!]),
+    HistoryItem(typesWithData: [.string: "baz".data(using: .utf8)!])
   ]
 
   var menu: Menu!

--- a/MaccyTests/SearchTests.swift
+++ b/MaccyTests/SearchTests.swift
@@ -40,7 +40,7 @@ class SearchTests: XCTestCase {
   }
 
   private class func historyMenuItem(_ value: String) -> HistoryMenuItem {
-    return HistoryMenuItem(item: HistoryItem(value: value.data(using: .utf8)!), onSelected: { _ in })
+    return HistoryMenuItem(item: HistoryItem(typesWithData: [.string: value.data(using: .utf8)!]), onSelected: { _ in })
   }
 
   private func search(_ string: String) -> Search.Searchable {

--- a/MaccyTests/SorterTests.swift
+++ b/MaccyTests/SorterTests.swift
@@ -2,15 +2,15 @@ import XCTest
 @testable import Maccy
 
 class SorterTests: XCTestCase {
-  let item1 = HistoryItem(value: "foo".data(using: .utf8)!,
+  let item1 = HistoryItem(typesWithData: [.string: "foo".data(using: .utf8)!],
                           firstCopiedAt: Date(timeIntervalSinceNow: -300),
                           lastCopiedAt: Date(timeIntervalSinceNow: -100),
                           numberOfCopies: 3)
-  let item2 = HistoryItem(value: "bar".data(using: .utf8)!,
+  let item2 = HistoryItem(typesWithData: [.string: "bar".data(using: .utf8)!],
                           firstCopiedAt: Date(timeIntervalSinceNow: -400),
                           lastCopiedAt: Date(timeIntervalSinceNow: -300),
                           numberOfCopies: 2)
-  let item3 = HistoryItem(value: "baz".data(using: .utf8)!,
+  let item3 = HistoryItem(typesWithData: [.string: "baz".data(using: .utf8)!],
                           firstCopiedAt: Date(timeIntervalSinceNow: -200),
                           lastCopiedAt: Date(timeIntervalSinceNow: -200),
                           numberOfCopies: 1)

--- a/MaccyTests/UserDefaultsTests.swift
+++ b/MaccyTests/UserDefaultsTests.swift
@@ -49,7 +49,7 @@ class UserDefaultsTests: XCTestCase {
   }
 
   func testChanging() {
-    let item = HistoryItem(value: "foo".data(using: .utf8)!)
+    let item = HistoryItem(typesWithData: [.string: "foo".data(using: .utf8)!])
 
     UserDefaults.standard.fuzzySearch = true
     UserDefaults.standard.hotKey = "command+shift+a"


### PR DESCRIPTION
Fixed #83 

Note: declaring the data as `.tiff` later (when selecting an item from the history menu and pasting it in the clipboard) works fine. I guess it auto-converts image data under the hood. Not sure if we need to distinguish tiff/png at the moment of creating a `HistoryItem` instance and then when we copy it to the clipboard, set the corresponding type for it (in `Clipboard.swift:copy`).

@p0deje thoughts?