### PR TITLE
Some fixes to event handling in order to avoid system beeps

### DIFF
--- a/Maccy/MenuHeader/MenuHeaderView.swift
+++ b/Maccy/MenuHeader/MenuHeaderView.swift
@@ -162,7 +162,7 @@ class MenuHeaderView: NSView, NSSearchFieldDelegate {
       }
     case .hide:
       customMenu?.cancelTracking()
-      return false
+      return true
     case .openPreferences:
       performMenuItemAction(MenuFooter.preferences.rawValue)
       return false

--- a/Maccy/MenuHeader/MenuHeaderView.swift
+++ b/Maccy/MenuHeader/MenuHeaderView.swift
@@ -165,7 +165,7 @@ class MenuHeaderView: NSView, NSSearchFieldDelegate {
       return true
     case .openPreferences:
       performMenuItemAction(MenuFooter.preferences.rawValue)
-      return false
+      return true
     case .paste:
       queryField.becomeFirstResponder()
       queryField.currentEditor()?.paste(nil)


### PR DESCRIPTION
This avoids a sound from being played when the menu is closed or the settings are opened.