### PR TITLE
Scroll to item after unpinning

### DIFF
--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -14,8 +14,12 @@ class AppState: Sendable {
   var height: CGFloat = 0
   var needsResize = false
 
+  var scrollTarget: UUID?
   var selection: UUID? = nil {
     didSet {
+      // Cancel scrolling
+      scrollTarget = nil
+
       history.selectedItem = nil
       footer.selectedItem = nil
 

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -258,7 +258,10 @@ class History {
     }
 
     updateUnpinnedShortcuts()
-    // TODO: Scroll to pinned item
+    AppState.shared.selection = item.id
+    if (item.isUnpinned) {
+      AppState.shared.scrollTarget = item.id
+    }
   }
 
   @MainActor

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -34,6 +34,7 @@ struct HistoryListView: View {
         LazyVStack(spacing: 0) {
           ForEach(appState.history.unpinnedItems) { item in
             HistoryItemView(item: item)
+              .id(item.item.id)
           }
         }
         .task(id: appState.selection) {
@@ -51,6 +52,13 @@ struct HistoryListView: View {
           } else {
             HistoryItemDecorator.previewThrottler.minimumDelay = Double(previewDelay) / 1000
             modifierFlags.flags = []
+          }
+        }
+        .onChange(of: appState.scrollTarget) { _, _ in
+          // Recheck if the target has been cleared in the meantime, due to navigation
+          if let targetId = appState.scrollTarget {
+            proxy.scrollTo(targetId, anchor: .bottom)
+            appState.scrollTarget = nil
           }
         }
         // Calculate the total height inside a scroll view.


### PR DESCRIPTION
This should fix the issue described in the discussion https://github.com/p0deje/Maccy/discussions/818#discussion-6970531

> (Un)pinning item doesn't immediately scroll to the item. It does not seem to be a big deal and is quite hard to fix, so likely it will not be fixed in the final release.

Let me know if I misunderstood the issue.