### PR TITLE
Translation correction

### DIFF
--- a/Maccy/Preferences/es.lproj/AdvancedPreferenceViewController.strings
+++ b/Maccy/Preferences/es.lproj/AdvancedPreferenceViewController.strings
@@ -18,7 +18,7 @@
 "jjU-HE-iIA.title" = "Evite centrarse en la aplicación";
 
 /* Class = "NSButtonCell"; title = "Clear history on quit"; ObjectID = "JvB-ng-8vt"; */
-"JvB-ng-8vt.title" = "Borrar historial al dejar de fumar";
+"JvB-ng-8vt.title" = "Borrar el historial al salir";
 
 /* Class = "NSTextFieldCell"; title = "Automatically remove all unpinned items before quitting the application."; ObjectID = "LW1-8W-pFI"; */
 "LW1-8W-pFI.title" = "Elimina automáticamente todos los elementos no anclados antes de salir de la aplicación.";


### PR DESCRIPTION
made a correction on the translation, in spanish it was "Borrar el historial al dejar de fumar" ("Clear history when quit smoking"), therefore the purpose of the button was not clear.