### PR TITLE
Fix popupScreen selection

### DIFF
--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -48,32 +48,50 @@ struct AppearanceSettingsPane: View {
     return formatter
   }()
 
+  private func labelForScreen(index screenIndex: Int) -> String {
+    switch screenIndex {
+    case 0:
+      return String(localized: "ActiveScreen", table: "AppearanceSettings")
+    case _: return screens[screenIndex - 1].localizedName
+    }
+  }
+
+  @ViewBuilder private func screenPicker(for position: PopupPosition)
+    -> some View
+  {
+    let screenBinding: Binding<Int> = Binding {
+      return popupScreen
+    } set: {
+      popupScreen = $0
+      popupAt = position
+    }
+    Picker(selection: screenBinding) {
+      Text(labelForScreen(index: 0))
+        .tag(0)
+
+      ForEach(screens.indices, id: \.self) { index in
+        Text(labelForScreen(index: index + 1))
+          .tag(index + 1)
+      }
+    } label: {
+      if popupAt == position {
+        Text("\(position.description) (\(labelForScreen(index: popupScreen)))")
+      } else {
+        Text(position.description)
+      }
+    }
+  }
+
   var body: some View {
     Settings.Container(contentWidth: 650) {
       Settings.Section(label: { Text("PopupAt", tableName: "AppearanceSettings") }) {
         HStack {
           Picker("", selection: $popupAt) {
             ForEach(PopupPosition.allCases) { position in
-              if position == .center || position == .lastPosition {
-                if screens.count > 1 {
-                  let screenBinding: Binding<Int> = Binding {
-                    return popupScreen
-                  } set: {
-                    popupScreen = $0
-                    popupAt = position
-                  }
-                  Picker(position.description, selection: screenBinding) {
-                    Text("ActiveScreen", tableName: "AppearanceSettings")
-                      .tag(0)
-
-                    ForEach(Array(screens.enumerated()), id: \.element) { index, screen in
-                      Text(screen.localizedName)
-                        .tag(index + 1)
-                    }
-                  }
-                } else {
-                  Text(position.description)
-                }
+              if position == .center || position == .lastPosition,
+                screens.count > 1
+              {
+                screenPicker(for: position)
               } else {
                 Text(position.description)
               }

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -56,7 +56,13 @@ struct AppearanceSettingsPane: View {
             ForEach(PopupPosition.allCases) { position in
               if position == .center || position == .lastPosition {
                 if screens.count > 1 {
-                  Picker(position.description, selection: $popupScreen) {
+                  let screenBinding: Binding<Int> = Binding {
+                    return popupScreen
+                  } set: {
+                    popupScreen = $0
+                    popupAt = position
+                  }
+                  Picker(position.description, selection: screenBinding) {
                     Text("ActiveScreen", tableName: "AppearanceSettings")
                       .tag(0)
 
@@ -64,9 +70,6 @@ struct AppearanceSettingsPane: View {
                       Text(screen.localizedName)
                         .tag(index + 1)
                     }
-                  }
-                  .onChange(of: popupScreen) {
-                    popupAt = position
                   }
                 } else {
                   Text(position.description)


### PR DESCRIPTION
Fixes #1019 

The correct popup location is now selected if the screen value is changed. I also implemented the proposal of displaying the current screen selection in the picker. Caveat: The picker is too narrow to display most of the values. Should I increase the width of the picker?


https://github.com/user-attachments/assets/aa54539f-e335-4b4f-a236-0992ebd64442

