### PR TITLE
Private Mode Feature

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     migrateUserDefaults()
 
     maccy = Maccy()
-    hotKey = GlobalHotKey(maccy.popUp)
+    hotKey = GlobalHotKey(maccy.popUp, maccy.togglePrivateMode)
   }
 
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/Maccy/GlobalHotKey.swift
+++ b/Maccy/GlobalHotKey.swift
@@ -7,10 +7,14 @@ class GlobalHotKey {
   static public var key: KeyboardShortcuts.Key? { KeyboardShortcuts.Shortcut(name: .popup)?.key }
   static public var modifierFlags: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .popup)?.modifiers }
 
-  private var handler: Handler
+  private var popupHandler: Handler
+  private var privateModeHandler: Handler
 
-  init(_ handler: @escaping Handler) {
-    self.handler = handler
-    KeyboardShortcuts.onKeyDown(for: .popup, action: handler)
+
+  init(_ popupHandler: @escaping Handler, _ privateModeHandler: @escaping Handler) {
+    self.popupHandler = popupHandler
+    self.privateModeHandler = privateModeHandler
+    KeyboardShortcuts.onKeyDown(for: .popup, action: popupHandler)
+    KeyboardShortcuts.onKeyDown(for: .privateMode, action: privateModeHandler)
   }
 }

--- a/Maccy/KeyboardShortcuts.Name+Popup.swift
+++ b/Maccy/KeyboardShortcuts.Name+Popup.swift
@@ -2,4 +2,5 @@ import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
   static let popup = Name("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
+  static let privateMode = Name("privateMode", default: Shortcut(.x, modifiers: [.command, .shift]))
 }

--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -147,7 +147,18 @@ class Maccy: NSObject {
       }
     }
   }
-
+    
+  func togglePrivateMode(){
+    UserDefaults.standard.ignoreEvents = !UserDefaults.standard.ignoreEvents
+    if(UserDefaults.standard.ignoreEvents == true){
+      DispatchQueue.main.asyncAfter(deadline: .now() + 60) {
+        if(UserDefaults.standard.ignoreEvents == true){
+          UserDefaults.standard.ignoreEvents = false
+        }
+      }
+    }
+  }
+    
   @objc
   func performStatusItemClick() {
     if let event = NSApp.currentEvent {

--- a/Maccy/Preferences/Base.lproj/GeneralPreferenceViewController.xib
+++ b/Maccy/Preferences/Base.lproj/GeneralPreferenceViewController.xib
@@ -15,6 +15,7 @@
                 <outlet property="launchAtLoginButton" destination="mOE-Th-WLC" id="taH-LL-vsV"/>
                 <outlet property="modifiersDescriptionLabel" destination="zFN-E4-6L5" id="9oM-Sw-fvf"/>
                 <outlet property="pasteAutomaticallyButton" destination="mI4-d4-FAq" id="NG2-Cl-5Vh"/>
+                <outlet property="privateModeHotkeyContainerView" destination="3s7-v4-2Ju" id="wqA-ol-r7O"/>
                 <outlet property="removeFormattingButton" destination="eZQ-w7-Bts" id="brY-wZ-15s"/>
                 <outlet property="sortByButton" destination="PWC-Rx-PPN" id="rxl-rl-hXr"/>
                 <outlet property="soundsButton" destination="vaq-g1-ECx" id="8jG-bL-FwP"/>
@@ -34,6 +35,8 @@
                     <rows>
                         <gridRow rowAlignment="firstBaseline" id="1lh-Qw-cAx"/>
                         <gridRow id="PHn-iI-jCM"/>
+                        <gridRow yPlacement="center" id="grg-Zn-uGR"/>
+                        <gridRow id="jqO-9j-y1f"/>
                         <gridRow id="cbV-VG-Q6m"/>
                         <gridRow id="PS2-Rm-W1c"/>
                         <gridRow id="g9F-gc-VeQ"/>
@@ -90,6 +93,37 @@ Hotkey:</string>
                                     <font key="font" metaFont="message" size="11"/>
                                     <string key="title">Global shortcut key to open application.
 Default: ⇧⌘C.</string>
+                                    <color key="textColor" name="systemGrayColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </gridCell>
+                        <gridCell row="grg-Zn-uGR" column="vOJ-9h-G8Y" rowAlignment="none" id="roD-oa-gG6">
+                            <textField key="contentView" horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xvr-Lj-WZZ">
+                                <rect key="frame" x="12" y="521" width="134" height="16"/>
+                                <textFieldCell key="cell" alignment="right" title="Private Mode Hotkey:" id="ToA-et-V5V">
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </gridCell>
+                        <gridCell row="grg-Zn-uGR" column="pQU-Pz-q1v" id="VXK-8O-dFK">
+                            <customView key="contentView" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3s7-v4-2Ju">
+                                <rect key="frame" x="157" y="517" width="100" height="25"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="25" id="RxD-hX-ebm"/>
+                                </constraints>
+                            </customView>
+                        </gridCell>
+                        <gridCell row="jqO-9j-y1f" column="vOJ-9h-G8Y" id="yQE-el-WkG"/>
+                        <gridCell row="jqO-9j-y1f" column="pQU-Pz-q1v" id="ByO-W1-ma4">
+                            <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MWV-iJ-igS">
+                                <rect key="frame" x="155" y="467" width="422" height="42"/>
+                                <textFieldCell key="cell" selectable="YES" id="Fc2-Yo-DLw">
+                                    <font key="font" metaFont="message" size="11"/>
+                                    <string key="title">Global shortcut key to toggle private mode. The private mode will be on for 60 seconds.
+Default: ⇧⌘X.</string>
                                     <color key="textColor" name="systemGrayColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>

--- a/Maccy/Preferences/GeneralPreferenceViewController.swift
+++ b/Maccy/Preferences/GeneralPreferenceViewController.swift
@@ -11,8 +11,12 @@ class GeneralPreferenceViewController: NSViewController, PreferencePane {
   override var nibName: NSNib.Name? { "GeneralPreferenceViewController" }
 
   private let hotkeyRecorder = KeyboardShortcuts.RecorderCocoa(for: .popup)
+  
+  private let privateModeHotkeyRecoder = KeyboardShortcuts.RecorderCocoa(for: .privateMode)
+
 
   @IBOutlet weak var hotkeyContainerView: NSView!
+  @IBOutlet weak var privateModeHotkeyContainerView: NSView!
   @IBOutlet weak var launchAtLoginButton: NSButton!
   @IBOutlet weak var fuzzySearchButton: NSButton!
   @IBOutlet weak var pasteAutomaticallyButton: NSButton!
@@ -29,6 +33,7 @@ class GeneralPreferenceViewController: NSViewController, PreferencePane {
   override func viewDidLoad() {
     super.viewDidLoad()
     hotkeyContainerView.addSubview(hotkeyRecorder)
+    privateModeHotkeyContainerView.addSubview(privateModeHotkeyRecoder)
   }
 
   override func viewWillAppear() {


### PR DESCRIPTION
First of all, I would like to thank you for creating such a good open source project. I use Maccy very actively. But every once in a while I need to turn it off for privacy. That's why I wrote a shell script and assigned a key shortcut with automator. I have found it very useful so I want to add it as a feature to Maccy.  

How it works: 
- Default shortcut key is: cmd +  shift + x
- When pressed these keys it will enter private mode and for 60 seconds it won't record the copied items to history. Since you already have icon changing on turn off the user can see wether or not is in private mode. 
- If you press these keys again within 60 seconds it will disable the private mode without waiting for time to run out. 

By the way I don't have any Swift experience, I tried to follow your structure. If you want anything changed don't hesitate on telling me. 

<img width="803" alt="maccy_private_mode" src="https://user-images.githubusercontent.com/23136437/108605078-ec492b80-73c2-11eb-857b-eec0a7a47096.png">
