### PR TITLE
Prevent menu from moving while scrolling

### DIFF
--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -103,7 +103,7 @@ class Maccy: NSObject {
       case "center":
         if let frame = NSScreen.forPopup?.visibleFrame {
           self.linkingMenuToStatusItem {
-            self.menu.popUp(positioning: nil, at: NSRect.centered(ofSize: self.menu.size, in: frame).origin, in: nil)
+            self.menu.popUpConstrained(positioning: nil, at: NSRect.centered(ofSize: self.menu.size, in: frame).origin, in: nil)
           }
         }
       case "statusItem":
@@ -111,14 +111,14 @@ class Maccy: NSObject {
       case "window":
         if let frame = windowFrame {
           self.linkingMenuToStatusItem {
-            self.menu.popUp(positioning: nil, at: NSRect.centered(ofSize: self.menu.size, in: frame).origin, in: nil)
+            self.menu.popUpConstrained(positioning: nil, at: NSRect.centered(ofSize: self.menu.size, in: frame).origin, in: nil)
           }
         } else {
           fallthrough
         }
       default:
         self.linkingMenuToStatusItem {
-          self.menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
+          self.menu.popUpConstrained(positioning: nil, at: NSEvent.mouseLocation, in: nil)
         }
       }
     }


### PR DESCRIPTION
If scrollbars are visible scrolling in the menu will cause it to move upwards which feels a bit weird.
This solution uses the `confinementRect(for:on:)` method of `NSMenuDelegate` to limit the menu to its original bounds it had when shown. To determine this size the menu is shown and immediately hidden just after querying the window bounds for the popup.

This technique is really dirty however I did not find a better solution without reinventing menu positioning. Therefore this is merely a suggestion :)