### PR TITLE
Enable Maccy to prompt for a11y permissions for pasting automatically.

### DIFF
--- a/Maccy/Maccy.entitlements
+++ b/Maccy/Maccy.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the Maccy entitlements so that Maccy prompts the user
for Accessbility permissions when attempting to paste immediately.

Sandboxed apps apparently cannot prompt for accessbility permissions:
https://developer.apple.com/forums/thread/24288

![maccy-a11y-prompt](https://user-images.githubusercontent.com/361429/90347461-7e701180-dfe5-11ea-8d05-8c33a76c4ba8.gif)
