### PR TITLE
Add display of prefix and suffix for clipboard entry

### DIFF
--- a/Maccy/HistoryMenuItem.swift
+++ b/Maccy/HistoryMenuItem.swift
@@ -123,8 +123,10 @@ class HistoryMenuItem: NSMenuItem {
       return string
     }
 
-    let index = string.index(string.startIndex, offsetBy: maxLength - 1)
-    return "\(string[...index])..."
+    let halfMaxLength: Int = maxLength / 2
+    let indexStart = string.index(string.startIndex, offsetBy: halfMaxLength - 1)
+    let indexEnd = string.index(string.endIndex, offsetBy: -halfMaxLength)
+    return "\(string[...indexStart])...\(string[indexEnd...])"
   }
 
   private func defaultTooltip(_ item: HistoryItem) -> String {

--- a/MaccyTests/HistoryMenuItemTests.swift
+++ b/MaccyTests/HistoryMenuItemTests.swift
@@ -56,10 +56,10 @@ class HistoryMenuItemTests: XCTestCase {
   }
 
   func testTitleLongerThanMaxLength() {
-    let trimmedTitle = String(repeating: "a", count: 50)
+    let trimmedTitle = String(repeating: "a", count: 25) + "..." + String(repeating: "a", count: 25)
     let title = String(repeating: "a", count: 51)
     let menuItem = historyMenuItem(title)
-    XCTAssertEqual(menuItem.title, "\(trimmedTitle)...")
+    XCTAssertEqual(menuItem.title, trimmedTitle)
     XCTAssertEqual(menuItem.value, title)
     XCTAssertEqual(menuItem.title.count, 53)
     XCTAssertEqual(menuItem.toolTip, tooltip(title))
@@ -133,7 +133,8 @@ class HistoryMenuItemTests: XCTestCase {
 
   func testTooltipLongerThanMax() {
     let menuItem = historyMenuItem(String(repeating: "a", count: 5_001))
-    XCTAssertEqual(menuItem.toolTip, tooltip("\(String(repeating: "a", count: 5_000))..."))
+    XCTAssertEqual(menuItem.toolTip,
+            tooltip("\(String(repeating: "a", count: 2_500))...\(String(repeating: "a", count: 2_500))"))
   }
 
   private func historyMenuItem(_ value: String?) -> HistoryMenuItem {


### PR DESCRIPTION
This commit will show both prefix and suffix of an entry in clipboard
by dividing the string's input to show prefix to half max length and similarly
show the suffix for another half max length. The text in between is
truncated and replaced with ellipsis.

Fixes #139