### PR TITLE
Update command to install from Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ and lets you quickly navigate, search, and use previous clipboard contents.
 Download the latest version from the [releases](https://github.com/p0deje/Maccy/releases/latest) page, or use [Homebrew](https://brew.sh/):
 
 ```sh
-brew cask install maccy
+brew install --cask maccy
 ```
 
 ## Usage


### PR DESCRIPTION
Thanks for Maccy, looks really cool!

Just a quick PR to change the Homebrew cask upgrade command for [the `2.6.0` upgrade](https://brew.sh/2020/12/01/homebrew-2.6.0/):

> All `brew cask` commands have been deprecated in favour of `brew` commands (with `--cask`) when necessary