### PR TITLE
Don’t scroll if selected through hovering

### DIFF
--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -15,15 +15,19 @@ class AppState: Sendable {
   var scrollTarget: UUID?
   var selection: UUID? {
     didSet {
-      history.selectedItem = nil
-      footer.selectedItem = nil
-
-      if let item = history.items.first(where: { $0.id == selection }) {
-        history.selectedItem = item
-      } else if let item = footer.items.first(where: { $0.id == selection }) {
-        footer.selectedItem = item
-      }
+      selectWithoutScrolling(selection)
       scrollTarget = selection
+    }
+  }
+
+  func selectWithoutScrolling(_ item: UUID?) {
+    history.selectedItem = nil
+    footer.selectedItem = nil
+
+    if let item = history.items.first(where: { $0.id == item }) {
+      history.selectedItem = item
+    } else if let item = footer.items.first(where: { $0.id == item }) {
+      footer.selectedItem = item
     }
   }
 

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -64,7 +64,7 @@ struct ListItemView<Title: View>: View {
     .onHover { hovering in
       if hovering {
         if !appState.isKeyboardNavigating {
-          appState.selection = id
+          appState.selectWithoutScrolling(id)
         } else {
           appState.hoverSelectionWhileKeyboardNavigating = id
         }


### PR DESCRIPTION
This fixes an issue where hovering over an item at the edge of the list it would cause it to be scrolled into view. I find this behaviour a bit irritating and it also causes stuttering when scrolling to far too the edge of the list.