### PR TITLE
issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+---
+name: 🐛 Bug Report
+description: Submit a Bug Report
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to complete this bug report!
+        This will help to find the cause of the issue faster and requires fewer follow-ups.
+  - type: checkboxes
+    attributes:
+      label: Before Submitting Your Bug Report
+      options:
+        - label: I have verified that there isn't already an issue reporting the same bug to prevent duplication.
+          required: false
+        - label: I have seen the [FAQ](https://github.com/p0deje/Maccy?tab=readme-ov-file#faq).
+          required: false
+  - type: input
+    attributes:
+      label: Maccy Version (see 'About' window)
+      placeholder: e.g. 0.29.0
+    validations:
+      required: false
+  - type: input
+    attributes:
+      label: macOS Version
+      placeholder: e.g. 13.5.2
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Maccy Settings
+      description: Provide the output from running 'defaults read org.p0deje.Maccy' in Terminal.app.
+      render: Shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please provide a clear and concise description of the bug.
+      placeholder: Short description
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Provide the steps to consistently reproduce the issue. If possible, record a screen video
+        demonstrating the problem using QuickTime.app.
+      placeholder: |
+        1. Navigate to …
+        2. Click on …
+        3. Scroll down to …
+        4. Observe …
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+---
+name: 💪 Feature request
+description: Suggest an idea for this project
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Before Submitting Your Feature Request
+      options:
+        - label: Check that there isn't already a similar feature request to avoid creating a duplicate.
+          required: false
+        - label: I have seen the [FAQ](https://github.com/p0deje/Maccy?tab=readme-ov-file#faq).
+          required: false
+  - type: textarea
+    attributes:
+      label: Problem
+      description:
+        Please add a clear and concise description of the problem you are
+        seeking to solve with this feature request.
+      placeholder: |
+        Description
+  - type: textarea
+    attributes:
+      label: Solution
+      description: Please describe what you might want to happen to address this issue. If applicable, add a screenshot, gif, or video to better convey your idea.
+      placeholder: |
+        Short description
+    validations:
+      required: false


### PR DESCRIPTION
### proposal

- Usage of issue template forms written in `YAML`.
- The primary goal is to save the maintainer's time by ensuring all necessary information is provided, thus reducing the need for trivial follow-up questions such as 'which version of 'Maccy' are you using?'
- A secondary goal is to provide the user with some guidance on what is expected in a 'Maccy' bug report.

#### links
- [Github Docs - Syntax for issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)

#### demo
https://github.com/LangLangBart/Maccy/issues/new/choose