### PR TITLE
Fixed showing popup window on center of the screen when working with multiple monitors

### DIFF
--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -88,7 +88,8 @@ class Maccy: NSObject {
     withFocus {
       switch UserDefaults.standard.popupPosition {
       case "center":
-        if let screen = NSScreen.main {
+        let activeLocation = NSEvent.mouseLocation
+        if let screen = NSScreen.screens.first(where: { NSMouseInRect(activeLocation, $0.frame, false) }) {
           let topLeftX = (screen.visibleFrame.width - self.menu.size.width) / 2 + screen.visibleFrame.origin.x
           var topLeftY = (screen.visibleFrame.height + self.menu.size.height) / 2 + screen.visibleFrame.origin.y
           if screen.visibleFrame.height < self.menu.size.height {


### PR DESCRIPTION
This is my first contribution ever, hope i did it right.

I actively use the application, but when working with two monitors when using the settings for displaying a pop-up window on the center of screen, in my opinion, it worked illogically: the window did not open on the active monitor where i working, but on the one marked in the system settings as the main monitor.

Fixed this for myself and i would like to share the fix.