### PR TITLE
Adjust popup position to clamp window into current screen region

### DIFF
--- a/Maccy/PopupLocation.swift
+++ b/Maccy/PopupLocation.swift
@@ -30,11 +30,30 @@ enum PopupLocation {
     case .inMenuBar:
       return nil
     case let .atMouseCursor(location):
+      if let frame = NSScreen.forPopup?.visibleFrame {
+        return clamp(location, size, to: frame)
+      }
       return location
     case let .centeredInWindow(frame):
       return NSRect.centered(ofSize: size, in: frame).origin
     case let .centeredInScreen(frame):
       return NSRect.centered(ofSize: size, in: frame).origin
     }
+  }
+
+  func clamp(_ pos: NSPoint, _ size: NSSize, to screenRect: NSRect) -> NSPoint {
+    var result = pos
+    if result.y > screenRect.maxY {
+      result.y -= result.y - screenRect.maxY
+    }
+    let bottomY = result.y - size.height
+    if bottomY < screenRect.minY {
+      result.y += screenRect.minY - bottomY
+    }
+    let rightX = result.x + size.width
+    if rightX > screenRect.maxX {
+      result.x -= size.width
+    }
+    return result
   }
 }


### PR DESCRIPTION
Simulate adjustments made by the OS to ensure the popup window is fully contained on the current screen.

Fixes #707