### PR TITLE
Add repeated-press logic to cycle popup selection

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		DAFE2DDA268A521B00990986 /* String+Shortened.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DD9268A521A00990986 /* String+Shortened.swift */; };
 		DAFE2DE9268A9B1B00990986 /* HistoryItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */; };
 		DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */; };
+		FE5B372C2D26274E00A9BC20 /* CycleSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5B372B2D26274E00A9BC20 /* CycleSelection.swift */; };
+		FE5B37302D26BC6C00A9BC20 /* CycleSelectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5B372F2D26BC6C00A9BC20 /* CycleSelectionUITests.swift */; };
+		FED48BDC2D2A1AF800FC57AF /* BaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED48BDB2D2A1AF800FC57AF /* BaseTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -483,6 +486,9 @@
 		DAFE2DD9268A521A00990986 /* String+Shortened.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Shortened.swift"; sourceTree = "<group>"; };
 		DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemTests.swift; sourceTree = "<group>"; };
 		DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardShortcuts.Name+Shortcuts.swift"; sourceTree = "<group>"; };
+		FE5B372B2D26274E00A9BC20 /* CycleSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleSelection.swift; sourceTree = "<group>"; };
+		FE5B372F2D26BC6C00A9BC20 /* CycleSelectionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleSelectionUITests.swift; sourceTree = "<group>"; };
+		FED48BDB2D2A1AF800FC57AF /* BaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -568,6 +574,8 @@
 			isa = PBXGroup;
 			children = (
 				DA0EE7B8204657830025FC60 /* MaccyUITests.swift */,
+				FED48BDB2D2A1AF800FC57AF /* BaseTest.swift */,
+				FE5B372F2D26BC6C00A9BC20 /* CycleSelectionUITests.swift */,
 			);
 			path = MaccyUITests;
 			sourceTree = "<group>";
@@ -740,6 +748,7 @@
 				DA20FA712B082DD600056DD5 /* Notifier.swift */,
 				DA689FC72C1D15140009B887 /* PinsPosition.swift */,
 				DA689FC52C1D14F10009B887 /* PopupPosition.swift */,
+				FE5B372B2D26274E00A9BC20 /* CycleSelection.swift */,
 				DAC14123232367B200FCFA30 /* Search.swift */,
 				2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */,
 				DAA5ACC92C1BEE8A00B58513 /* SoftwareUpdater.swift */,
@@ -952,6 +961,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA0EE7B9204657830025FC60 /* MaccyUITests.swift in Sources */,
+				FE5B37302D26BC6C00A9BC20 /* CycleSelectionUITests.swift in Sources */,
+				FED48BDC2D2A1AF800FC57AF /* BaseTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -993,6 +1004,7 @@
 				DA689FC82C1D15140009B887 /* PinsPosition.swift in Sources */,
 				DA13D7D92C1A223E00FA9E23 /* Get.swift in Sources */,
 				DA1969182C3F327500258481 /* SearchFieldView.swift in Sources */,
+				FE5B372C2D26274E00A9BC20 /* CycleSelection.swift in Sources */,
 				DAE8F5D42C43262B00851CA9 /* Popup.swift in Sources */,
 				DA13D7DA2C1A223E00FA9E23 /* Clear.swift in Sources */,
 				DA13D7DB2C1A223E00FA9E23 /* Delete.swift in Sources */,

--- a/Maccy/CycleSelection.swift
+++ b/Maccy/CycleSelection.swift
@@ -1,0 +1,162 @@
+import AppKit
+import KeyboardShortcuts
+
+/// Represents a popup action that cycles through clipboard history items.
+final class CycleSelection {
+
+  /// The event tap reference.
+  private var eventTap: CFMachPort?
+  /// The event tap's run loop source.
+  private var runLoopSource: CFRunLoopSource?
+  /// Pointer to callback context data (holding keyCode and modifiers).
+  private var callbackContextPtr: UnsafeMutableRawPointer?
+  /// Track whether the popup was opened via CycleSelection shortcut vs. another way.
+  var isOpeningReason = false
+
+  /// Initializes the popup cycle action and sets up the event tap for the popup shortcut.
+  init?(_ shortcut: KeyboardShortcuts.Shortcut) {
+
+    let keyCode: Int = shortcut.carbonKeyCode
+    let modifiers: UInt64 = UInt64(shortcut.modifiers.rawValue)
+
+    // Prepare a mask. We are interested in capturing events for keyDown, keyUp, flagsChanged.
+    let eventMask: CGEventMask = (1 << CGEventType.keyDown.rawValue)
+      | (1 << CGEventType.flagsChanged.rawValue)
+
+    // Create and retain the context to pass along in the event callback.
+    let context = PopupCallbackContext(keyCode: keyCode, modifiers: modifiers)
+    self.callbackContextPtr = UnsafeMutableRawPointer(Unmanaged.passRetained(context).toOpaque())
+
+    // Create the event tap. If this fails, something is wrong at the system level.
+    guard let eventTap = CGEvent.tapCreate(
+      tap: .cgSessionEventTap,
+      place: .headInsertEventTap,
+      options: .defaultTap,
+      eventsOfInterest: eventMask,
+      callback: popupCallback,
+      userInfo: callbackContextPtr
+    ) else {
+      NSLog("Failed to create event tap.")
+      return nil
+    }
+    self.eventTap = eventTap
+
+    // Wrap the tap in a run loop source and add it to the current run loop.
+    self.runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
+    CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+
+    // Enable the event tap.
+    CGEvent.tapEnable(tap: eventTap, enable: true)
+  }
+
+  /// Clean up resources to avoid leaks and ensure event taps are disabled on deinit.
+  deinit {
+    // Disable and invalidate the event tap if it exists.
+    if let eventTap = eventTap {
+      CGEvent.tapEnable(tap: eventTap, enable: false)
+      CFMachPortInvalidate(eventTap)
+    }
+
+    // Remove the run loop source if it was added.
+    if let runLoopSource = runLoopSource {
+      CFRunLoopRemoveSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
+    }
+
+    // Release the callback context pointer if it was created.
+    if let contextPtr = callbackContextPtr {
+      Unmanaged<PopupCallbackContext>.fromOpaque(contextPtr).release()
+    }
+
+    eventTap = nil
+    runLoopSource = nil
+    callbackContextPtr = nil
+  }
+}
+
+/// Simple storage for the key code and modifiers needed by the callback.
+private class PopupCallbackContext {
+  let keyCode: Int
+  let modifiers: UInt64
+
+  init(keyCode: Int, modifiers: UInt64) {
+    self.keyCode = keyCode
+    self.modifiers = modifiers
+  }
+}
+
+/// The callback function that receives low-level keyboard events.
+func popupCallback(
+  proxy: CGEventTapProxy,
+  eventType: CGEventType,
+  event: CGEvent,
+  userInfo: UnsafeMutableRawPointer?
+) -> Unmanaged<CGEvent>? {
+  // Make sure we can get back the context we stored.
+  guard let userInfo = userInfo else {
+    // If there's no context, return the event unmodified.
+    return Unmanaged.passRetained(event)
+  }
+
+  // Pull out the context without transferring ownership.
+  let context = Unmanaged<PopupCallbackContext>.fromOpaque(userInfo).takeUnretainedValue()
+  let cycleSelection = AppState.shared.popup.cycleSelection!
+  let eventFlags = UInt64(event.flags.rawValue & UInt64(NSEvent.ModifierFlags.deviceIndependentFlagsMask.rawValue))
+
+  switch eventType {
+  case .keyDown:
+    // Check for matching keyCode + modifiers
+    if isKeyCode(event, matching: context.keyCode) && isModifiers(eventFlags, matching: context.modifiers) {
+      // If the popup is open, cycle to the next item; otherwise, open the popup.
+      if cycleSelection.isOpeningReason {
+        AppState.shared.highlightNext()
+        return nil
+      }
+
+      if !AppState.shared.popup.isOpen() {
+        cycleSelection.isOpeningReason = true
+        AppState.shared.popup.open(height: AppState.shared.popup.height)
+        return nil
+      }
+    }
+
+  case .flagsChanged:
+    // If the popup is open and the event's modifiers no longer match our target,
+    // perform a selection action and consume the event.
+    if cycleSelection.isOpeningReason && !isModifiers(eventFlags, matching: context.modifiers) {
+      DispatchQueue.main.async {
+        AppState.shared.select(flags: NSEvent.ModifierFlags(event.flags))
+      }
+      return nil
+    }
+
+  default:
+    break
+  }
+
+  // Return the event so other parts of the system can see it.
+  return Unmanaged.passRetained(event)
+}
+
+/// Check if a `CGEvent` has the specified key code.
+private func isKeyCode(_ event: CGEvent, matching keyCode: Int) -> Bool {
+  return event.getIntegerValueField(.keyboardEventKeycode) == keyCode
+}
+
+/// Check if a `CGEvent` has (at least) the specified modifier flags.
+private func isModifiers(_ eventFlags: UInt64, matching modifiers: UInt64) -> Bool {
+  return (eventFlags & modifiers) == modifiers
+}
+
+extension NSEvent.ModifierFlags {
+    init(_ eventFlags: CGEventFlags) {
+        self = []
+        if eventFlags.contains(.maskAlphaShift) { self.insert(.capsLock) }
+        if eventFlags.contains(.maskShift) { self.insert(.shift) }
+        if eventFlags.contains(.maskControl) { self.insert(.control) }
+        if eventFlags.contains(.maskAlternate) { self.insert(.option) }
+        if eventFlags.contains(.maskCommand) { self.insert(.command) }
+        if eventFlags.contains(.maskNumericPad) { self.insert(.numericPad) }
+        if eventFlags.contains(.maskHelp) { self.insert(.help) }
+        if eventFlags.contains(.maskSecondaryFn) { self.insert(.function) }
+    }
+}

--- a/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -2,6 +2,7 @@ import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
   static let popup = Self("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
+  static let cycleSelection = Self("cycleSelection", default: Shortcut(.v, modifiers: [.command, .shift]))
   static let pin = Self("pin", default: Shortcut(.p, modifiers: [.option]))
   static let delete = Self("delete", default: Shortcut(.delete, modifiers: [.option]))
 }

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -66,9 +66,9 @@ class AppState: Sendable {
   }
 
   @MainActor
-  func select() {
+  func select(flags: NSEvent.ModifierFlags? = nil) {
     if let item = history.selectedItem, history.items.contains(item) {
-      history.select(item)
+      history.select(item, flags: flags)
     } else if let item = footer.selectedItem {
       if item.confirmation != nil {
         item.showConfirmation = true

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -216,12 +216,12 @@ class History { // swiftlint:disable:this type_body_length
   }
 
   @MainActor
-  func select(_ item: HistoryItemDecorator?) {
+  func select(_ item: HistoryItemDecorator?, flags: NSEvent.ModifierFlags? = nil) {
     guard let item else {
       return
     }
 
-    let modifierFlags = NSApp.currentEvent?.modifierFlags
+    let modifierFlags = flags ?? NSApp.currentEvent?.modifierFlags
       .intersection(.deviceIndependentFlagsMask)
       .subtracting([.capsLock, .numericPad, .function]) ?? []
 

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -12,10 +12,15 @@ class Popup {
   var headerHeight: CGFloat = 0
   var pinnedItemsHeight: CGFloat = 0
   var footerHeight: CGFloat = 0
+  var cycleSelection: CycleSelection?
 
   init() {
     KeyboardShortcuts.onKeyUp(for: .popup) {
       self.toggle()
+    }
+
+    if let shortcut = KeyboardShortcuts.getShortcut(for: .cycleSelection) {
+      cycleSelection = CycleSelection(shortcut)
     }
   }
 
@@ -23,11 +28,16 @@ class Popup {
     AppState.shared.appDelegate?.panel.toggle(height: height, at: popupPosition)
   }
 
+  func isOpen() -> Bool {
+      return AppState.shared.appDelegate?.panel.isPresented ?? false
+  }
+
   func open(height: CGFloat, at popupPosition: PopupPosition = Defaults[.popupPosition]) {
     AppState.shared.appDelegate?.panel.open(height: height, at: popupPosition)
   }
 
   func close() {
+    self.cycleSelection?.isOpeningReason = false  // reset
     AppState.shared.appDelegate?.panel.close()
   }
 

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -36,6 +36,19 @@ struct GeneralSettingsPane: View {
         KeyboardShortcuts.Recorder(for: .popup)
           .help(Text("OpenTooltip", tableName: "GeneralSettings"))
       }
+
+      Settings.Section(label: { Text("CycleSelection", tableName: "GeneralSettings") }) {
+        KeyboardShortcuts.Recorder(for: .cycleSelection) { newShortcut in
+          guard let shortcut = newShortcut else {
+            AppState.shared.popup.cycleSelection = nil
+              return
+            }
+
+          AppState.shared.popup.cycleSelection = CycleSelection(shortcut)
+        }
+        .help(Text("CycleSelectionHelp", tableName: "GeneralSettings"))
+      }
+
       Settings.Section(label: { Text("Pin", tableName: "GeneralSettings") }) {
         KeyboardShortcuts.Recorder(for: .pin)
           .help(Text("PinTooltip", tableName: "GeneralSettings"))

--- a/Maccy/Settings/en.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/en.lproj/GeneralSettings.strings
@@ -18,3 +18,5 @@
 "Regex" = "Regular expressions";
 "Mixed" = "Mixed";
 "NotificationsAndSounds" = "Notifications and sounds 􀱁";
+"CycleSelection" = "Cycle selection:";
+"CycleSelectionHelp" = "When enabled, pressing the key shortcut again while keeping modifiers pressed will select the next item in the clipboard history. Releasing all keys will confirm selection and close Maccy popup.";

--- a/MaccyUITests/BaseTest.swift
+++ b/MaccyUITests/BaseTest.swift
@@ -1,0 +1,157 @@
+import Carbon
+import XCTest
+
+class BaseTest: XCTestCase {
+  let app = XCUIApplication()
+  let pasteboard = NSPasteboard.general
+
+  override func setUp() {
+    super.setUp()
+    app.launchArguments.append("enable-testing")
+    app.launch()
+  }
+
+  override func tearDown() {
+    super.tearDown()
+    app.terminate()
+  }
+
+  func popUpWithHotkey() {
+    simulatePopupHotkey()
+    waitUntilPoppedUp()
+  }
+
+  func popUpWithMouse() {
+    app.statusItems.firstMatch.click()
+    waitUntilPoppedUp()
+  }
+
+  func simulatePopupHotkey() {
+    let commandDown = CGEvent(
+      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Command), keyDown: true)!
+    let commandUp = CGEvent(
+      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Command), keyDown: false)!
+    let shiftDown = CGEvent(
+      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: true)!
+    let shiftUp = CGEvent(
+      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: false)!
+    shiftDown.flags = [.maskCommand]
+    shiftUp.flags = [.maskCommand]
+    let cDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: true)!
+    let cUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: false)!
+    cDown.flags = [.maskCommand, .maskShift]
+    cUp.flags = [.maskCommand, .maskShift]
+    commandDown.post(tap: .cghidEventTap)
+    shiftDown.post(tap: .cghidEventTap)
+    cDown.post(tap: .cghidEventTap)
+    cUp.post(tap: .cghidEventTap)
+    shiftUp.post(tap: .cghidEventTap)
+    commandUp.post(tap: .cghidEventTap)
+  }
+
+  func waitUntilPoppedUp() {
+    if !app.staticTexts.firstMatch.waitForExistence(timeout: 3) {
+      XCTFail("Maccy did not pop up")
+    }
+  }
+
+  func waitUntilDismissed() {
+    if !app.staticTexts.firstMatch.waitForNonExistence(timeout: 3) {
+      XCTFail("Maccy did not dismiss")
+    }
+  }
+
+  // Default interval for Maccy to check clipboard is 1 second
+  func waitTillClipboardCheck() {
+    usleep(1_500_000)
+  }
+
+  func hover(_ element: XCUIElement) {
+    element.hover()
+    usleep(20000)
+  }
+
+  func search(_ string: String) {
+    // NOTE: app.typeText is broken in Sonoma and causes some
+    //       Chars to be submitted with a .command mask (e.g. 'p', 'k' or 'j')
+    string.forEach {
+      app.typeKey("\($0)", modifierFlags: [])
+    }
+    waitForSearch()
+  }
+
+  func waitForSearch() {
+    // NOTE: This is a hack and is flaky.
+    // Ideally we should wait for a proper condition to detect that search has settled down.
+    usleep(500000)  // wait for search throttle
+  }
+
+  func assertExists(_ element: XCUIElement) {
+    expectation(for: NSPredicate(format: "exists = 1"), evaluatedWith: element)
+    waitForExpectations(timeout: 3)
+  }
+
+  func assertNotExists(_ element: XCUIElement) {
+    expectation(for: NSPredicate(format: "exists = 0"), evaluatedWith: element)
+    waitForExpectations(timeout: 3)
+  }
+
+  func assertNotVisible(_ element: XCUIElement) {
+    expectation(
+      for: NSPredicate(format: "(exists = 0) || (isHittable = 0)"), evaluatedWith: element)
+    waitForExpectations(timeout: 3)
+  }
+
+  func assertPasteboardDataEquals(
+    _ expected: Data?, forType: NSPasteboard.PasteboardType = .string
+  ) {
+    let predicate = NSPredicate { (object, _) -> Bool in
+      guard let copy = object as? Data else {
+        return false
+      }
+
+      return self.pasteboard.data(forType: forType) == copy
+    }
+    expectation(for: predicate, evaluatedWith: expected)
+    waitForExpectations(timeout: 3)
+  }
+
+  func assertPasteboardDataCountEquals(
+    _ expected: Int, forType: NSPasteboard.PasteboardType = .string
+  ) {
+    let predicate = NSPredicate { (object, _) -> Bool in
+      guard let count = object as? Int else {
+        return false
+      }
+
+      return self.pasteboard.data(forType: forType)!.count == count
+    }
+    expectation(for: predicate, evaluatedWith: expected)
+    waitForExpectations(timeout: 3)
+  }
+
+  func assertPasteboardStringEquals(
+    _ expected: String?, forType: NSPasteboard.PasteboardType = .string
+  ) {
+    let predicate = NSPredicate { (object, _) -> Bool in
+      guard let copy = object as? String else {
+        return false
+      }
+
+      return self.pasteboard.string(forType: forType) == copy
+    }
+    expectation(for: predicate, evaluatedWith: expected)
+    waitForExpectations(timeout: 3)
+  }
+
+  func assertSearchFieldValue(_ string: String) {
+    XCTAssertEqual(app.textFields.firstMatch.value as? String, string)
+  }
+
+  func confirmClear() {
+    let button = app.dialogs.firstMatch.buttons["Clear"].firstMatch
+    expectation(for: NSPredicate(format: "isHittable = 1"), evaluatedWith: button)
+    waitForExpectations(timeout: 3)
+    button.click()
+  }
+}

--- a/MaccyUITests/CycleSelectionUITests.swift
+++ b/MaccyUITests/CycleSelectionUITests.swift
@@ -1,0 +1,89 @@
+import Carbon
+import XCTest
+
+class CycleSelectionUITests: BaseTest {
+
+  let copy1 = UUID().uuidString
+  let copy2 = UUID().uuidString
+  let copy3 = UUID().uuidString
+
+  override func setUp() {
+    super.setUp()
+
+    copyToClipboard(copy3)
+    copyToClipboard(copy2)
+    copyToClipboard(copy1)
+  }
+
+  func testOpenAndClose() throws {
+    // Simulate the popup hotkey press (Cmd + Shift + V).
+    let vDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_V), keyDown: true)!
+    vDown.flags = [.maskCommand, .maskShift]
+    vDown.post(tap: .cghidEventTap)
+
+    // Wait for the popup to appear.
+    waitUntilPoppedUp()
+
+    // Release the 'V' key but keep the popup open.
+    let vUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_V), keyDown: false)!
+    vUp.flags = [.maskCommand, .maskShift]
+    vUp.post(tap: .cghidEventTap)
+
+    // Assert that the popup is still visible.
+    waitUntilPoppedUp()
+
+    // Release the 'Shift' key and assert that the popup closes.
+    let shiftUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: false)!
+    shiftUp.flags = [.maskCommand] // Command remains active, Shift released
+    shiftUp.post(tap: .cghidEventTap)
+
+    waitUntilDismissed()
+  }
+
+  func testOpenAndSelectSecondItem() throws {
+    // Simulate the popup hotkey press (Cmd + Shift + V).
+    let vDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_V), keyDown: true)!
+    vDown.flags = [.maskCommand, .maskShift]
+    vDown.post(tap: .cghidEventTap)
+
+    // Wait for the popup to appear.
+    waitUntilPoppedUp()
+
+    vDown.post(tap: .cghidEventTap)
+
+    // Release the 'Shift' key and assert that the popup closes.
+    let shiftUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: false)!
+    shiftUp.flags = [.maskCommand] // Command remains active, Shift released
+    shiftUp.post(tap: .cghidEventTap)
+
+    waitUntilDismissed()
+    assertPasteboardStringEquals(copy2)
+  }
+
+  func testOpenAndSelectThirdItem() throws {
+    // Simulate the popup hotkey press (Cmd + Shift + V).
+    let vDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_V), keyDown: true)!
+    vDown.flags = [.maskCommand, .maskShift]
+    vDown.post(tap: .cghidEventTap)
+
+    // Wait for the popup to appear.
+    waitUntilPoppedUp()
+
+    vDown.post(tap: .cghidEventTap)
+    vDown.post(tap: .cghidEventTap)
+
+    // Release the 'Shift' key and assert that the popup closes.
+    let shiftUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: false)!
+    shiftUp.flags = [.maskCommand] // Command remains active, Shift released
+    shiftUp.post(tap: .cghidEventTap)
+
+    waitUntilDismissed()
+    assertPasteboardStringEquals(copy3)
+  }
+
+  private func copyToClipboard(_ content: String) {
+    pasteboard.clearContents()
+    pasteboard.setString(content, forType: .string)
+    waitTillClipboardCheck()
+  }
+}

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -1,11 +1,8 @@
 import Carbon
 import XCTest
 
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
-class MaccyUITests: XCTestCase {
-  let app = XCUIApplication()
-  let pasteboard = NSPasteboard.general
+class MaccyUITests: BaseTest {
 
   let copy1 = UUID().uuidString
   let copy2 = UUID().uuidString
@@ -46,16 +43,9 @@ class MaccyUITests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    app.launchArguments.append("enable-testing")
-    app.launch()
 
     copyToClipboard(copy2)
     copyToClipboard(copy1)
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    app.terminate()
   }
 
   func testPopupWithHotkey() throws {
@@ -338,45 +328,6 @@ class MaccyUITests: XCTestCase {
     assertExists(items["foo bar"])
   }
 
-  private func popUpWithHotkey() {
-    simulatePopupHotkey()
-    waitUntilPoppedUp()
-  }
-
-  private func popUpWithMouse() {
-    app.statusItems.firstMatch.click()
-    waitUntilPoppedUp()
-  }
-
-  private func simulatePopupHotkey() {
-    let commandDown = CGEvent(
-      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Command), keyDown: true)!
-    let commandUp = CGEvent(
-      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Command), keyDown: false)!
-    let shiftDown = CGEvent(
-      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: true)!
-    let shiftUp = CGEvent(
-      keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Shift), keyDown: false)!
-    shiftDown.flags = [.maskCommand]
-    shiftUp.flags = [.maskCommand]
-    let cDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: true)!
-    let cUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: false)!
-    cDown.flags = [.maskCommand, .maskShift]
-    cUp.flags = [.maskCommand, .maskShift]
-    commandDown.post(tap: .cghidEventTap)
-    shiftDown.post(tap: .cghidEventTap)
-    cDown.post(tap: .cghidEventTap)
-    cUp.post(tap: .cghidEventTap)
-    shiftUp.post(tap: .cghidEventTap)
-    commandUp.post(tap: .cghidEventTap)
-  }
-
-  private func waitUntilPoppedUp() {
-    if !app.staticTexts.firstMatch.waitForExistence(timeout: 3) {
-      XCTFail("Maccy did not pop up")
-    }
-  }
-
   private func copyToClipboard(_ content: String) {
     pasteboard.clearContents()
     pasteboard.setString(content, forType: .string)
@@ -404,105 +355,10 @@ class MaccyUITests: XCTestCase {
     waitTillClipboardCheck()
   }
 
-  // Default interval for Maccy to check clipboard is 1 second
-  private func waitTillClipboardCheck() {
-    usleep(1_500_000)
-  }
-
-  private func pin(_ title: String) {
+  func pin(_ title: String) {
     hover(items[title].firstMatch)
     app.typeKey("p", modifierFlags: [.option])
     usleep(1_500_000)
   }
-
-  private func hover(_ element: XCUIElement) {
-    element.hover()
-    usleep(20000)
-  }
-
-  private func search(_ string: String) {
-    // NOTE: app.typeText is broken in Sonoma and causes some
-    //       Chars to be submitted with a .command mask (e.g. 'p', 'k' or 'j')
-    string.forEach {
-      app.typeKey("\($0)", modifierFlags: [])
-    }
-    waitForSearch()
-  }
-
-  private func waitForSearch() {
-    // NOTE: This is a hack and is flaky.
-    // Ideally we should wait for a proper condition to detect that search has settled down.
-    usleep(500000)  // wait for search throttle
-  }
-
-  private func assertExists(_ element: XCUIElement) {
-    expectation(for: NSPredicate(format: "exists = 1"), evaluatedWith: element)
-    waitForExpectations(timeout: 3)
-  }
-
-  private func assertNotExists(_ element: XCUIElement) {
-    expectation(for: NSPredicate(format: "exists = 0"), evaluatedWith: element)
-    waitForExpectations(timeout: 3)
-  }
-
-  private func assertNotVisible(_ element: XCUIElement) {
-    expectation(
-      for: NSPredicate(format: "(exists = 0) || (isHittable = 0)"), evaluatedWith: element)
-    waitForExpectations(timeout: 3)
-  }
-
-  private func assertPasteboardDataEquals(
-    _ expected: Data?, forType: NSPasteboard.PasteboardType = .string
-  ) {
-    let predicate = NSPredicate { (object, _) -> Bool in
-      guard let copy = object as? Data else {
-        return false
-      }
-
-      return self.pasteboard.data(forType: forType) == copy
-    }
-    expectation(for: predicate, evaluatedWith: expected)
-    waitForExpectations(timeout: 3)
-  }
-
-  private func assertPasteboardDataCountEquals(
-    _ expected: Int, forType: NSPasteboard.PasteboardType = .string
-  ) {
-    let predicate = NSPredicate { (object, _) -> Bool in
-      guard let count = object as? Int else {
-        return false
-      }
-
-      return self.pasteboard.data(forType: forType)!.count == count
-    }
-    expectation(for: predicate, evaluatedWith: expected)
-    waitForExpectations(timeout: 3)
-  }
-
-  private func assertPasteboardStringEquals(
-    _ expected: String?, forType: NSPasteboard.PasteboardType = .string
-  ) {
-    let predicate = NSPredicate { (object, _) -> Bool in
-      guard let copy = object as? String else {
-        return false
-      }
-
-      return self.pasteboard.string(forType: forType) == copy
-    }
-    expectation(for: predicate, evaluatedWith: expected)
-    waitForExpectations(timeout: 3)
-  }
-
-  private func assertSearchFieldValue(_ string: String) {
-    XCTAssertEqual(app.textFields.firstMatch.value as? String, string)
-  }
-
-  private func confirmClear() {
-    let button = app.dialogs.firstMatch.buttons["Clear"].firstMatch
-    expectation(for: NSPredicate(format: "isHittable = 1"), evaluatedWith: button)
-    waitForExpectations(timeout: 3)
-    button.click()
-  }
 }
 // swiftlint:enable type_body_length
-// swiftlint:enable file_length


### PR DESCRIPTION
Hey!

I was hoping to contribute to Maccy.

I'd like to add an option to cycle over the clipboard option on repeated "open" shortcut stroke. 

Before merge, there are probably a couple of things needed to be done, such as adding tests.

I was looking to get your thoughts before spending more time on it. Couple of questions:

- Would you like to get this feature merged?
- Do you use any formatter/linter? (It's my first time working with Swift/Xcode) I tried using [swiftformat](https://github.com/nicklockwood/SwiftFormat) and most of the files changed.
- Does the current logic look OK?
- Any general requirements to create a PR/commit?
