### PR TITLE
Revert "Remove header underline in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,5 +159,3 @@ Also, I wanted to learn Swift and get acquainted with macOS application developm
 ## License
 
 [MIT](./LICENSE)
-
-<style>h1 { border-bottom: 0; } </style>


### PR DESCRIPTION
Reverts p0deje/Maccy#755

style attribute does not work well on the GitHub README