### PR TITLE
Fix popovers on pre-Sonoma

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
+		2F73DF2C2AE2749E00DB654E /* PreviewMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F73DF2B2AE2749E00DB654E /* PreviewMenuItem.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		5AA9C8402AD80E1B003340F9 /* IgnorePasteboardTypesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA9C83F2AD80E1B003340F9 /* IgnorePasteboardTypesViewController.swift */; };
 		5ACA94F52AD4D1E200ECAB6A /* IgnoreRegexViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ACA94F42AD4D1E200ECAB6A /* IgnoreRegexViewController.swift */; };
@@ -174,6 +175,7 @@
 		11EB892A281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/IgnoreSettingsViewController.strings; sourceTree = "<group>"; };
 		11EB892B281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = Maccy/Preferences/ko.lproj/StorageSettingsViewController.strings; sourceTree = "<group>"; };
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2F73DF2B2AE2749E00DB654E /* PreviewMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMenuItem.swift; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4DC4D10F252713D700FE5FAC /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AdvancedSettingsViewController.strings; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 				DAF65F4724D396FE00F3978F /* CopyMenuItem.swift */,
 				DAF65F4624D396FE00F3978F /* PasteMenuItem.swift */,
 				DAF65F4524D396FE00F3978F /* PasteWithoutFormattingMenuItem.swift */,
+				2F73DF2B2AE2749E00DB654E /* PreviewMenuItem.swift */,
 			);
 			path = HistoryMenuItem;
 			sourceTree = "<group>";
@@ -864,6 +867,7 @@
 				DAF65F4924D396FE00F3978F /* PasteMenuItem.swift in Sources */,
 				DA57C64E249E2A550032707A /* MenuFooter.swift in Sources */,
 				DAB65DFF2440AE29000AECA8 /* CoreDataManager.swift in Sources */,
+				2F73DF2C2AE2749E00DB654E /* PreviewMenuItem.swift in Sources */,
 				DA2B0AF2234201E500EFAD72 /* UserDefaults+Configuration.swift in Sources */,
 				DAC7AFAF2A801C92006081BB /* RunLoopLocalEventMonitor.swift in Sources */,
 				DA0EF1881E444B2A00E58577 /* Clipboard.swift in Sources */,

--- a/Maccy/HistoryMenuItem/PreviewMenuItem.swift
+++ b/Maccy/HistoryMenuItem/PreviewMenuItem.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+extension HistoryMenuItem {
+  @available(macOS, obsoleted: 14.0)
+  class PreviewMenuItem: NSMenuItem {
+    private let initialSize = NSSize(width: CGFloat(Menu.menuWidth), height: 0.1)
+
+    init() {
+      super.init(title: "", action: nil, keyEquivalent: "")
+      view = NSView(frame: NSRect(origin: .zero, size: initialSize))
+      isHidden = true
+    }
+
+    required init(coder: NSCoder) {
+      super.init(coder: coder)
+    }
+  }
+}


### PR DESCRIPTION
I didn't find a way to adapt the new code path for older versions. Hence as discussed this restores the codepath on these versions.