### PR TITLE
Optimize ignore apps list view

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0ABDD5102BB472120054963B /* Bundle+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD50F2BB472120054963B /* Bundle+ApplicationName.swift */; };
 		2F3205B92AE3EDCA002EA545 /* MenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3205B82AE3EDCA002EA545 /* MenuController.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
@@ -131,6 +132,7 @@
 		088F4DA328BECBC40003AD19 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/PinsSettingsViewController.strings; sourceTree = "<group>"; };
 		088F4DA428BECBC40003AD19 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/IgnoreSettingsViewController.strings; sourceTree = "<group>"; };
 		088F4DA628BECBC40003AD19 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0ABDD50F2BB472120054963B /* Bundle+ApplicationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+ApplicationName.swift"; sourceTree = "<group>"; };
 		1180C7312826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AdvancedSettingsViewController.strings; sourceTree = "<group>"; };
 		1180C7322826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AppearanceSettingsViewController.strings; sourceTree = "<group>"; };
 		1180C7332826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/GeneralSettingsViewController.strings; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 			isa = PBXGroup;
 			children = (
 				DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */,
+				0ABDD50F2BB472120054963B /* Bundle+ApplicationName.swift */,
 				DA3EAE0B2AE30F7500F39108 /* NSApplication+Windows.swift */,
 				DA7A753D26A52F0F00DC16EF /* NSImage+Names.swift */,
 				DAC929D6297A0E8B00814F19 /* NSPasteboard.PasteboardType+Types.swift */,
@@ -898,6 +901,7 @@
 				DA81D674252A056B009977BC /* Throttler.swift in Sources */,
 				DA20FA722B082DD600056DD5 /* Notifier.swift in Sources */,
 				DA196A9328AB0D4500ADD8A2 /* MenuHeaderView.swift in Sources */,
+				0ABDD5102BB472120054963B /* Bundle+ApplicationName.swift in Sources */,
 				DA573EAD1EDD410F00561FB2 /* HistoryMenuItem.swift in Sources */,
 				DA1B0FD6289DFEA200E641BE /* PinComboBoxCell.swift in Sources */,
 				DA1DF95227AF8BBA006839E0 /* StorageSettingsViewController.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0ABDD5102BB472120054963B /* Bundle+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD50F2BB472120054963B /* Bundle+ApplicationName.swift */; };
+		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
 		2F3205B92AE3EDCA002EA545 /* MenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3205B82AE3EDCA002EA545 /* MenuController.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
@@ -133,6 +134,7 @@
 		088F4DA428BECBC40003AD19 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/IgnoreSettingsViewController.strings; sourceTree = "<group>"; };
 		088F4DA628BECBC40003AD19 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0ABDD50F2BB472120054963B /* Bundle+ApplicationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+ApplicationName.swift"; sourceTree = "<group>"; };
+		0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWorkspace+ApplicationName.swift"; sourceTree = "<group>"; };
 		1180C7312826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AdvancedSettingsViewController.strings; sourceTree = "<group>"; };
 		1180C7322826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/AppearanceSettingsViewController.strings; sourceTree = "<group>"; };
 		1180C7332826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/GeneralSettingsViewController.strings; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 				DA20FA772B082E1A00056DD5 /* NSSound+Named.swift */,
 				DAFE2DD9268A521A00990986 /* String+Shortened.swift */,
 				DA2B0AF1234201E500EFAD72 /* UserDefaults+Configuration.swift */,
+				0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -891,6 +894,7 @@
 				DAAEB196219694AE00A7883C /* About.swift in Sources */,
 				DA6D98E22AEABE03008A77CE /* Accessibility.swift in Sources */,
 				DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */,
+				0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */,
 				DAB65E0D2440B0D4000AECA8 /* HistoryItemContent.swift in Sources */,
 				DA696BCE240177E800DE80CF /* Sorter.swift in Sources */,
 				DABDE97F2974706C005B32E9 /* KeyboardLayout.swift in Sources */,

--- a/Maccy/Extensions/Bundle+ApplicationName.swift
+++ b/Maccy/Extensions/Bundle+ApplicationName.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Bundle {
+  var applicationName: String {
+    if let displayName: String = object(forInfoDictionaryKey: "CFBundleDisplayName") as? String {
+      return displayName
+    } else if let name: String = object(forInfoDictionaryKey: "CFBundleName") as? String {
+      return name
+    }
+    if let executableURL {
+      return executableURL.deletingLastPathComponent().lastPathComponent
+    }
+    return ""
+  }
+}
+

--- a/Maccy/Extensions/Bundle+ApplicationName.swift
+++ b/Maccy/Extensions/Bundle+ApplicationName.swift
@@ -13,4 +13,3 @@ extension Bundle {
     return ""
   }
 }
-

--- a/Maccy/Extensions/NSWorkspace+ApplicationName.swift
+++ b/Maccy/Extensions/NSWorkspace+ApplicationName.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+extension NSWorkspace {
+  func applicationName(url: URL) -> String {
+    if let bundle = Bundle(url: url) {
+      return bundle.applicationName
+    }
+    return url.deletingLastPathComponent().lastPathComponent
+  }
+}

--- a/Maccy/Settings/IgnoreSettingsViewController/IgnoreApplicationsViewController.swift
+++ b/Maccy/Settings/IgnoreSettingsViewController/IgnoreApplicationsViewController.swift
@@ -34,8 +34,7 @@ class IgnoreApplicationsViewController: NSViewController, NSTableViewDataSource,
     let appIdentifier = ignoredApps[row]
     if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appIdentifier) {
       appCell.imageView?.image = NSWorkspace.shared.icon(forFile: url.path)
-      appCell.textField?.stringValue = Bundle(url: url)?.applicationName
-        ?? url.deletingLastPathComponent().lastPathComponent
+      appCell.textField?.stringValue = NSWorkspace.shared.applicationName(url: url)
     } else {
       appCell.imageView?.image = nil
       appCell.textField?.stringValue = appIdentifier

--- a/Maccy/Settings/IgnoreSettingsViewController/IgnoreApplicationsViewController.swift
+++ b/Maccy/Settings/IgnoreSettingsViewController/IgnoreApplicationsViewController.swift
@@ -34,8 +34,10 @@ class IgnoreApplicationsViewController: NSViewController, NSTableViewDataSource,
     let appIdentifier = ignoredApps[row]
     if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appIdentifier) {
       appCell.imageView?.image = NSWorkspace.shared.icon(forFile: url.path)
-      appCell.textField?.stringValue = url.deletingPathExtension().lastPathComponent
+      appCell.textField?.stringValue = Bundle(url: url)?.applicationName
+        ?? url.deletingLastPathComponent().lastPathComponent
     } else {
+      appCell.imageView?.image = nil
       appCell.textField?.stringValue = appIdentifier
     }
 
@@ -66,7 +68,8 @@ class IgnoreApplicationsViewController: NSViewController, NSTableViewDataSource,
     if dialog.runModal() == .OK {
       if let appUrl = dialog.url,
          let bundle = Bundle(path: appUrl.path),
-         let bundleIdentifier = bundle.bundleIdentifier {
+         let bundleIdentifier = bundle.bundleIdentifier,
+         !ignoredApps.contains(bundleIdentifier) {
         ignoredApps.append(bundleIdentifier)
         ignoredItemsTable.reloadData()
       }


### PR DESCRIPTION
1. Some app's name is different in Applications with Ignore app list(`VidHub` named `MediaCenter` in ignore app)
2. Chose the same app multiple times will have duplicate items
3. Icon view may shown cached image if the app is removed(last item in below screenshot)


![SCR-20240327-ujze](https://github.com/p0deje/Maccy/assets/103433299/1e24ea0b-0824-4bc6-b445-ed66ce5b4043)

<img width="195" alt="2024-03-27 23 42 35" src="https://github.com/p0deje/Maccy/assets/103433299/a91f5b21-df54-4330-88f1-0d46dbacbfa8">
