### PR TITLE
Fix text storage not being active by default 

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -1,12 +1,21 @@
 import AppKit
 import Defaults
 
+struct StorageType {
+  static let files = StorageType(types: [.fileURL])
+  static let images = StorageType(types: [.png, .tiff])
+  static let text = StorageType(types: [.html, .rtf, .string])
+  static let all = StorageType(types: files.types + images.types + text.types)
+
+  var types: [NSPasteboard.PasteboardType]
+}
+
 extension Defaults.Keys {
   static let clearOnQuit = Key<Bool>("clearOnQuit", default: false)
   static let clearSystemClipboard = Key<Bool>("clearSystemClipboard", default: false)
   static let clipboardCheckInterval = Key<Double>("clipboardCheckInterval", default: 0.5)
   static let enabledPasteboardTypes = Key<Set<NSPasteboard.PasteboardType>>(
-    "enabledPasteboardTypes", default: [.fileURL, .png, .string, .tiff]
+    "enabledPasteboardTypes", default: Set(StorageType.all.types)
   )
   static let highlightMatch = Key<HighlightMatch>("highlightMatch", default: .bold)
   static let ignoreAllAppsExceptListed = Key<Bool>("ignoreAllAppsExceptListed", default: false)

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -9,9 +9,9 @@ struct StorageSettingsPane: View {
       didSet {
         Defaults.withoutPropagation {
           if saveFiles {
-            Defaults[.enabledPasteboardTypes].insert(.fileURL)
+            Defaults[.enabledPasteboardTypes].formUnion(StorageType.files.types)
           } else {
-            Defaults[.enabledPasteboardTypes].remove(.fileURL)
+            Defaults[.enabledPasteboardTypes].subtract(StorageType.files.types)
           }
         }
       }
@@ -21,9 +21,9 @@ struct StorageSettingsPane: View {
       didSet {
         Defaults.withoutPropagation {
           if saveImages {
-            Defaults[.enabledPasteboardTypes].formUnion([.tiff, .png])
+            Defaults[.enabledPasteboardTypes].formUnion(StorageType.images.types)
           } else {
-            Defaults[.enabledPasteboardTypes].subtract([.tiff, .png])
+            Defaults[.enabledPasteboardTypes].subtract(StorageType.images.types)
           }
         }
       }
@@ -33,9 +33,9 @@ struct StorageSettingsPane: View {
       didSet {
         Defaults.withoutPropagation {
           if saveText {
-            Defaults[.enabledPasteboardTypes].formUnion([.html, .rtf, .string])
+            Defaults[.enabledPasteboardTypes].formUnion(StorageType.text.types)
           } else {
-            Defaults[.enabledPasteboardTypes].subtract([.html, .rtf, .string])
+            Defaults[.enabledPasteboardTypes].subtract(StorageType.text.types)
           }
         }
       }
@@ -45,9 +45,9 @@ struct StorageSettingsPane: View {
 
     init() {
       observer = Defaults.observe(.enabledPasteboardTypes) { change in
-        self.saveFiles = change.newValue.contains(.fileURL)
-        self.saveImages = change.newValue.isSuperset(of: [.tiff, .png])
-        self.saveText = change.newValue.isSuperset(of: [.html, .rtf, .string])
+        self.saveFiles = change.newValue.isSubset(of: StorageType.files.types)
+        self.saveImages = change.newValue.isSuperset(of: StorageType.images.types)
+        self.saveText = change.newValue.isSuperset(of: StorageType.text.types)
       }
     }
 


### PR DESCRIPTION
The default pasteboard types only contained `.string` but also checked for `.rtf` and `.html` when checking if text storage is enabled. I moved the association from storage type to pasteboard types into its own class which defines the single source of truth for the setting. This way further issues (e.g. if a new type for text is added) can be avoided.

Fixes #883 