### PR TITLE
Add explain for pin item

### DIFF
--- a/Maccy/HistoryItem.swift
+++ b/Maccy/HistoryItem.swift
@@ -35,6 +35,7 @@ class HistoryItem: NSManagedObject {
   @NSManaged public var numberOfCopies: Int
   @NSManaged public var pin: String?
   @NSManaged public var title: String?
+  @NSManaged public var explain: String?
 
   var fileURL: URL? {
     guard let data = contentData([.fileURL]) else {

--- a/Maccy/Preferences/Base.lproj/PinsPreferenceViewController.xib
+++ b/Maccy/Preferences/Base.lproj/PinsPreferenceViewController.xib
@@ -13,28 +13,28 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wB8-4N-LTh">
-            <rect key="frame" x="0.0" y="0.0" width="506" height="409"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="wB8-4N-LTh">
+            <rect key="frame" x="0.0" y="0.0" width="679" height="417"/>
             <subviews>
                 <gridView xPlacement="fill" yPlacement="top" rowAlignment="lastBaseline" rowSpacing="8" columnSpacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="gYS-Mv-Vgf">
-                    <rect key="frame" x="26" y="21" width="460" height="375"/>
+                    <rect key="frame" x="35" y="21" width="610" height="375"/>
                     <rows>
                         <gridRow rowAlignment="firstBaseline" height="330" id="C5b-RL-gFE"/>
                         <gridRow id="blo-k0-0wL"/>
                     </rows>
                     <columns>
-                        <gridColumn width="460" id="UAs-ob-LWJ"/>
+                        <gridColumn width="610" id="UAs-ob-LWJ"/>
                     </columns>
                     <gridCells>
                         <gridCell row="C5b-RL-gFE" column="UAs-ob-LWJ" yPlacement="fill" rowAlignment="none" id="sFH-bL-pZC">
                             <scrollView key="contentView" autohidesScrollers="YES" horizontalLineScroll="20" horizontalPageScroll="10" verticalLineScroll="20" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xnm-Sk-2Ep">
-                                <rect key="frame" x="0.0" y="45" width="460" height="330"/>
+                                <rect key="frame" x="0.0" y="45" width="610" height="330"/>
                                 <clipView key="contentView" id="Ihc-rk-C2u">
-                                    <rect key="frame" x="1" y="1" width="458" height="328"/>
+                                    <rect key="frame" x="1" y="1" width="608" height="328"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="18" headerView="r8A-0m-vQY" id="9Bg-93-1ao">
-                                            <rect key="frame" x="0.0" y="0.0" width="458" height="300"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="608" height="300"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="3" height="2"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -72,12 +72,26 @@
                                                         <binding destination="1Hm-jM-tqp" name="value" keyPath="arrangedObjects.title" id="bkY-jM-ilP"/>
                                                     </connections>
                                                 </tableColumn>
+                                                <tableColumn width="150" minWidth="10" maxWidth="3.4028234663852886e+38" id="gp0-11-DX7">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Explain">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="PJt-OZ-Gi0">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <connections>
+                                                        <binding destination="1Hm-jM-tqp" name="value" keyPath="arrangedObjects.explain" id="p4t-dc-NSq"/>
+                                                    </connections>
+                                                </tableColumn>
                                             </tableColumns>
                                         </tableView>
                                     </subviews>
                                 </clipView>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="cHx-e5-xEh">
-                                    <rect key="frame" x="1" y="314" width="458" height="15"/>
+                                    <rect key="frame" x="1" y="314" width="608" height="15"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="PnM-2f-NvS">
@@ -85,14 +99,14 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <tableHeaderView key="headerView" wantsLayer="YES" id="r8A-0m-vQY">
-                                    <rect key="frame" x="0.0" y="0.0" width="458" height="28"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="608" height="28"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
                         </gridCell>
                         <gridCell row="blo-k0-0wL" column="UAs-ob-LWJ" id="8JK-5C-Zus">
                             <textField key="contentView" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="UQR-eA-hk9">
-                                <rect key="frame" x="-2" y="9" width="464" height="28"/>
+                                <rect key="frame" x="-2" y="9" width="614" height="28"/>
                                 <textFieldCell key="cell" selectable="YES" id="jBl-gB-eEV">
                                     <font key="font" metaFont="controlContent" size="11"/>
                                     <string key="title">You can customize the title and hotkey of every pinned item.

--- a/Maccy/Preferences/bs.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/bs.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Objašnjenje";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Dugme";

--- a/Maccy/Preferences/de.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/de.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Erklären";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Hotkey";

--- a/Maccy/Preferences/es.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/es.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Explicar";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Clave";

--- a/Maccy/Preferences/fr.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/fr.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Expliquer";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Clé";

--- a/Maccy/Preferences/hr.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/hr.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Polje teksta";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Objasniti";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Tipka";

--- a/Maccy/Preferences/it.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/it.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Calla Testuale";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Spiegare";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Chiave";

--- a/Maccy/Preferences/ja.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/ja.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "テキストセル";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "説明";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "キー";

--- a/Maccy/Preferences/ko.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/ko.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "텍스트 셀";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "설명";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "키";

--- a/Maccy/Preferences/nb.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/nb.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Forklare";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Nøkkel";

--- a/Maccy/Preferences/ru.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/ru.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Объяснить";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Клавиша";

--- a/Maccy/Preferences/th.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/th.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Cell ข้อความ";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "อธิบาย";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "คีย์";

--- a/Maccy/Preferences/tr.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/tr.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Açıklama";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Düğme";

--- a/Maccy/Preferences/uk.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/uk.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "Text Cell";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "Пояснення";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "Клавіша";

--- a/Maccy/Preferences/zh-Hans.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/zh-Hans.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "文本格";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "解释";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "键位";

--- a/Maccy/Preferences/zh-Hant.lproj/PinsPreferenceViewController.strings
+++ b/Maccy/Preferences/zh-Hant.lproj/PinsPreferenceViewController.strings
@@ -11,5 +11,8 @@
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "juh-Mt-VZK"; */
 "juh-Mt-VZK.title" = "文字";
 
+/* Class = "NSTableColumn"; headerCell.title = "Explain"; ObjectID = "gp0-11-DX7"; */
+"gp0-11-DX7.headerCell.title" = "解釋";
+
 /* Class = "NSTableColumn"; headerCell.title = "Key"; ObjectID = "qRS-YB-ZPI"; */
 "qRS-YB-ZPI.headerCell.title" = "快速鍵";

--- a/Maccy/Preview/Base.lproj/Preview.xib
+++ b/Maccy/Preview/Base.lproj/Preview.xib
@@ -8,6 +8,7 @@
         <customObject id="-2" userLabel="File's Owner" customClass="Preview" customModule="Maccy" customModuleProvider="target">
             <connections>
                 <outlet property="applicationValueLabel" destination="vfJ-eN-smJ" id="Bup-Ci-7Ed"/>
+                <outlet property="explainValueLabel" destination="3Id-iR-RD3" id="Iwj-NY-gU7"/>
                 <outlet property="firstCopyTimeValueLabel" destination="2XE-55-cRR" id="KsJ-p4-71t"/>
                 <outlet property="imageView" destination="eUh-Sy-ZGJ" id="fUX-f9-odQ"/>
                 <outlet property="lastCopyTimeValueLabel" destination="0RA-bO-K2R" id="0EU-OV-I14"/>
@@ -19,10 +20,10 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="v9u-1t-63F">
-            <rect key="frame" x="0.0" y="0.0" width="198" height="171"/>
+            <rect key="frame" x="0.0" y="0.0" width="198" height="188"/>
             <subviews>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="XIp-HY-KNa" userLabel="Content">
-                    <rect key="frame" x="10" y="145" width="178" height="16"/>
+                    <rect key="frame" x="10" y="162" width="178" height="16"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oAD-3G-XiA" userLabel="Text">
                             <rect key="frame" x="-2" y="0.0" width="182" height="16"/>
@@ -51,13 +52,13 @@
                     </constraints>
                 </customView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="fkF-ll-ISY">
-                    <rect key="frame" x="10" y="133" width="178" height="5"/>
+                    <rect key="frame" x="10" y="150" width="178" height="5"/>
                 </box>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="Vv7-qP-Jw0" userLabel="Details">
-                    <rect key="frame" x="10" y="61" width="178" height="65"/>
+                    <rect key="frame" x="10" y="61" width="178" height="82"/>
                     <subviews>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FTN-9D-ff0" userLabel="Application">
-                            <rect key="frame" x="-2" y="51" width="67" height="14"/>
+                            <rect key="frame" x="-2" y="68" width="67" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Application:" id="v53-2O-7HD">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -65,7 +66,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vfJ-eN-smJ" userLabel="Application value">
-                            <rect key="frame" x="66" y="51" width="38" height="14"/>
+                            <rect key="frame" x="66" y="68" width="38" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Xcode" id="Krv-qU-Cbs">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -73,7 +74,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cg6-3e-xc1" userLabel="First copy time">
-                            <rect key="frame" x="-2" y="34" width="85" height="14"/>
+                            <rect key="frame" x="-2" y="51" width="85" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="First copy time:" id="Ot3-5Y-zfU">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -81,7 +82,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2XE-55-cRR" userLabel="First copy time value">
-                            <rect key="frame" x="84" y="34" width="87" height="14"/>
+                            <rect key="frame" x="84" y="51" width="87" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Jan 28, 8:22:33" id="ung-5b-7M1">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -89,7 +90,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SS5-LZ-uKc" userLabel="Last copy time">
-                            <rect key="frame" x="-2" y="17" width="85" height="14"/>
+                            <rect key="frame" x="-2" y="34" width="85" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Last copy time:" id="ify-Om-Foy">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -97,7 +98,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0RA-bO-K2R" userLabel="Last copy time value">
-                            <rect key="frame" x="84" y="17" width="87" height="14"/>
+                            <rect key="frame" x="84" y="34" width="87" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Jan 28, 8:22:33" id="Efh-V6-485">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -105,7 +106,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r2k-lU-Gsl" userLabel="Number of copies">
-                            <rect key="frame" x="-2" y="0.0" width="101" height="14"/>
+                            <rect key="frame" x="-2" y="17" width="101" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Number of copies:" id="bmV-pZ-ccc">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -113,8 +114,24 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5pE-jy-xQR" userLabel="Number of copies value">
-                            <rect key="frame" x="100" y="0.0" width="10" height="14"/>
+                            <rect key="frame" x="100" y="17" width="10" height="14"/>
                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="1" id="Klp-cA-i6M" userLabel="1">
+                                <font key="font" metaFont="smallSystem"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hbB-aR-suU" userLabel="Explain">
+                            <rect key="frame" x="-2" y="0.0" width="45" height="14"/>
+                            <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Explain:" id="n35-CP-pjc">
+                                <font key="font" metaFont="smallSystem"/>
+                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                            </textFieldCell>
+                        </textField>
+                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Id-iR-RD3" userLabel="Explain value">
+                            <rect key="frame" x="44" y="0.0" width="19" height="14"/>
+                            <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="No" id="tn3-Io-CBp" userLabel="No">
                                 <font key="font" metaFont="smallSystem"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -122,23 +139,28 @@
                         </textField>
                     </subviews>
                     <constraints>
+                        <constraint firstAttribute="bottom" secondItem="hbB-aR-suU" secondAttribute="bottom" id="1SZ-RW-pNe"/>
                         <constraint firstItem="r2k-lU-Gsl" firstAttribute="leading" secondItem="Vv7-qP-Jw0" secondAttribute="leading" id="3np-EU-8Ra"/>
                         <constraint firstItem="0RA-bO-K2R" firstAttribute="centerY" secondItem="SS5-LZ-uKc" secondAttribute="centerY" id="7CC-BP-I3d"/>
+                        <constraint firstItem="3Id-iR-RD3" firstAttribute="leading" secondItem="hbB-aR-suU" secondAttribute="trailing" constant="5" id="AVt-0a-Zqq"/>
                         <constraint firstItem="cg6-3e-xc1" firstAttribute="leading" secondItem="Vv7-qP-Jw0" secondAttribute="leading" id="DCk-f5-IUB"/>
                         <constraint firstItem="vfJ-eN-smJ" firstAttribute="leading" secondItem="FTN-9D-ff0" secondAttribute="trailing" constant="5" id="F4L-Ms-gmh"/>
                         <constraint firstItem="5pE-jy-xQR" firstAttribute="leading" secondItem="r2k-lU-Gsl" secondAttribute="trailing" constant="5" id="FZp-6g-4YP"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="vfJ-eN-smJ" secondAttribute="trailing" priority="750" id="Fms-Tt-Zep"/>
                         <constraint firstItem="SS5-LZ-uKc" firstAttribute="leading" secondItem="Vv7-qP-Jw0" secondAttribute="leading" id="GcS-ri-OQl"/>
+                        <constraint firstItem="hbB-aR-suU" firstAttribute="leading" secondItem="Vv7-qP-Jw0" secondAttribute="leading" id="JKS-t9-Teu"/>
                         <constraint firstItem="0RA-bO-K2R" firstAttribute="leading" secondItem="SS5-LZ-uKc" secondAttribute="trailing" constant="5" id="Jnm-fd-Zhm"/>
                         <constraint firstItem="SS5-LZ-uKc" firstAttribute="top" secondItem="cg6-3e-xc1" secondAttribute="bottom" constant="3" id="L0K-DU-mgV"/>
                         <constraint firstItem="2XE-55-cRR" firstAttribute="centerY" secondItem="cg6-3e-xc1" secondAttribute="centerY" id="Mds-bG-TLl"/>
-                        <constraint firstAttribute="bottom" secondItem="r2k-lU-Gsl" secondAttribute="bottom" id="WZk-qE-wV3"/>
+                        <constraint firstItem="3Id-iR-RD3" firstAttribute="centerY" secondItem="hbB-aR-suU" secondAttribute="centerY" id="Rcc-RF-lT7"/>
                         <constraint firstItem="FTN-9D-ff0" firstAttribute="top" secondItem="Vv7-qP-Jw0" secondAttribute="top" id="Wdj-Vu-Zmc"/>
                         <constraint firstItem="cg6-3e-xc1" firstAttribute="top" secondItem="FTN-9D-ff0" secondAttribute="bottom" constant="3" id="Xfr-nI-kbz"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5pE-jy-xQR" secondAttribute="trailing" priority="750" id="bcu-eD-2IE"/>
                         <constraint firstItem="2XE-55-cRR" firstAttribute="leading" secondItem="cg6-3e-xc1" secondAttribute="trailing" constant="5" id="gRe-P9-5gn"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2XE-55-cRR" secondAttribute="trailing" priority="750" constant="9" id="irc-vF-AVY"/>
                         <constraint firstItem="5pE-jy-xQR" firstAttribute="centerY" secondItem="r2k-lU-Gsl" secondAttribute="centerY" id="kWq-Cm-aPL"/>
+                        <constraint firstItem="hbB-aR-suU" firstAttribute="top" secondItem="r2k-lU-Gsl" secondAttribute="bottom" constant="3" id="kbc-sB-uHB"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3Id-iR-RD3" secondAttribute="trailing" constant="20" symbolic="YES" id="meJ-sv-rUs"/>
                         <constraint firstItem="r2k-lU-Gsl" firstAttribute="top" secondItem="SS5-LZ-uKc" secondAttribute="bottom" constant="3" id="nLt-db-I4L"/>
                         <constraint firstItem="FTN-9D-ff0" firstAttribute="leading" secondItem="Vv7-qP-Jw0" secondAttribute="leading" id="pVf-ru-MgM"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0RA-bO-K2R" secondAttribute="trailing" priority="750" id="pXx-ae-FLx"/>
@@ -186,7 +208,7 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3ca-72-NPr" secondAttribute="trailing" priority="750" constant="10" id="qdE-CM-Jms"/>
                 <constraint firstItem="fkF-ll-ISY" firstAttribute="trailing" secondItem="v9u-1t-63F" secondAttribute="trailing" constant="-10" id="yeh-0G-aST"/>
             </constraints>
-            <point key="canvasLocation" x="-46" y="-408"/>
+            <point key="canvasLocation" x="-46" y="-352.5"/>
         </customView>
     </objects>
 </document>

--- a/Maccy/Preview/Preview.swift
+++ b/Maccy/Preview/Preview.swift
@@ -7,6 +7,7 @@ class Preview: NSViewController {
   @IBOutlet weak var firstCopyTimeValueLabel: NSTextField!
   @IBOutlet weak var lastCopyTimeValueLabel: NSTextField!
   @IBOutlet weak var numberOfCopiesValueLabel: NSTextField!
+  @IBOutlet weak var explainValueLabel: NSTextField!
 
   private let maxTextSize = 1_500
 
@@ -56,6 +57,7 @@ class Preview: NSViewController {
     firstCopyTimeValueLabel.stringValue = formatDate(item.firstCopiedAt)
     lastCopyTimeValueLabel.stringValue = formatDate(item.lastCopiedAt)
     numberOfCopiesValueLabel.stringValue = String(item.numberOfCopies)
+    explainValueLabel.stringValue = item.explain ?? ""
   }
 
   private func formatDate(_ date: Date) -> String {

--- a/Maccy/Preview/bs.lproj/Preview.strings
+++ b/Maccy/Preview/bs.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Aplikacija:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Objašnjenje:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Ne"

--- a/Maccy/Preview/de.lproj/Preview.strings
+++ b/Maccy/Preview/de.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Programm:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Erklären:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Nein"

--- a/Maccy/Preview/es.lproj/Preview.strings
+++ b/Maccy/Preview/es.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Aplicación:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Explicar:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "No"

--- a/Maccy/Preview/fr.lproj/Preview.strings
+++ b/Maccy/Preview/fr.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Application:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Expliquer:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Non"

--- a/Maccy/Preview/hr.lproj/Preview.strings
+++ b/Maccy/Preview/hr.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Program:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Objasniti:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Ne"

--- a/Maccy/Preview/it.lproj/Preview.strings
+++ b/Maccy/Preview/it.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Applicazione:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Spiegare:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "No"

--- a/Maccy/Preview/ja.lproj/Preview.strings
+++ b/Maccy/Preview/ja.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "アプリケーション:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "説明:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "いいえ"

--- a/Maccy/Preview/ko.lproj/Preview.strings
+++ b/Maccy/Preview/ko.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "어플리케이션:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "설명:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "아니요"

--- a/Maccy/Preview/nb.lproj/Preview.strings
+++ b/Maccy/Preview/nb.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Applikasjon:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Forklare:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Nei"

--- a/Maccy/Preview/ru.lproj/Preview.strings
+++ b/Maccy/Preview/ru.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Приложение:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Объяснить:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Нет"

--- a/Maccy/Preview/th.lproj/Preview.strings
+++ b/Maccy/Preview/th.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "แอปพลิเคชัน:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "อธิบาย:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "ไม่"

--- a/Maccy/Preview/tr.lproj/Preview.strings
+++ b/Maccy/Preview/tr.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Uygulama:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Açıklama:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Hayır"

--- a/Maccy/Preview/uk.lproj/Preview.strings
+++ b/Maccy/Preview/uk.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "Додаток:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "Пояснення:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "Ні"

--- a/Maccy/Preview/zh-Hans.lproj/Preview.strings
+++ b/Maccy/Preview/zh-Hans.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "应用:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "解释:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "无"

--- a/Maccy/Preview/zh-Hant.lproj/Preview.strings
+++ b/Maccy/Preview/zh-Hant.lproj/Preview.strings
@@ -30,3 +30,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Application:"; ObjectID = "v53-2O-7HD"; */
 "v53-2O-7HD.title" = "應用:";
+
+/* Class = "NSTextFieldCell"; title = "Explain:"; ObjectID = "n35-CP-pjc"; */
+"n35-CP-pjc.title" = "解釋:"
+
+/* Class = "NSTextFieldCell"; title = "No"; ObjectID = "tn3-Io-CBp"; */
+"tn3-Io-CBp.title" = "無"

--- a/Maccy/Storage.xcdatamodeld/Storage.xcdatamodel/contents
+++ b/Maccy/Storage.xcdatamodeld/Storage.xcdatamodel/contents
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F66" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="22D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="HistoryItem" representedClassName="HistoryItem" syncable="YES">
         <attribute name="application" optional="YES" attributeType="String"/>
+        <attribute name="explain" optional="YES" attributeType="String"/>
         <attribute name="firstCopiedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastCopiedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="numberOfCopies" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>


### PR DESCRIPTION
The software is incredibly useful, but during my usage, I noticed that when I have multiple similar entries pinned, I occasionally forget what they originally represent. Hence, I have submitted this pull request to address the issue.
To assist you in better understanding, here are two relevant screenshots showcasing this feature in action:
![Xnip2023-07-01_11-04-08](https://github.com/p0deje/Maccy/assets/11513056/43afeffc-3212-45e6-9bae-36c4df2bdde3)
![Xnip2023-07-01_11-03-29](https://github.com/p0deje/Maccy/assets/11513056/630451f1-1cd6-4a7c-921b-415c187a4927)
