### PR TITLE
Fix saving contents that are copied when ignoreEvents is enabled

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -113,8 +113,9 @@ class Clipboard {
     guard pasteboard.changeCount != changeCount else {
       return
     }
-
+    
     if UserDefaults.standard.ignoreEvents {
+      changeCount = pasteboard.changeCount
       return
     }
 


### PR DESCRIPTION
Fix for issue: #260 
