### PR TITLE
Add option to show application icon

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
 		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
+		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
@@ -160,6 +161,7 @@
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
+		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 		DA19690C2C3EEF9300258481 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */,
 				DAA072DE2C41C63C006DDFD2 /* ConfirmationView.swift */,
 				DA243D112C2F64820012A27F /* ContentView.swift */,
 				DAA072DC2C41C61F006DDFD2 /* FooterItemView.swift */,
@@ -947,6 +950,7 @@
 				DA1969142C3F11D600258481 /* PreviewItemView.swift in Sources */,
 				DAA072D52C40AC52006DDFD2 /* HistoryListView.swift in Sources */,
 				DAB082962A2B7B850053E463 /* AppStoreReview.swift in Sources */,
+				2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */,
 				DA13D7D22C19F91B00FA9E23 /* Defaults.Keys+Names.swift in Sources */,
 				DA1969102C3F0AAC00258481 /* KeyShortcut.swift in Sources */,
 				DA9C3C622C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift in Sources */,

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -57,4 +57,5 @@ extension Defaults.Keys {
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
+  static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: false)
 }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -13,6 +13,7 @@ class HistoryItemDecorator: Identifiable, Hashable {
   static var previewThrottler = Throttler(minimumDelay: Double(Defaults[.previewDelay]) / 1000)
   static var previewImageSize: NSSize { NSScreen.forPopup?.visibleFrame.size ?? NSSize(width: 2048, height: 1536) }
   static var thumbnailImageSize: NSSize { NSSize(width: 340, height: Defaults[.imageMaxHeight]) }
+  static let applicationImageCache = ApplicationImageCache()
 
   let id = UUID()
 
@@ -52,6 +53,7 @@ class HistoryItemDecorator: Identifiable, Hashable {
 
   var previewImage: NSImage?
   var thumbnailImage: NSImage?
+  var applicationImage: ApplicationImage
 
   var text: String { item.previewableText }
 
@@ -70,6 +72,7 @@ class HistoryItemDecorator: Identifiable, Hashable {
     self.item = item
     self.shortcuts = shortcuts
     self.title = item.title
+    self.applicationImage = Self.applicationImageCache.getImage(item: item)
 
     synchronizeItemPin()
     synchronizeItemTitle()

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -16,6 +16,7 @@ struct AppearanceSettingsPane: View {
   @Default(.searchVisibility) private var searchVisibility
   @Default(.showFooter) private var showFooter
   @Default(.windowPosition) private var windowPosition
+  @Default(.showApplicationIcons) private var showApplicationIcons
 
   @State private var screens = NSScreen.screens
 
@@ -180,6 +181,9 @@ struct AppearanceSettingsPane: View {
         }
         Defaults.Toggle(key: .showTitle) {
           Text("ShowTitleBeforeSearchField", tableName: "AppearanceSettings")
+        }
+        Defaults.Toggle(key: .showApplicationIcons) {
+          Text("ShowApplicationIcons", tableName: "AppearanceSettings")
         }
 
         Defaults.Toggle(key: .showFooter) {

--- a/Maccy/Settings/en.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/en.lproj/AppearanceSettings.strings
@@ -31,4 +31,5 @@
 "ShowSearchField" = "Show search field";
 "ShowTitleBeforeSearchField" = "Show title before search field";
 "ShowFooter" = "Show footer";
+"ShowApplicationIcons" = "Show application icons next to entries";
 "OpenPreferencesWarning" = "⚠️ Press ⌘, to open preferences when footer is hidden.";

--- a/Maccy/Views/ApplicationImage.swift
+++ b/Maccy/Views/ApplicationImage.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+class ApplicationImage {
+  fileprivate static let fallbackImage = NSImage(
+    systemSymbolName: "questionmark.app.dashed", accessibilityDescription: nil)!
+  private static let retryInterval: TimeInterval = 60 * 60
+
+  let bundleIdentifier: String?
+  private var image: NSImage?
+  private var lastChecked: Date?
+  private var eventSource: (any DispatchSourceFileSystemObject)?
+
+  init(bundleIdentifier: String?, image: NSImage? = nil) {
+    self.bundleIdentifier = bundleIdentifier
+    self.image = image
+  }
+
+  var nsImage: NSImage {
+    guard let bundleIdentifier else { return Self.fallbackImage }
+
+    if let image { return image }
+
+    // The image has been queried before but since the application has been deleted.
+    // Check from time to time if the application has returned.
+    if let lastChecked,
+      Date().timeIntervalSince(lastChecked) < Self.retryInterval {
+      return Self.fallbackImage
+    }
+    lastChecked = .now
+
+    if let appURL = NSWorkspace.shared.urlForApplication(
+      withBundleIdentifier: bundleIdentifier
+    ) {
+      let img = NSWorkspace.shared.icon(forFile: appURL.path)
+      image = img
+
+      let descriptor = open(appURL.path, O_EVTONLY)
+      if descriptor == -1 {
+        let errorCode = errno
+        print("Error code: \(errorCode)")
+        print("Error message: \(String(cString: strerror(errorCode)))")
+      }
+      if descriptor > 0 {
+        let source = DispatchSource.makeFileSystemObjectSource(
+          fileDescriptor: descriptor,
+          eventMask: [.write, .delete],
+          queue: DispatchQueue.global()
+        )
+        eventSource = source
+        source.setEventHandler {
+          DispatchQueue.main.async {
+            let event = source.data
+            if event.contains(.delete) {
+              // File was deleted.
+              print("Deleted", appURL.path)
+              source.cancel()
+              self.image = nil
+            } else if event.contains(.write) {
+              // File was modified. Fetch new icon
+              print("Modified", appURL.path)
+              self.image = NSWorkspace.shared.icon(forFile: appURL.path)
+            }
+          }
+        }
+        source.setCancelHandler {
+          close(descriptor)
+        }
+        source.resume()
+      }
+
+      return img
+    }
+    return Self.fallbackImage
+  }
+}
+
+class ApplicationImageCache {
+  private static let universalClipboardIdentifier: String =
+    "com.apple.finder.Open-iCloudDrive"
+  private static let fallback = ApplicationImage(bundleIdentifier: nil)
+  private var cache: [String: ApplicationImage] = [:]
+
+  private func bundleIdentifier(for item: HistoryItem) -> String? {
+    if item.universalClipboard { return Self.universalClipboardIdentifier }
+    if let bundleIdentifier = item.application { return bundleIdentifier }
+    return nil
+  }
+
+  func getImage(item: HistoryItem) -> ApplicationImage {
+    guard let bundleIdentifier = bundleIdentifier(for: item) else {
+      return Self.fallback
+    }
+    if let image = cache[bundleIdentifier] {
+      return image
+    }
+    let image = ApplicationImage(bundleIdentifier: bundleIdentifier)
+    cache[bundleIdentifier] = image
+    return image
+  }
+}

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -9,6 +9,7 @@ struct HistoryItemView: View {
   var body: some View {
     ListItemView(
       id: item.id,
+      appIcon: item.applicationImage,
       image: item.thumbnailImage ?? ColorImage.from(item.title),
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,

--- a/Maccy/Views/ListItemTitleView.swift
+++ b/Maccy/Views/ListItemTitleView.swift
@@ -10,13 +10,13 @@ struct ListItemTitleView<Title: View>: View {
         .accessibilityIdentifier("copy-history-item")
         .lineLimit(1)
         .truncationMode(.middle)
-        .padding(.leading, 10)
+        .padding(.leading, 5)
     } else {
       title()
         .accessibilityIdentifier("copy-history-item")
         .lineLimit(1)
         .truncationMode(.middle)
-        .padding(.leading, 10)
+        .padding(.leading, 5)
     }
   }
 }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ListItemView<Title: View>: View {
   var id: UUID
+  var appIcon: ApplicationImage?
   var image: NSImage?
   var attributedTitle: AttributedString?
   var shortcuts: [KeyShortcut]
@@ -10,18 +11,30 @@ struct ListItemView<Title: View>: View {
   var help: LocalizedStringKey?
   @ViewBuilder var title: () -> Title
 
+  @Default(.showApplicationIcons) private var showIcons
   @Environment(AppState.self) private var appState
   @Environment(ModifierFlags.self) private var modifierFlags
 
   var body: some View {
     HStack(spacing: 0) {
+      if showIcons, let appIcon {
+        VStack {
+          Image(nsImage: appIcon.nsImage)
+            .resizable()
+            .frame(width: 15, height: 15)
+          Spacer(minLength: 0)
+        }
+        .padding(.leading, 5)
+        .padding(.vertical, 5)
+      }
       if let image {
         Image(nsImage: image)
           .accessibilityIdentifier("copy-history-item")
-          .padding(.leading, 10)
+          .padding(.leading, 5)
           .padding(.vertical, 5)
       }
       ListItemTitleView(attributedTitle: attributedTitle, title: title)
+        .padding(.leading, showIcons ? 0 : 5)
       Spacer()
       if !shortcuts.isEmpty {
         ZStack {

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -23,6 +23,9 @@ struct PreviewItemView: View {
       if let application = item.application {
         HStack(spacing: 3) {
           Text("Application", tableName: "PreviewItemView")
+          Image(nsImage: item.applicationImage.nsImage)
+            .resizable()
+            .frame(width: 11, height: 11)
           Text(application)
         }
       }


### PR DESCRIPTION
Add option to show app icon in the history list (see #912). The settings toggle is missing translations to languages other than english.
The app icon is also shown in the popover. 

Icons are kept for 24 hours (so they are updated if the application icon changes).

I tried to match the icon size to the visual height of the text next to it (for both the history list and the popover).

<img width="676" alt="image" src="https://github.com/user-attachments/assets/a9b1fb10-662f-4c90-8418-4e529f9ba455">

<img width="476" alt="image" src="https://github.com/user-attachments/assets/fc4c11f7-811c-47d5-ac16-1d0a9bf13b1f">
