### PR TITLE
Add preference to avoid taking app focus

### DIFF
--- a/Maccy/FilterMenuItemView.swift
+++ b/Maccy/FilterMenuItemView.swift
@@ -240,6 +240,10 @@ class FilterMenuItemView: NSView, NSTextFieldDelegate {
     if let chars = event.charactersIgnoringModifiers {
       if chars.count == 1 {
         focusQueryField()
+        if UserDefaults.standard.avoidTakingFocus {
+            setQuery("\(queryField.stringValue)\(chars)")
+            return true
+        }
       }
     }
 

--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -277,7 +277,9 @@ class Maccy: NSObject {
   private func withFocus(_ closure: @escaping () -> Void) {
     Maccy.returnFocusToPreviousApp = extraVisibleWindows.count == 0
     KeyboardShortcuts.disable(.popup)
-    NSApp.activate(ignoringOtherApps: true)
+    if !UserDefaults.standard.avoidTakingFocus {
+        NSApp.activate(ignoringOtherApps: true)
+    }
     Timer.scheduledTimer(withTimeInterval: 0.04, repeats: false) { _ in
       closure()
       KeyboardShortcuts.enable(.popup)

--- a/Maccy/Preferences/AdvancedPreferenceViewController.swift
+++ b/Maccy/Preferences/AdvancedPreferenceViewController.swift
@@ -9,6 +9,7 @@ class AdvancedPreferenceViewController: NSViewController, NSTableViewDataSource,
   override var nibName: NSNib.Name? { "AdvancedPreferenceViewController" }
 
   @IBOutlet weak var turnOffButton: NSButton!
+  @IBOutlet weak var avoidTakingFocusButton: NSButton!
   @IBOutlet weak var ignoredItemsTable: NSTableView!
 
   private let exampleIgnoredType = "zzz.yyy.xxx"
@@ -21,6 +22,7 @@ class AdvancedPreferenceViewController: NSViewController, NSTableViewDataSource,
   override func viewWillAppear() {
     super.viewWillAppear()
     populateTurnOff()
+    populateAvoidTakingFocus()
   }
 
   func numberOfRows(in tableView: NSTableView) -> Int {
@@ -52,6 +54,10 @@ class AdvancedPreferenceViewController: NSViewController, NSTableViewDataSource,
   @IBAction func turnOffChanged(_ sender: NSButton) {
     UserDefaults.standard.ignoreEvents = (turnOffButton.state == .on)
   }
+    
+  @IBAction func avoidTakingFocusChanged(_ sender: NSButton) {
+    UserDefaults.standard.avoidTakingFocus = (avoidTakingFocusButton.state == .on)
+  }
 
   @IBAction func ignoredTypeAddedOrRemoved(_ sender: NSSegmentedCell) {
     switch sender.selectedSegment {
@@ -70,6 +76,10 @@ class AdvancedPreferenceViewController: NSViewController, NSTableViewDataSource,
 
   private func populateTurnOff() {
     turnOffButton.state = UserDefaults.standard.ignoreEvents ? .on : .off
+  }
+    
+  private func populateAvoidTakingFocus() {
+    avoidTakingFocusButton.state = UserDefaults.standard.avoidTakingFocus ? .on : .off
   }
 
   private func addIgnoredType() {

--- a/Maccy/Preferences/AdvancedPreferenceViewController.swift
+++ b/Maccy/Preferences/AdvancedPreferenceViewController.swift
@@ -54,7 +54,7 @@ class AdvancedPreferenceViewController: NSViewController, NSTableViewDataSource,
   @IBAction func turnOffChanged(_ sender: NSButton) {
     UserDefaults.standard.ignoreEvents = (turnOffButton.state == .on)
   }
-    
+
   @IBAction func avoidTakingFocusChanged(_ sender: NSButton) {
     UserDefaults.standard.avoidTakingFocus = (avoidTakingFocusButton.state == .on)
   }
@@ -77,7 +77,7 @@ class AdvancedPreferenceViewController: NSViewController, NSTableViewDataSource,
   private func populateTurnOff() {
     turnOffButton.state = UserDefaults.standard.ignoreEvents ? .on : .off
   }
-    
+
   private func populateAvoidTakingFocus() {
     avoidTakingFocusButton.state = UserDefaults.standard.avoidTakingFocus ? .on : .off
   }

--- a/Maccy/Preferences/Base.lproj/AdvancedPreferenceViewController.xib
+++ b/Maccy/Preferences/Base.lproj/AdvancedPreferenceViewController.xib
@@ -8,6 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AdvancedPreferenceViewController" customModule="Maccy" customModuleProvider="target">
             <connections>
+                <outlet property="avoidTakingFocusButton" destination="4MH-H4-Ce2" id="iHM-Ux-GrT"/>
                 <outlet property="ignoredItemsTable" destination="bHz-DT-4be" id="gNK-Vm-y4D"/>
                 <outlet property="turnOffButton" destination="RTY-w8-2Wt" id="xy5-W3-yjD"/>
                 <outlet property="view" destination="vfL-pB-YIa" id="gmn-hk-Nsm"/>
@@ -16,18 +17,23 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vfL-pB-YIa">
-            <rect key="frame" x="0.0" y="0.0" width="438" height="419"/>
+            <rect key="frame" x="0.0" y="0.0" width="438" height="552"/>
             <subviews>
                 <gridView misplaced="YES" xPlacement="fill" yPlacement="top" rowAlignment="lastBaseline" rowSpacing="8" columnSpacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="FlB-UI-Pmg">
-                    <rect key="frame" x="20" y="20" width="398" height="379"/>
+                    <rect key="frame" x="20" y="19" width="398" height="513"/>
                     <rows>
                         <gridRow id="CZD-ac-NuU"/>
                         <gridRow id="l2s-iI-2ix"/>
                         <gridRow id="M6T-bh-slS"/>
+                        <gridRow topPadding="4" bottomPadding="4" id="ey0-TY-bAY"/>
+                        <gridRow id="tDm-DG-HuU"/>
+                        <gridRow id="o97-4G-dK7"/>
                         <gridRow yPlacement="center" topPadding="4" bottomPadding="4" id="xPS-dE-Nfw"/>
                         <gridRow rowAlignment="firstBaseline" height="170" bottomPadding="-8" id="Tg0-YM-rNy"/>
                         <gridRow id="PpW-h6-8J3"/>
                         <gridRow id="jmK-5E-oHJ"/>
+                        <gridRow id="j8O-QU-1zc"/>
+                        <gridRow id="FOp-RD-92y"/>
                     </rows>
                     <columns>
                         <gridColumn width="398" id="8aH-p4-Hiw"/>
@@ -35,7 +41,7 @@
                     <gridCells>
                         <gridCell row="CZD-ac-NuU" column="8aH-p4-Hiw" id="PcE-h5-Afe">
                             <button key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RTY-w8-2Wt">
-                                <rect key="frame" x="-2" y="363" width="402" height="18"/>
+                                <rect key="frame" x="-2" y="497" width="402" height="18"/>
                                 <buttonCell key="cell" type="check" title="Turn off" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="RA0-eh-Udt">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -47,7 +53,7 @@
                         </gridCell>
                         <gridCell row="l2s-iI-2ix" column="8aH-p4-Hiw" id="XZW-aJ-d98">
                             <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ahJ-Lm-rjm">
-                                <rect key="frame" x="-2" y="315" width="402" height="42"/>
+                                <rect key="frame" x="-2" y="449" width="402" height="42"/>
                                 <textFieldCell key="cell" selectable="YES" id="Ejh-zi-AFs">
                                     <font key="font" metaFont="controlContent" size="11"/>
                                     <string key="title">Temporarily ignore all new copies.
@@ -59,7 +65,7 @@ You are likely to use it programmatically and disable application while copying 
                         </gridCell>
                         <gridCell row="M6T-bh-slS" column="8aH-p4-Hiw" id="dQu-KC-grG">
                             <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fpb-AC-gT0">
-                                <rect key="frame" x="-2" y="274" width="402" height="33"/>
+                                <rect key="frame" x="-2" y="408" width="402" height="33"/>
                                 <textFieldCell key="cell" selectable="YES" id="LFh-6b-GFi">
                                     <font key="font" size="10" name="Menlo-Regular"/>
                                     <string key="title">defaults write org.p0deje.Maccy ignoreEvents true
@@ -70,14 +76,42 @@ defaults write org.p0deje.Maccy ignoreEvents false</string>
                                 </textFieldCell>
                             </textField>
                         </gridCell>
+                        <gridCell row="ey0-TY-bAY" column="8aH-p4-Hiw" id="uUX-Op-ca8">
+                            <box key="contentView" verticalHuggingPriority="750" ambiguous="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uoQ-aq-GS3">
+                                <rect key="frame" x="0.0" y="393" width="398" height="5"/>
+                            </box>
+                        </gridCell>
+                        <gridCell row="tDm-DG-HuU" column="8aH-p4-Hiw" id="d4M-7j-KcB">
+                            <button key="contentView" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4MH-H4-Ce2">
+                                <rect key="frame" x="-2" y="367" width="402" height="18"/>
+                                <buttonCell key="cell" type="check" title="Avoid taking app focus" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jjU-HE-iIA">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="avoidTakingFocusChanged:" target="-2" id="5Pw-LA-h4U"/>
+                                </connections>
+                            </button>
+                        </gridCell>
+                        <gridCell row="o97-4G-dK7" column="8aH-p4-Hiw" id="TZ9-X9-vIe">
+                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T2q-cI-BLE">
+                                <rect key="frame" x="-2" y="291" width="402" height="70"/>
+                                <textFieldCell key="cell" selectable="YES" id="Y8y-xQ-lFm">
+                                    <font key="font" metaFont="controlContent" size="11"/>
+                                    <string key="title">By default, Maccy will take the application focus while the popup is displayed. Maccy needs app focus to allow advanced text handling in the search bar. If you enable this, you will only be able to search for basic ASCII. However, certain situations (such as a text editor that auto-formats when it loses focus) may make this desirable.</string>
+                                    <color key="textColor" name="systemGrayColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </gridCell>
                         <gridCell row="xPS-dE-Nfw" column="8aH-p4-Hiw" xPlacement="fill" id="XTe-Nh-Nsd">
                             <box key="contentView" verticalHuggingPriority="750" ambiguous="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="zG7-X4-p00">
-                                <rect key="frame" x="0.0" y="255" width="398" height="5"/>
+                                <rect key="frame" x="0.0" y="272" width="398" height="5"/>
                             </box>
                         </gridCell>
                         <gridCell row="Tg0-YM-rNy" column="8aH-p4-Hiw" yPlacement="fill" rowAlignment="none" id="yXB-pk-D1X">
                             <scrollView key="contentView" ambiguous="YES" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilW-Uu-98E">
-                                <rect key="frame" x="0.0" y="71" width="398" height="170"/>
+                                <rect key="frame" x="0.0" y="87" width="398" height="170"/>
                                 <clipView key="contentView" id="UbA-97-4zD">
                                     <rect key="frame" x="1" y="0.0" width="396" height="169"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -124,7 +158,7 @@ defaults write org.p0deje.Maccy ignoreEvents false</string>
                         </gridCell>
                         <gridCell row="PpW-h6-8J3" column="8aH-p4-Hiw" xPlacement="leading" id="EKL-co-FtI">
                             <segmentedControl key="contentView" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="15K-aj-GdE">
-                                <rect key="frame" x="0.0" y="49" width="57" height="23"/>
+                                <rect key="frame" x="0.0" y="65" width="57" height="23"/>
                                 <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fill" style="smallSquare" trackingMode="momentary" id="RIZ-u6-XNr">
                                     <font key="font" metaFont="system"/>
                                     <segments>
@@ -139,7 +173,7 @@ defaults write org.p0deje.Maccy ignoreEvents false</string>
                         </gridCell>
                         <gridCell row="jmK-5E-oHJ" column="8aH-p4-Hiw" id="OPn-rl-TE0">
                             <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oEs-ZN-ssL">
-                                <rect key="frame" x="-2" y="0.0" width="402" height="42"/>
+                                <rect key="frame" x="-2" y="16" width="402" height="42"/>
                                 <textFieldCell key="cell" selectable="YES" id="Meq-nm-ddS">
                                     <font key="font" metaFont="controlContent" size="11"/>
                                     <string key="title">It's possible to ignore certain pasteboard item types from remembering.
@@ -149,6 +183,8 @@ By default, some known application-specific types are defined. You can remove th
                                 </textFieldCell>
                             </textField>
                         </gridCell>
+                        <gridCell row="j8O-QU-1zc" column="8aH-p4-Hiw" id="lgJ-nZ-6aS"/>
+                        <gridCell row="FOp-RD-92y" column="8aH-p4-Hiw" id="iIN-FI-RSv"/>
                     </gridCells>
                 </gridView>
             </subviews>
@@ -156,9 +192,9 @@ By default, some known application-specific types are defined. You can remove th
                 <constraint firstItem="FlB-UI-Pmg" firstAttribute="centerX" secondItem="vfL-pB-YIa" secondAttribute="centerX" id="5Df-de-3FT"/>
                 <constraint firstItem="FlB-UI-Pmg" firstAttribute="width" secondItem="vfL-pB-YIa" secondAttribute="width" multiplier="0.81893" id="7tk-Oh-85A"/>
                 <constraint firstItem="FlB-UI-Pmg" firstAttribute="centerY" secondItem="vfL-pB-YIa" secondAttribute="centerY" id="SNC-0D-pSa"/>
-                <constraint firstItem="FlB-UI-Pmg" firstAttribute="height" secondItem="vfL-pB-YIa" secondAttribute="height" multiplier="0.751012" id="tsa-Jn-Abh"/>
+                <constraint firstItem="FlB-UI-Pmg" firstAttribute="height" secondItem="vfL-pB-YIa" secondAttribute="height" multiplier="0.9" id="tsa-Jn-Abh"/>
             </constraints>
-            <point key="canvasLocation" x="153" y="109.5"/>
+            <point key="canvasLocation" x="153" y="232"/>
         </customView>
     </objects>
     <resources>

--- a/Maccy/Preferences/es.lproj/AdvancedPreferenceViewController.strings
+++ b/Maccy/Preferences/es.lproj/AdvancedPreferenceViewController.strings
@@ -16,3 +16,9 @@
 
 /* Class = "NSButtonCell"; title = "Turn off"; ObjectID = "RA0-eh-Udt"; */
 "RA0-eh-Udt.title" = "Desactivar";
+
+/* Class = "NSTextFieldCell"; title = "By default, Maccy will take the application focus while the popup is displayed. Maccy needs app focus to allow advanced text handling in the search bar. If you enable this, you will only be able to search for basic ASCII. However, certain situations (such as a text editor that auto-formats when it loses focus) may make this desirable."; ObjectID = "Y8y-xQ-lFm"; */
+"Y8y-xQ-lFm.title" = "De forma predeterminada, Maccy tomará el foco de la aplicación mientras se muestre la ventana emergente. Maccy necesita el enfoque de la aplicación para permitir el manejo avanzado de texto en la barra de búsqueda. Si habilita esto, solo podrá buscar ASCII básico. Sin embargo, ciertas situaciones (como un editor de texto que formatea automáticamente cuando pierde el foco) pueden hacer esto deseable.";
+
+/* Class = "NSButtonCell"; title = "Avoid taking app focus"; ObjectID = "jjU-HE-iIA"; */
+"jjU-HE-iIA.title" = "Evite centrarse en la aplicación";

--- a/Maccy/Preferences/ru.lproj/AdvancedPreferenceViewController.strings
+++ b/Maccy/Preferences/ru.lproj/AdvancedPreferenceViewController.strings
@@ -16,3 +16,9 @@
 
 /* Class = "NSButtonCell"; title = "Turn off"; ObjectID = "RA0-eh-Udt"; */
 "RA0-eh-Udt.title" = "Выключить";
+
+/* Class = "NSTextFieldCell"; title = "By default, Maccy will take the application focus while the popup is displayed. Maccy needs app focus to allow advanced text handling in the search bar. If you enable this, you will only be able to search for basic ASCII. However, certain situations (such as a text editor that auto-formats when it loses focus) may make this desirable."; ObjectID = "Y8y-xQ-lFm"; */
+"Y8y-xQ-lFm.title" = "По умолчанию Maccy берет фокус приложения, пока отображается всплывающее окно. Maccy нужен фокус приложения, чтобы разрешить расширенную обработку текста в строке поиска. Если вы включите это, вы сможете искать только базовый ASCII. Однако в определенных ситуациях (например, в текстовом редакторе, автоматически форматирующем при потере фокуса) это может быть желательно.";
+
+/* Class = "NSButtonCell"; title = "Avoid taking app focus"; ObjectID = "jjU-HE-iIA"; */
+"jjU-HE-iIA.title" = "Избегайте сосредоточения внимания на приложении";

--- a/Maccy/Preferences/zh-Hans.lproj/AdvancedPreferenceViewController.strings
+++ b/Maccy/Preferences/zh-Hans.lproj/AdvancedPreferenceViewController.strings
@@ -16,3 +16,9 @@
 
 /* Class = "NSButtonCell"; title = "Turn off"; ObjectID = "RA0-eh-Udt"; */
 "RA0-eh-Udt.title" = "关闭";
+
+/* Class = "NSTextFieldCell"; title = "By default, Maccy will take the application focus while the popup is displayed. Maccy needs app focus to allow advanced text handling in the search bar. If you enable this, you will only be able to search for basic ASCII. However, certain situations (such as a text editor that auto-formats when it loses focus) may make this desirable."; ObjectID = "Y8y-xQ-lFm"; */
+"Y8y-xQ-lFm.title" = "默认情况下，在显示弹出窗口时，Maccy将以应用程序为焦点。 Maccy需要关注应用程序才能在搜索栏中进行高级文本处理。 如果启用此功能，则只能搜索基本ASCII。 但是，在某些情况下（例如，文本编辑器在失去焦点时会自动格式化）可能是理想的选择。";
+
+/* Class = "NSButtonCell"; title = "Avoid taking app focus"; ObjectID = "jjU-HE-iIA"; */
+"jjU-HE-iIA.title" = "避免关注应用程序";

--- a/Maccy/UserDefaults+Configuration.swift
+++ b/Maccy/UserDefaults+Configuration.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension UserDefaults {
   public struct Keys {
+    static let avoidTakingFocus = "avoidTakingFocus"
     static let fuzzySearch = "fuzzySearch"
     static let hideFooter = "hideFooter"
     static let hideSearch = "hideSearch"
@@ -45,6 +46,11 @@ extension UserDefaults {
   public var fuzzySearch: Bool {
     get { ProcessInfo.processInfo.arguments.contains("ui-testing") ? false : bool(forKey: Keys.fuzzySearch) }
     set { set(newValue, forKey: Keys.fuzzySearch) }
+  }
+    
+  @objc dynamic public var avoidTakingFocus: Bool {
+    get { bool(forKey: Keys.avoidTakingFocus) }
+    set { set(newValue, forKey: Keys.avoidTakingFocus) }
   }
 
   @objc dynamic public var hideFooter: Bool {

--- a/Maccy/UserDefaults+Configuration.swift
+++ b/Maccy/UserDefaults+Configuration.swift
@@ -47,7 +47,7 @@ extension UserDefaults {
     get { ProcessInfo.processInfo.arguments.contains("ui-testing") ? false : bool(forKey: Keys.fuzzySearch) }
     set { set(newValue, forKey: Keys.fuzzySearch) }
   }
-    
+
   @objc dynamic public var avoidTakingFocus: Bool {
     get { bool(forKey: Keys.avoidTakingFocus) }
     set { set(newValue, forKey: Keys.avoidTakingFocus) }


### PR DESCRIPTION
Changes to focus in #129 to enable better text editing are great, and helpful for many users.

However, there are some use cases where I'd rather sacrifice system text features to not take focus away from the current app. Here's an example:
1. Maccy is configured to paste automatically 
2. A text editor (such as vsCode) is configured to format when it loses focus. 
3. Activate Maccy, editor loses focus and removes trailing spaces from the current line (or other code linting/formating)
4. Paste your text from Maccy, but not where you intended due to the formatting.  

Text from the advanced preferences page sums it up:
> By default, Maccy will take the application focus while the popup is displayed. Maccy needs app focus to allow advanced text handling in the search bar. If you enable this, you will only be able to search for basic ASCII. However, certain situations (such as a text editor that auto-formats when it loses focus) may make this desirable.

related issue: #144 with more use cases in the comments(Hotkey Window, Context menus) 