### PR TITLE
Adjust paddings to make history list edge to edge

### DIFF
--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -30,7 +30,6 @@ struct ContentView: View {
       .animation(.default.speed(3), value: appState.history.items)
       .animation(.easeInOut(duration: 0.2), value: appState.searchVisible)
       .padding(.horizontal, 5)
-      .padding(.vertical, appState.popup.verticalPadding)
       .onAppear {
         searchFocused = true
         appState.isKeyboardNavigating = true

--- a/Maccy/Views/FooterView.swift
+++ b/Maccy/Views/FooterView.swift
@@ -22,7 +22,7 @@ struct FooterView: View {
     VStack(spacing: 0) {
       Divider()
         .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.bottom, 6)
 
       ZStack {
         FooterItemView(item: footer.items[0])

--- a/Maccy/Views/HeaderView.swift
+++ b/Maccy/Views/HeaderView.swift
@@ -28,10 +28,10 @@ struct HeaderView: View {
     }
     .frame(height: appState.searchVisible ? 25 : 0)
     .opacity(appState.searchVisible ? 1 : 0)
-    .padding(.horizontal, 10)
     // 2px is needed to prevent items from showing behind top pinned items during scrolling
     // https://github.com/p0deje/Maccy/issues/832
-    .padding(.bottom, appState.searchVisible ? 5 : 2)
+    .padding(.top, appState.searchVisible ? 5 : 2)
+    .background(.clear)
     .background {
       GeometryReader { geo in
         Color.clear

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -11,6 +11,7 @@ struct HistoryListView: View {
 
   @Default(.pinTo) private var pinTo
   @Default(.previewDelay) private var previewDelay
+  @Default(.showFooter) private var showFooter
 
   var body: some View {
     if pinTo == .top {
@@ -73,6 +74,8 @@ struct HistoryListView: View {
         }
       }
       .contentMargins(.leading, 10, for: .scrollIndicators)
+      .padding(.top, 3)
+      .padding(.bottom, showFooter ? 0 : 5)
     }
 
     if pinTo == .bottom {


### PR DESCRIPTION
Adjusts some paddings to make the history list more "edge to edge" removing some whitespace cutting of history items half way.

**Before:**
<img width="411" alt="SCR-20241125-kbep" src="https://github.com/user-attachments/assets/2a8960d8-19c6-4cfd-8a2e-1464c2f3390f">
<img width="420" alt="SCR-20241125-kbkh" src="https://github.com/user-attachments/assets/7c4f3f5e-30a8-4f61-b523-08de8931d97a">
<img width="454" alt="SCR-20241125-kbna" src="https://github.com/user-attachments/assets/83276c4b-dead-43c0-a524-0249a328658c">

**After:**
<img width="437" alt="SCR-20241125-kccp" src="https://github.com/user-attachments/assets/868f63d7-e9c8-4f79-b9ae-c68a26d1179a">
<img width="425" alt="SCR-20241125-kceb" src="https://github.com/user-attachments/assets/12c48ed4-092d-44d8-8136-28e6ddfe1933">
<img width="420" alt="SCR-20241125-kbxu" src="https://github.com/user-attachments/assets/bef6c25a-2c37-4d36-9b86-4dad5690b1dd">

