### PR TITLE
Add option to remember the last window position

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
+		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
@@ -146,6 +147,7 @@
 		0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWorkspace+ApplicationName.swift"; sourceTree = "<group>"; };
 		1180C7372826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -469,6 +471,7 @@
 				DA49EE7828B594DC002752E0 /* NSRunningApplication+WindowFrame.swift */,
 				DA6491AF29ABCF2400837D93 /* NSScreen+ForPopup.swift */,
 				DAA072E62C423617006DDFD2 /* NSSize+DefaultsSerializable.swift */,
+				2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */,
 				DA20FA772B082E1A00056DD5 /* NSSound+Named.swift */,
 				0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */,
 				DA181176247D14DA00066D55 /* Settings.PaneIdentifier+Panes.swift */,
@@ -955,6 +958,7 @@
 				DA81D674252A056B009977BC /* Throttler.swift in Sources */,
 				DA05B5112C234CB2006980FE /* MaccyApp.swift in Sources */,
 				DA13D7DE2C1A436E00FA9E23 /* AppIntentError.swift in Sources */,
+				2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */,
 				DAA072D72C41C574006DDFD2 /* AppState.swift in Sources */,
 				DA9C3C5E2C20E1190056795D /* IgnoreApplicationsSettingsView.swift in Sources */,
 				DA20FA722B082DD600056DD5 /* Notifier.swift in Sources */,

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -48,4 +48,5 @@ extension Defaults.Keys {
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
+  static let windowPosition = Key<NSSize>("windowPosition", default: NSSize(width: 0.5, height: 0.8))
 }

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -48,5 +48,5 @@ extension Defaults.Keys {
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
-  static let windowPosition = Key<NSSize>("windowPosition", default: NSSize(width: 0.5, height: 0.8))
+  static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
 }

--- a/Maccy/Extensions/NSPoint+DefaultsSerializable.swift
+++ b/Maccy/Extensions/NSPoint+DefaultsSerializable.swift
@@ -1,0 +1,6 @@
+import CoreGraphics
+import Defaults
+import Foundation
+
+extension NSPoint: Defaults.Serializable {
+}

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -99,7 +99,9 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
   }
 
   func windowDidMove(_ notification: Notification) {
+    // Only update position if the window is visible to avoid accumulating floating point errors.
     guard isVisible else { return }
+
     if let screenFrame = screen?.visibleFrame {
       let anchorX = frame.minX + frame.width / 2 - screenFrame.minX
       let anchorY = frame.maxY - screenFrame.minY

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -55,7 +55,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
       rootView: view()
         .ignoresSafeArea()
         .gesture(DragGesture()
-          .onChanged { _ in
+          .onEnded { _ in
             if let screenFrame = self.screen?.visibleFrame {
               let anchorX = self.frame.minX + self.frame.width / 2 - screenFrame.minX
               let anchorY = self.frame.maxY - screenFrame.minY

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -91,6 +91,22 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     return frameSize
   }
 
+  override var isMovable: Bool {
+    get {
+      return Defaults[.popupPosition] == .lastPosition
+    }
+    set {}
+  }
+
+  func windowDidMove(_ notification: Notification) {
+    guard isVisible else { return }
+    if let screenFrame = screen?.visibleFrame {
+      let anchorX = frame.minX + frame.width / 2 - screenFrame.minX
+      let anchorY = frame.maxY - screenFrame.minY
+      Defaults[.windowPosition] = NSSize(width: anchorX / screenFrame.width, height: anchorY / screenFrame.height)
+    }
+  }
+
   /// Close automatically when out of focus, e.g. outside click
   override func resignKey() {
     super.resignKey()

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -93,7 +93,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
   override var isMovable: Bool {
     get {
-      return Defaults[.popupPosition] == .lastPosition
+      return Defaults[.popupPosition] != .statusItem
     }
     set {}
   }
@@ -103,7 +103,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     if let screenFrame = screen?.visibleFrame {
       let anchorX = frame.minX + frame.width / 2 - screenFrame.minX
       let anchorY = frame.maxY - screenFrame.minY
-      Defaults[.windowPosition] = NSSize(width: anchorX / screenFrame.width, height: anchorY / screenFrame.height)
+      Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
     }
   }
 

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -52,7 +52,16 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     /// Set the content view.
     /// The safe area is ignored because the title bar still interferes with the geometry
     contentView = NSHostingView(
-      rootView: view().ignoresSafeArea()
+      rootView: view()
+        .ignoresSafeArea()
+        .gesture(DragGesture()
+          .onChanged { _ in
+            if let screenFrame = self.screen?.visibleFrame {
+              let anchorX = self.frame.minX + self.frame.width / 2 - screenFrame.minX
+              let anchorY = self.frame.maxY - screenFrame.minY
+              Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
+            }
+        })
     )
   }
 
@@ -96,17 +105,6 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
       return Defaults[.popupPosition] != .statusItem
     }
     set {}
-  }
-
-  func windowDidMove(_ notification: Notification) {
-    // Only update position if the window is visible to avoid accumulating floating point errors.
-    guard isVisible else { return }
-
-    if let screenFrame = screen?.visibleFrame {
-      let anchorX = frame.minX + frame.width / 2 - screenFrame.minX
-      let anchorY = frame.maxY - screenFrame.minY
-      Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
-    }
   }
 
   /// Close automatically when out of focus, e.g. outside click

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -56,11 +56,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
         .ignoresSafeArea()
         .gesture(DragGesture()
           .onEnded { _ in
-            if let screenFrame = self.screen?.visibleFrame {
-              let anchorX = self.frame.minX + self.frame.width / 2 - screenFrame.minX
-              let anchorY = self.frame.maxY - screenFrame.minY
-              Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
-            }
+            self.saveWindowFrame(frame: self.frame)
         })
     )
   }
@@ -94,8 +90,18 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     }
   }
 
+  func saveWindowFrame(frame: NSRect) {
+    Defaults[.windowSize] = frame.size
+
+    if let screenFrame = screen?.visibleFrame {
+      let anchorX = frame.minX + frame.width / 2 - screenFrame.minX
+      let anchorY = frame.maxY - screenFrame.minY
+      Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
+    }
+  }
+
   func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
-    Defaults[.windowSize] = frameSize
+    saveWindowFrame(frame: NSRect(origin: frame.origin, size: frameSize))
 
     return frameSize
   }

--- a/Maccy/PopupPosition.swift
+++ b/Maccy/PopupPosition.swift
@@ -7,6 +7,7 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
   case statusItem
   case window
   case center
+  case lastPosition
 
   var id: Self { self }
 
@@ -20,6 +21,8 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
       return NSLocalizedString("PopupAtWindowCenter", tableName: "AppearanceSettings", comment: "")
     case .center:
       return NSLocalizedString("PopupAtScreenCenter", tableName: "AppearanceSettings", comment: "")
+    case .lastPosition:
+      return NSLocalizedString("PopupAtLastPosition", tableName: "AppearanceSettings", comment: "")
     }
   }
 
@@ -39,6 +42,14 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
         if let screenRect = menuBarButton.window?.convertToScreen(rectInWindow) {
           return screenRect.origin
         }
+      }
+    case .lastPosition:
+      if let frame = NSScreen.forPopup?.visibleFrame {
+        let relativePos = Defaults[.windowPosition]
+        let anchorX = frame.minX + frame.width * relativePos.width
+        let anchorY = frame.minY + frame.height * relativePos.height
+        // Anchor is top middle of frame
+        return NSPoint(x: anchorX - size.width / 2, y: anchorY - size.height)
       }
     default:
       break

--- a/Maccy/PopupPosition.swift
+++ b/Maccy/PopupPosition.swift
@@ -46,8 +46,8 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
     case .lastPosition:
       if let frame = NSScreen.forPopup?.visibleFrame {
         let relativePos = Defaults[.windowPosition]
-        let anchorX = frame.minX + frame.width * relativePos.width
-        let anchorY = frame.minY + frame.height * relativePos.height
+        let anchorX = frame.minX + frame.width * relativePos.x
+        let anchorY = frame.minY + frame.height * relativePos.y
         // Anchor is top middle of frame
         return NSPoint(x: anchorX - size.width / 2, y: anchorY - size.height)
       }

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -80,11 +80,13 @@ struct AppearanceSettingsPane: View {
           .help(Text("PopupAtTooltip", tableName: "AppearanceSettings"))
 
           if popupAt == .lastPosition {
-            Button(action: {
+            Button {
               _windowPosition.reset()
-            }) {
-              Text("PopupAtLastLocationReset", tableName: "AppearanceSettings")
+            } label: {
+              Image(systemName: "arrow.uturn.backward")
             }
+            .buttonStyle(.borderless)
+            .help(Text("PopupAtLastLocationReset", tableName: "AppearanceSettings"))
             .disabled(windowPosition == _windowPosition.defaultValue)
           }
         }

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -83,7 +83,8 @@ struct AppearanceSettingsPane: View {
             Button {
               _windowPosition.reset()
             } label: {
-              Image(systemName: "arrow.uturn.backward")
+              Image(systemName: "arrow.uturn.backward.circle.fill")
+                .imageScale(.large)
             }
             .buttonStyle(.borderless)
             .help(Text("PopupAtLastLocationReset", tableName: "AppearanceSettings"))

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -15,6 +15,7 @@ struct AppearanceSettingsPane: View {
   @Default(.menuIcon) private var menuIcon
   @Default(.showInStatusBar) private var showInStatusBar
   @Default(.showFooter) private var showFooter
+  @Default(.windowPosition) private var windowPosition
 
   @State private var screens = NSScreen.screens
 
@@ -49,33 +50,44 @@ struct AppearanceSettingsPane: View {
   var body: some View {
     Settings.Container(contentWidth: 650) {
       Settings.Section(label: { Text("PopupAt", tableName: "AppearanceSettings") }) {
-        Picker("", selection: $popupAt) {
-          ForEach(PopupPosition.allCases) { position in
-            if position == .center {
-              if screens.count > 1 {
-                Picker(position.description, selection: $popupScreen) {
-                  Text("ActiveScreen", tableName: "AppearanceSettings")
-                    .tag(0)
+        HStack {
+          Picker("", selection: $popupAt) {
+            ForEach(PopupPosition.allCases) { position in
+              if position == .center || position == .lastPosition {
+                if screens.count > 1 {
+                  Picker(position.description, selection: $popupScreen) {
+                    Text("ActiveScreen", tableName: "AppearanceSettings")
+                      .tag(0)
 
-                  ForEach(Array(screens.enumerated()), id: \.element) { index, screen in
-                    Text(screen.localizedName)
-                      .tag(index + 1)
+                    ForEach(Array(screens.enumerated()), id: \.element) { index, screen in
+                      Text(screen.localizedName)
+                        .tag(index + 1)
+                    }
                   }
-                }
-                .onChange(of: popupScreen) {
-                  popupAt = .center
+                  .onChange(of: popupScreen) {
+                    popupAt = position
+                  }
+                } else {
+                  Text(position.description)
                 }
               } else {
                 Text(position.description)
               }
-            } else {
-              Text(position.description)
             }
           }
+          .labelsHidden()
+          .frame(width: 141)
+          .help(Text("PopupAtTooltip", tableName: "AppearanceSettings"))
+
+          if popupAt == .lastPosition {
+            Button(action: {
+              _windowPosition.reset()
+            }) {
+              Text("PopupAtLastLocationReset", tableName: "AppearanceSettings")
+            }
+            .disabled(windowPosition == _windowPosition.defaultValue)
+          }
         }
-        .labelsHidden()
-        .frame(width: 141)
-        .help(Text("PopupAtTooltip", tableName: "AppearanceSettings"))
       }
 
       Settings.Section(label: { Text("PinTo", tableName: "AppearanceSettings") }) {

--- a/Maccy/Settings/ar.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ar.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "أيقونة القائمة";
 "PopupAtWindowCenter" = "مركز النافذة";
 "PopupAtScreenCenter" = "مركز الشاشة";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "تغيير موقع ظهور الإنبثاق.\nالافتراضي: المؤشر.";
 "ActiveScreen" = "شاشة نشطة";
 "PinTo" = "تثبيت إلى:";

--- a/Maccy/Settings/ar.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ar.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "أيقونة القائمة";
 "PopupAtWindowCenter" = "مركز النافذة";
 "PopupAtScreenCenter" = "مركز الشاشة";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "الموضع الأخير";
+"PopupAtLastLocationReset" = "إعادة تعيين الموضع";
 "PopupAtTooltip" = "تغيير موقع ظهور الإنبثاق.\nالافتراضي: المؤشر.";
 "ActiveScreen" = "شاشة نشطة";
 "PinTo" = "تثبيت إلى:";

--- a/Maccy/Settings/bs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/bs.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Meni ikona";
 "PopupAtWindowCenter" = "Centar prozora";
 "PopupAtScreenCenter" = "Centar zaslona";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Promijeni lokaciju na kojoj se pojavljuje priručni prozor.\nZadano: Kursor.";
 "ActiveScreen" = "Aktivni zaslon";
 "PinTo" = "Zakači na:";

--- a/Maccy/Settings/bs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/bs.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Meni ikona";
 "PopupAtWindowCenter" = "Centar prozora";
 "PopupAtScreenCenter" = "Centar zaslona";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Poslednja pozicija";
+"PopupAtLastLocationReset" = "Resetuj poziciju";
 "PopupAtTooltip" = "Promijeni lokaciju na kojoj se pojavljuje priručni prozor.\nZadano: Kursor.";
 "ActiveScreen" = "Aktivni zaslon";
 "PinTo" = "Zakači na:";

--- a/Maccy/Settings/cs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/cs.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Menu ikony";
 "PopupAtWindowCenter" = "Středu okna";
 "PopupAtScreenCenter" = "Středu obrazovky";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Dolů";
 "ActiveScreen" = "Aktivní obrazovka";
 "PinTo" = "Připnout:";

--- a/Maccy/Settings/cs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/cs.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Menu ikony";
 "PopupAtWindowCenter" = "Středu okna";
 "PopupAtScreenCenter" = "Středu obrazovky";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Poslední pozice";
+"PopupAtLastLocationReset" = "Vynulování polohy";
 "PopupAtTooltip" = "Dolů";
 "ActiveScreen" = "Aktivní obrazovka";
 "PinTo" = "Připnout:";

--- a/Maccy/Settings/de.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/de.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Menüleistensymbol";
 "PopupAtWindowCenter" = "Fenstermitte";
 "PopupAtScreenCenter" = "Bildschirmmitte";
+"PopupAtLastPosition" = "Letzte Position";
+"PopupAtLastLocationReset" = "Position zurücksetzen";
 "PopupAtTooltip" = "Ändere die Position des Popup-Fensters.\nStandard: Mauszeiger.";
 "ActiveScreen" = "Aktiver Bildschirm";
 "PinTo" = "Angeheftete Einträge:";

--- a/Maccy/Settings/en.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/en.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Menu icon";
 "PopupAtWindowCenter" = "Window center";
 "PopupAtScreenCenter" = "Screen center";
+"PopupAtLastPosition" = "Last position";
+"PopupAtLastLocationReset" = "Reset position";
 "PopupAtTooltip" = "Change the location where popup appears.\nDefault: Cursor.";
 "ActiveScreen" = "Active screen";
 "PinTo" = "Pin to:";

--- a/Maccy/Settings/es.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/es.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Icono del menú";
 "PopupAtWindowCenter" = "Centro de la ventana";
 "PopupAtScreenCenter" = "Centro de la pantalla";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Cambia la ubicación donde aparce la aplicación\nPor defecto: Cursor.";
 "ActiveScreen" = "Pantalla activa";
 "PinTo" = "Anclar a:";

--- a/Maccy/Settings/es.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/es.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Icono del menú";
 "PopupAtWindowCenter" = "Centro de la ventana";
 "PopupAtScreenCenter" = "Centro de la pantalla";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Última posición";
+"PopupAtLastLocationReset" = "Restablecer posición";
 "PopupAtTooltip" = "Cambia la ubicación donde aparce la aplicación\nPor defecto: Cursor.";
 "ActiveScreen" = "Pantalla activa";
 "PinTo" = "Anclar a:";

--- a/Maccy/Settings/fr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/fr.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Icône du menu";
 "PopupAtWindowCenter" = "Centre de la fenêtre";
 "PopupAtScreenCenter" = "Centre de l'écran";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Dernière position";
+"PopupAtLastLocationReset" = "Réinitialiser la position";
 "PopupAtTooltip" = "Changer la localisation de l'apparition du popup.\nPar défaut : Curseur.";
 "ActiveScreen" = "Écran actif";
 "PinTo" = "Epingler à :";

--- a/Maccy/Settings/fr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/fr.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Icône du menu";
 "PopupAtWindowCenter" = "Centre de la fenêtre";
 "PopupAtScreenCenter" = "Centre de l'écran";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Changer la localisation de l'apparition du popup.\nPar défaut : Curseur.";
 "ActiveScreen" = "Écran actif";
 "PinTo" = "Epingler à :";

--- a/Maccy/Settings/he.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/he.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "סמל תפריט";
 "PopupAtWindowCenter" = "מרכז החלון";
 "PopupAtScreenCenter" = "מרכז המסך";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "החלפת מקום הופעת החלונית הצצה.\nברירת מחדל: סמן.";
 "ActiveScreen" = "מסך פעיל";
 "PinTo" = "הצמדה אל:";

--- a/Maccy/Settings/he.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/he.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "סמל תפריט";
 "PopupAtWindowCenter" = "מרכז החלון";
 "PopupAtScreenCenter" = "מרכז המסך";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "תפקיד אחרון";
+"PopupAtLastLocationReset" = "אפס את המיקום";
 "PopupAtTooltip" = "החלפת מקום הופעת החלונית הצצה.\nברירת מחדל: סמן.";
 "ActiveScreen" = "מסך פעיל";
 "PinTo" = "הצמדה אל:";

--- a/Maccy/Settings/hr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hr.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Ikona u izborniku";
 "PopupAtWindowCenter" = "Središte prozora";
 "PopupAtScreenCenter" = "Sredina ekrana";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Promijeni mjesto gdje će se skočni prozor pojaviti.\nStandardno: Kursor.";
 "ActiveScreen" = "Aktivni ekran";
 "PinTo" = "Prikvači:";

--- a/Maccy/Settings/hr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hr.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Ikona u izborniku";
 "PopupAtWindowCenter" = "Središte prozora";
 "PopupAtScreenCenter" = "Sredina ekrana";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Zadnja pozicija";
+"PopupAtLastLocationReset" = "Resetiraj položaj";
 "PopupAtTooltip" = "Promijeni mjesto gdje će se skočni prozor pojaviti.\nStandardno: Kursor.";
 "ActiveScreen" = "Aktivni ekran";
 "PinTo" = "Prikvači:";

--- a/Maccy/Settings/it.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/it.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Icona del menù";
 "PopupAtWindowCenter" = "Centro della finestra";
 "PopupAtScreenCenter" = "Centro dello schermo";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Cambia la posizione in cui appare il popup.\nDefault: Cursore.";
 "ActiveScreen" = "Schermo attivo";
 "PinTo" = "Blocca su:";

--- a/Maccy/Settings/it.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/it.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Icona del menù";
 "PopupAtWindowCenter" = "Centro della finestra";
 "PopupAtScreenCenter" = "Centro dello schermo";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Ultima posizione";
+"PopupAtLastLocationReset" = "Azzeramento della posizione";
 "PopupAtTooltip" = "Cambia la posizione in cui appare il popup.\nDefault: Cursore.";
 "ActiveScreen" = "Schermo attivo";
 "PinTo" = "Blocca su:";

--- a/Maccy/Settings/ja.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ja.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "メニューアイコン";
 "PopupAtWindowCenter" = "窓の中央";
 "PopupAtScreenCenter" = "画面の中央";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "ポップアップが表れる場所を変更します。\nデフォルト：カーソル。";
 "ActiveScreen" = "アクティブスクリーン";
 "PinTo" = "ピン留め場所:";

--- a/Maccy/Settings/ja.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ja.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "メニューアイコン";
 "PopupAtWindowCenter" = "窓の中央";
 "PopupAtScreenCenter" = "画面の中央";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "最終位置";
+"PopupAtLastLocationReset" = "リセット位置";
 "PopupAtTooltip" = "ポップアップが表れる場所を変更します。\nデフォルト：カーソル。";
 "ActiveScreen" = "アクティブスクリーン";
 "PinTo" = "ピン留め場所:";

--- a/Maccy/Settings/ko.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ko.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "메뉴 아이콘";
 "PopupAtWindowCenter" = "창의 중앙";
 "PopupAtScreenCenter" = "화면 중앙";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "마지막 위치";
+"PopupAtLastLocationReset" = "위치 재설정";
 "PopupAtTooltip" = "팝업이 나타나는 위치를 변경합니다.\n기본값: 커서.";
 "ActiveScreen" = "활성 화면";
 "PinTo" = "고정 위치:";

--- a/Maccy/Settings/ko.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ko.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "메뉴 아이콘";
 "PopupAtWindowCenter" = "창의 중앙";
 "PopupAtScreenCenter" = "화면 중앙";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "팝업이 나타나는 위치를 변경합니다.\n기본값: 커서.";
 "ActiveScreen" = "활성 화면";
 "PinTo" = "고정 위치:";

--- a/Maccy/Settings/nb.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nb.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Meny ikon";
 "PopupAtWindowCenter" = "Vindussenter";
 "PopupAtScreenCenter" = "Skjermsenter";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Forandre plassering av hvor popup vises.\nStandard: Musepeker.";
 "ActiveScreen" = "Aktiv skjerm";
 "PinTo" = "Fest til:";

--- a/Maccy/Settings/nb.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nb.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Meny ikon";
 "PopupAtWindowCenter" = "Vindussenter";
 "PopupAtScreenCenter" = "Skjermsenter";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Siste posisjon";
+"PopupAtLastLocationReset" = "Tilbakestill posisjon";
 "PopupAtTooltip" = "Forandre plassering av hvor popup vises.\nStandard: Musepeker.";
 "ActiveScreen" = "Aktiv skjerm";
 "PinTo" = "Fest til:";

--- a/Maccy/Settings/nl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nl.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Menu-icoon";
 "PopupAtWindowCenter" = "Venstercentrum";
 "PopupAtScreenCenter" = "Schermcentrum";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Laatste positie";
+"PopupAtLastLocationReset" = "Positie terugzetten";
 "PopupAtTooltip" = "Wijzig de locatie waar de pop-up verschijnt.\nStandaard: Cursor.";
 "ActiveScreen" = "Actief scherm";
 "PinTo" = "Maak vast:";

--- a/Maccy/Settings/nl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nl.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Menu-icoon";
 "PopupAtWindowCenter" = "Venstercentrum";
 "PopupAtScreenCenter" = "Schermcentrum";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Wijzig de locatie waar de pop-up verschijnt.\nStandaard: Cursor.";
 "ActiveScreen" = "Actief scherm";
 "PinTo" = "Maak vast:";

--- a/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Ícone do menu";
 "PopupAtWindowCenter" = "Centro da janela";
 "PopupAtScreenCenter" = "Centro da tela";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Altere o local onde o pop-up aparece.\nPadrão: Cursor.";
 "ActiveScreen" = "Tela ativa";
 "PinTo" = "Fixar em:";

--- a/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Ícone do menu";
 "PopupAtWindowCenter" = "Centro da janela";
 "PopupAtScreenCenter" = "Centro da tela";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Última posição";
+"PopupAtLastLocationReset" = "Redefinir posição";
 "PopupAtTooltip" = "Altere o local onde o pop-up aparece.\nPadrão: Cursor.";
 "ActiveScreen" = "Tela ativa";
 "PinTo" = "Fixar em:";

--- a/Maccy/Settings/ru.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ru.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Иконки в меню";
 "PopupAtWindowCenter" = "Центра окна";
 "PopupAtScreenCenter" = "Центра экрана";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Изменить место для появления всплывающего окна.\nПо умолчанию: Курсор.";
 "ActiveScreen" = "Активный экран";
 "PinTo" = "Прикреплять к:";

--- a/Maccy/Settings/ru.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ru.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Иконки в меню";
 "PopupAtWindowCenter" = "Центра окна";
 "PopupAtScreenCenter" = "Центра экрана";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Последнее положение";
+"PopupAtLastLocationReset" = "Сбросить позицию";
 "PopupAtTooltip" = "Изменить место для появления всплывающего окна.\nПо умолчанию: Курсор.";
 "ActiveScreen" = "Активный экран";
 "PinTo" = "Прикреплять к:";

--- a/Maccy/Settings/th.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/th.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "เมนูไอคอน";
 "PopupAtWindowCenter" = "ตรงกลางหน้าต่าง";
 "PopupAtScreenCenter" = "ตรงกลางจอภาพ";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "เปลี่ยนตำแหน่งที่ popup แสดง.\nค่าเริ่มต้น: Cursor";
 "ActiveScreen" = "หน้าจอที่ใช้งานอยู่";
 "PinTo" = "ปักหมุดไปยัง:";

--- a/Maccy/Settings/th.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/th.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "เมนูไอคอน";
 "PopupAtWindowCenter" = "ตรงกลางหน้าต่าง";
 "PopupAtScreenCenter" = "ตรงกลางจอภาพ";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "ตำแหน่งสุดท้าย";
+"PopupAtLastLocationReset" = "รีเซ็ตตำแหน่ง";
 "PopupAtTooltip" = "เปลี่ยนตำแหน่งที่ popup แสดง.\nค่าเริ่มต้น: Cursor";
 "ActiveScreen" = "หน้าจอที่ใช้งานอยู่";
 "PinTo" = "ปักหมุดไปยัง:";

--- a/Maccy/Settings/tr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/tr.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Menü simgesi";
 "PopupAtWindowCenter" = "Pencere merkezi";
 "PopupAtScreenCenter" = "Ekran merkezi";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Son pozisyon";
+"PopupAtLastLocationReset" = "Pozisyonu sıfırla";
 "PopupAtTooltip" = "Açılır pencerenin göründüğü konumu değiştirin.\nSaptanmış: İmleç.";
 "ActiveScreen" = "Aktif ekran";
 "PinTo" = "Şuraya iğnele:";

--- a/Maccy/Settings/tr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/tr.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Menü simgesi";
 "PopupAtWindowCenter" = "Pencere merkezi";
 "PopupAtScreenCenter" = "Ekran merkezi";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Açılır pencerenin göründüğü konumu değiştirin.\nSaptanmış: İmleç.";
 "ActiveScreen" = "Aktif ekran";
 "PinTo" = "Şuraya iğnele:";

--- a/Maccy/Settings/uk.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/uk.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "Значок меню";
 "PopupAtWindowCenter" = "Центр вікна";
 "PopupAtScreenCenter" = "Центр екрану";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "Змініть розташування спливаючого вікна.\nЗа замовчуванням: Курсор.";
 "ActiveScreen" = "Активний екран";
 "PinTo" = "Закріпити:";

--- a/Maccy/Settings/uk.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/uk.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "Значок меню";
 "PopupAtWindowCenter" = "Центр вікна";
 "PopupAtScreenCenter" = "Центр екрану";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "Остання позиція";
+"PopupAtLastLocationReset" = "Скинути позицію";
 "PopupAtTooltip" = "Змініть розташування спливаючого вікна.\nЗа замовчуванням: Курсор.";
 "ActiveScreen" = "Активний екран";
 "PinTo" = "Закріпити:";

--- a/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "菜单栏图标";
 "PopupAtWindowCenter" = "窗口中心";
 "PopupAtScreenCenter" = "屏幕中央";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "更改弹窗显示的位置。\n默认：光标。";
 "ActiveScreen" = "活动屏幕";
 "PinTo" = "固定项目位置：";

--- a/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "菜单栏图标";
 "PopupAtWindowCenter" = "窗口中心";
 "PopupAtScreenCenter" = "屏幕中央";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "最后位置";
+"PopupAtLastLocationReset" = "重置位置";
 "PopupAtTooltip" = "更改弹窗显示的位置。\n默认：光标。";
 "ActiveScreen" = "活动屏幕";
 "PinTo" = "固定项目位置：";

--- a/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
@@ -4,8 +4,8 @@
 "PopupAtMenuBarIcon" = "選單列圖示";
 "PopupAtWindowCenter" = "窗口中心";
 "PopupAtScreenCenter" = "螢幕中央";
-"PopupAtLastPosition" = "TODO";
-"PopupAtLastLocationReset" = "TODO";
+"PopupAtLastPosition" = "最後位置";
+"PopupAtLastLocationReset" = "重設位置";
 "PopupAtTooltip" = "更改彈窗顯示位置。\n預設：指標。";
 "ActiveScreen" = "使用中的螢幕";
 "PinTo" = "固定項目位置：";

--- a/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
@@ -4,6 +4,8 @@
 "PopupAtMenuBarIcon" = "選單列圖示";
 "PopupAtWindowCenter" = "窗口中心";
 "PopupAtScreenCenter" = "螢幕中央";
+"PopupAtLastPosition" = "TODO";
+"PopupAtLastLocationReset" = "TODO";
 "PopupAtTooltip" = "更改彈窗顯示位置。\n預設：指標。";
 "ActiveScreen" = "使用中的螢幕";
 "PinTo" = "固定項目位置：";


### PR DESCRIPTION
Haven't yet updated all the translations. 

Also made it such that the window is no longer movable when "Last position" isn't selected as it may be confusing if moving the window has no effect (this may not be desirable, if so it can be reverted).

Some additional thought:

The window center method could be converted to "Presets" for `.lastPosition` together with the current default position of `.lastPosition`. I imagine this being an additional dropdown with Options `["Default", "Center", "Custom"]`, where `Custom` is selected if the window is moved. This way the reset button could also be removed as resetting is a matter of changing it back to `Default`.

<img width="698" alt="image" src="https://github.com/user-attachments/assets/a7b00ebf-12fb-41ce-8c0b-fea634e07d12">
