### PR TITLE
Fix macOS Sonoma Beta 2 menubar hang/crash

### DIFF
--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -174,9 +174,7 @@ class Maccy: NSObject {
     clipboard.onNewCopy(updateMenuTitle)
     clipboard.startListening()
 
-    populateHeader()
-    populateItems()
-    populateFooter()
+    rebuild();
 
     updateStatusItemEnabledness()
   }
@@ -258,7 +256,11 @@ class Maccy: NSObject {
     menu.clearAll()
     menu.removeAllItems()
 
-    populateHeader()
+    if !UserDefaults.standard.hideTitle || !UserDefaults.standard.hideSearch {
+      // The header only contains the title and search bar right now.
+      // Don't add the header to the menu if they're both disabled:
+      populateHeader()
+    }
     populateItems()
     populateFooter()
   }

--- a/Maccy/MenuHeader/MenuHeaderView.swift
+++ b/Maccy/MenuHeader/MenuHeaderView.swift
@@ -24,13 +24,10 @@ class MenuHeaderView: NSView, NSSearchFieldDelegate {
   private var eventHandler: EventHandlerRef?
 
   private lazy var customMenu: Menu? = self.enclosingMenuItem?.menu as? Menu
-  private lazy var headerHeight = UserDefaults.standard.hideSearch ? 1 : 29
-  private lazy var headerRect = NSRect(x: 0, y: 0, width: Menu.menuWidth, height: headerHeight)
 
   override func awakeFromNib() {
-    autoresizingMask = .width
-    frame = headerRect
-
+    autoresizingMask = [.width]
+    
     queryField.delegate = self
     queryField.placeholderString = NSLocalizedString("search_placeholder", comment: "")
 
@@ -47,6 +44,7 @@ class MenuHeaderView: NSView, NSSearchFieldDelegate {
     }
 
     if UserDefaults.standard.hideSearch {
+      queryField.isHidden = true
       constraints.forEach(removeConstraint)
     }
   }


### PR DESCRIPTION
This fixes the hang and crash that occurs since macOS Sonoma Beta 2. (https://github.com/p0deje/Maccy/issues/566)

Maccy used to hide the "Maccy" title and search bar within the menu by setting the height of the NSView to a small value.

In Beta 2, modifying the frame in any way results in a crash.

While this is likely an OS bug, since setting the height to 1 is a hack anyway, and the header only contains the title and search bar, not adding the header when both are disabled seems like a cleaner solution to me.