### PR TITLE
Make location adjustment adaptable for new types

### DIFF
--- a/Maccy/Maccy.swift
+++ b/Maccy/Maccy.swift
@@ -105,7 +105,7 @@ class Maccy: NSObject {
           self.linkingMenuToStatusItem {
             self.menu.popUpMenu(
               at: NSRect.centered(ofSize: self.menu.size, in: frame).origin,
-              within: frame
+              ofType: .centeredInScreen(frame: frame)
             )
           }
         }
@@ -116,7 +116,7 @@ class Maccy: NSObject {
           self.linkingMenuToStatusItem {
             self.menu.popUpMenu(
               at: NSRect.centered(ofSize: self.menu.size, in: frame).origin,
-              within: windowFrame
+              ofType: .centeredInWindow(frame: frame)
             )
           }
         } else {
@@ -124,7 +124,8 @@ class Maccy: NSObject {
         }
       default:
         self.linkingMenuToStatusItem {
-          self.menu.popUpMenu(at: NSEvent.mouseLocation)
+          let mouseLocation = NSEvent.mouseLocation
+          self.menu.popUpMenu(at: mouseLocation, ofType: .atMouseCursor(location: mouseLocation))
         }
       }
     }
@@ -307,7 +308,7 @@ class Maccy: NSObject {
     if let buttonCell = statusItem.button?.cell as? NSButtonCell {
       withMenuButtonHighlighted(buttonCell) {
         self.linkingMenuToStatusItem {
-          self.menu.prepareForPopup(shouldAdjustLocationAfterwards: false)
+          self.menu.prepareForPopup(location: .inMenuBar)
           self.statusItem.button?.performClick(self)
         }
       }

--- a/Maccy/MenuHeader/MenuHeaderView.swift
+++ b/Maccy/MenuHeader/MenuHeaderView.swift
@@ -30,8 +30,6 @@ class MenuHeaderView: NSView, NSSearchFieldDelegate {
   private lazy var headerHeight = UserDefaults.standard.hideSearch ? 1 : 28
   private lazy var headerSize = NSSize(width: Menu.menuWidth, height: headerHeight)
 
-  var shouldAdjustMenuWindowLocation = false
-
   override func awakeFromNib() {
     autoresizingMask = .width
     setFrameSize(headerSize)
@@ -62,11 +60,10 @@ class MenuHeaderView: NSView, NSSearchFieldDelegate {
     if window != nil && customMenu?.isVisible == true {
       // Fix for Sonoma. The menu will report an icorrect height causing the popup to be
       // This is the most conventient and earliest point possible to intercept and adjust the window location.
-      if #available(macOS 14, *), shouldAdjustMenuWindowLocation {
+      if #available(macOS 14, *) {
         if customMenu?.size.height ?? 0.0 < NSScreen.forPopup?.visibleFrame.height ?? 0.0 {
           customMenu?.adjustMenuWindowPosition()
         }
-        shouldAdjustMenuWindowLocation = false
       }
       eventMonitor.start()
     } else if window == nil && customMenu?.isVisible == false {

--- a/MaccyTests/MenuTests.swift
+++ b/MaccyTests/MenuTests.swift
@@ -55,7 +55,7 @@ class MenuTests: XCTestCase {
     UserDefaults.standard.removeFormattingByDefault = false
 
     menu.buildItems()
-    menu.prepareForPopup(shouldAdjustLocationAfterwards: false)
+    menu.prepareForPopup(location: .inMenuBar)
 
     XCTAssertEqual(chunkedItems.count, 3)
     for (index, chunk) in chunkedItems.enumerated() {
@@ -82,7 +82,7 @@ class MenuTests: XCTestCase {
     UserDefaults.standard.removeFormattingByDefault = false
 
     menu.buildItems()
-    menu.prepareForPopup(shouldAdjustLocationAfterwards: false)
+    menu.prepareForPopup(location: .inMenuBar)
 
     XCTAssertEqual(chunkedItems.count, 3)
     for (index, chunk) in chunkedItems.enumerated() {
@@ -109,7 +109,7 @@ class MenuTests: XCTestCase {
     UserDefaults.standard.removeFormattingByDefault = true
 
     menu.buildItems()
-    menu.prepareForPopup(shouldAdjustLocationAfterwards: false)
+    menu.prepareForPopup(location: .inMenuBar)
 
     XCTAssertEqual(chunkedItems.count, 3)
     for (index, chunk) in chunkedItems.enumerated() {
@@ -136,7 +136,7 @@ class MenuTests: XCTestCase {
     UserDefaults.standard.removeFormattingByDefault = true
 
     menu.buildItems()
-    menu.prepareForPopup(shouldAdjustLocationAfterwards: false)
+    menu.prepareForPopup(location: .inMenuBar)
 
     XCTAssertEqual(chunkedItems.count, 3)
     for (index, chunk) in chunkedItems.enumerated() {


### PR DESCRIPTION
Don't differentiate between different popup types in code paths. Instead the window just isn't adjusted in `adjustMenuWindowPosition()` if not necessary. I'm playing with an implementation for opening the menu at the current text cursor location and this makes it a bit easier. Generally I think this makes the code a bit easier to reason about.