### PR TITLE
add example password regex to settings description

### DIFF
--- a/Maccy/Settings/Base.lproj/IgnoreSettingsViewController.xib
+++ b/Maccy/Settings/Base.lproj/IgnoreSettingsViewController.xib
@@ -321,13 +321,13 @@ By default, some known application-specific types are defined. You can remove th
                                 <rect key="frame" x="-2" y="41" width="455" height="42"/>
                                 <textFieldCell key="cell" selectable="YES" id="FqC-BY-av4">
                                     <font key="font" metaFont="controlContent" size="11"/>
-                                    <string key="title">It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex.
+                                    <string key="title">It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$
 </string>
                                     <color key="textColor" name="systemGrayColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <string key="userLabel">It's possible to ignore certain pasteboard item types from remembering. By default, some known application-specific types are defined. You can remove them and add any custom types you want.</string>
                                 </textFieldCell>
-                                <string key="userLabel">It's possible to ignore certain pasteboard items from remembering | w based on defined regex strings. Create strings using standard regex.</string>
+                                <string key="userLabel">It's possible to ignore certain pasteboard items from remembering | w based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$</string>
                             </textField>
                         </gridCell>
                     </gridCells>

--- a/Maccy/Settings/Base.lproj/IgnoreSettingsViewController.xib
+++ b/Maccy/Settings/Base.lproj/IgnoreSettingsViewController.xib
@@ -321,13 +321,13 @@ By default, some known application-specific types are defined. You can remove th
                                 <rect key="frame" x="-2" y="41" width="455" height="42"/>
                                 <textFieldCell key="cell" selectable="YES" id="FqC-BY-av4">
                                     <font key="font" metaFont="controlContent" size="11"/>
-                                    <string key="title">It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$
+                                    <string key="title">It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$
 </string>
                                     <color key="textColor" name="systemGrayColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <string key="userLabel">It's possible to ignore certain pasteboard item types from remembering. By default, some known application-specific types are defined. You can remove them and add any custom types you want.</string>
                                 </textFieldCell>
-                                <string key="userLabel">It's possible to ignore certain pasteboard items from remembering | w based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$</string>
+                                <string key="userLabel">It's possible to ignore certain pasteboard items from remembering | w based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$</string>
                             </textField>
                         </gridCell>
                     </gridCells>

--- a/Maccy/Settings/bs.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/bs.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex Strings";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Moguće je zanemariti određene stavke kartona od pamćenja na osnovu definiranih nizova regularnih izraza. Kreirajte nizove koristeći standardni regularni izraz.";

--- a/Maccy/Settings/bs.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/bs.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex Strings";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Moguće je zanemariti određene stavke kartona od pamćenja na osnovu definiranih nizova regularnih izraza. Kreirajte nizove koristeći standardni regularni izraz.";

--- a/Maccy/Settings/de.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/de.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex-Strings";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Es ist möglich, bestimmte Pasteboard-Elemente basierend auf definierten Regex-Strings aus der Erinnerung zu ignorieren. Erstellen Sie Zeichenfolgen mit Standard-Regex.";

--- a/Maccy/Settings/de.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/de.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex-Strings";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Es ist möglich, bestimmte Pasteboard-Elemente basierend auf definierten Regex-Strings aus der Erinnerung zu ignorieren. Erstellen Sie Zeichenfolgen mit Standard-Regex.";

--- a/Maccy/Settings/es.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/es.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Cadenas de expresiones regulares";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Es posible ignorar ciertos elementos del tablero para que no se recuerden en función de cadenas de expresiones regulares definidas. Crea cadenas usando expresiones regulares estándar.";

--- a/Maccy/Settings/es.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/es.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Cadenas de expresiones regulares";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Es posible ignorar ciertos elementos del tablero para que no se recuerden en función de cadenas de expresiones regulares definidas. Crea cadenas usando expresiones regulares estándar.";

--- a/Maccy/Settings/fr.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/fr.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Chaînes d'expression régulière";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Il est possible d'ignorer certains éléments du carton de mémorisation en fonction des chaînes d'expression régulière définies. Créez des chaînes à l’aide d’une expression régulière standard.";

--- a/Maccy/Settings/fr.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/fr.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Chaînes d'expression régulière";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Il est possible d'ignorer certains éléments du carton de mémorisation en fonction des chaînes d'expression régulière définies. Créez des chaînes à l’aide d’une expression régulière standard.";

--- a/Maccy/Settings/hr.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/hr.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex nizovi";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Moguće je ignorirati određene pasteboard stavke od pamćenja na temelju definiranih regularnih nizova. Stvorite nizove pomoću standardnog regularnog izraza.";

--- a/Maccy/Settings/hr.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/hr.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex nizovi";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Moguće je ignorirati određene pasteboard stavke od pamćenja na temelju definiranih regularnih nizova. Stvorite nizove pomoću standardnog regularnog izraza.";

--- a/Maccy/Settings/it.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/it.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Stringhe regex";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "È possibile ignorare alcuni elementi del pasteboard in modo che vengano ricordati in base a stringhe regex definite. Crea stringhe utilizzando regex standard.";

--- a/Maccy/Settings/it.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/it.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Stringhe regex";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "È possibile ignorare alcuni elementi del pasteboard in modo che vengano ricordati in base a stringhe regex definite. Crea stringhe utilizzando regex standard.";

--- a/Maccy/Settings/ja.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/ja.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "正規表現文字列";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "定義された正規表現文字列に基づいて、特定のペーストボード項目の記憶を無視することができます。標準の正規表現を使用して文字列を作成します";

--- a/Maccy/Settings/ja.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/ja.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "正規表現文字列";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "定義された正規表現文字列に基づいて、特定のペーストボード項目の記憶を無視することができます。標準の正規表現を使用して文字列を作成します";

--- a/Maccy/Settings/ko.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/ko.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "정규식 문자열";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "정의된 정규식 문자열을 기반으로 특정 임시 보드 항목이 기억되지 않도록 무시할 수 있습니다. 표준 정규식을 사용하여 문자열을 만듭니다";

--- a/Maccy/Settings/ko.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/ko.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "정규식 문자열";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "정의된 정규식 문자열을 기반으로 특정 임시 보드 항목이 기억되지 않도록 무시할 수 있습니다. 표준 정규식을 사용하여 문자열을 만듭니다";

--- a/Maccy/Settings/nb.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/nb.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex-strenger";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Det er mulig å ignorere visse elementer i limbrettet fra å huske basert på definerte regex-strenger. Lag strenger ved å bruke standard regulært uttrykk.";

--- a/Maccy/Settings/nb.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/nb.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex-strenger";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Det er mulig å ignorere visse elementer i limbrettet fra å huske basert på definerte regex-strenger. Lag strenger ved å bruke standard regulært uttrykk.";

--- a/Maccy/Settings/ru.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/ru.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Строки регулярных выражений";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Можно игнорировать определенные элементы монтажного стола из запоминания на основе определенных строк регулярных выражений. Создавайте строки, используя стандартное регулярное выражение.";

--- a/Maccy/Settings/ru.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/ru.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Строки регулярных выражений";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Можно игнорировать определенные элементы монтажного стола из запоминания на основе определенных строк регулярных выражений. Создавайте строки, используя стандартное регулярное выражение.";

--- a/Maccy/Settings/th.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/th.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "สตริง Regex";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "เป็นไปได้ที่จะเพิกเฉยต่อรายการแผ่นแปะบางรายการจากการจำตามสตริง regex ที่กำหนดไว้ สร้างสตริงโดยใช้ regex มาตรฐาน";

--- a/Maccy/Settings/th.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/th.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "สตริง Regex";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "เป็นไปได้ที่จะเพิกเฉยต่อรายการแผ่นแปะบางรายการจากการจำตามสตริง regex ที่กำหนดไว้ สร้างสตริงโดยใช้ regex มาตรฐาน";

--- a/Maccy/Settings/tr.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/tr.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex Dizeleri";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Belirli çalışma alanı öğelerinin, tanımlanmış normal ifade dizelerine göre hatırlanmasını göz ardı etmek mümkündür. Standart normal ifadeyi kullanarak dizeler oluşturun.";

--- a/Maccy/Settings/tr.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/tr.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Regex Dizeleri";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Belirli çalışma alanı öğelerinin, tanımlanmış normal ifade dizelerine göre hatırlanmasını göz ardı etmek mümkündür. Standart normal ifadeyi kullanarak dizeler oluşturun.";

--- a/Maccy/Settings/uk.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/uk.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Рядки регулярних виразів";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Можна ігнорувати певні елементи картону від запам’ятовування на основі визначених рядків регулярного виразу. Створіть рядки за допомогою стандартного регулярного виразу.";

--- a/Maccy/Settings/uk.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/uk.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "Рядки регулярних виразів";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "Можна ігнорувати певні елементи картону від запам’ятовування на основі визначених рядків регулярного виразу. Створіть рядки за допомогою стандартного регулярного виразу.";

--- a/Maccy/Settings/zh-Hans.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/zh-Hans.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "正则表达式字符串";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "可以根据定义的正则表达式字符串忽略某些粘贴板项目。使用标准正则表达式创建字符串。";

--- a/Maccy/Settings/zh-Hans.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/zh-Hans.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "正则表达式字符串";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "可以根据定义的正则表达式字符串忽略某些粘贴板项目。使用标准正则表达式创建字符串。";

--- a/Maccy/Settings/zh-Hant.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/zh-Hant.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "正規表示式字串";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex."; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "可以根據定義的正規表示式字串忽略某些黏貼簿項目。使用標準正規表示式建立字串。";

--- a/Maccy/Settings/zh-Hant.lproj/IgnoreSettingsViewController.strings
+++ b/Maccy/Settings/zh-Hant.lproj/IgnoreSettingsViewController.strings
@@ -25,5 +25,5 @@
 /* Class = "NSTableColumn"; headerCell.title = "Regex Strings"; ObjectID = "L9O-de-BED"; */
 "L9O-de-BED.headerCell.title" = "正規表示式字串";
 
-/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s\n]{8,}$"; ObjectID = "FqC-BY-av4"; */
+/* Class = "NSTextFieldCell"; headerCell.title = "It's possible to ignore certain pasteboard items from remembering based on defined regex strings. Create strings using standard regex. For example, many passwords are matched by ^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$"; ObjectID = "FqC-BY-av4"; */
 "FqC-BY-av4.title" = "可以根據定義的正規表示式字串忽略某些黏貼簿項目。使用標準正規表示式建立字串。";


### PR DESCRIPTION
Sorry I don't have xcode so I'm not certain I did this right. Feel free ofc to make any changes as you see fit, or delete and recreate or whatever, no need to check with me.

Regex explanation:

```
^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\s]{8,}$
(?=.*[a-z])   --  at least one lowercase
(?=.*[A-Z])   --  at least one uppercase
(?=.*\d)      --  at least one digit
[^\s]{8,}     -- 8 or more non-whitespace characters
```