### PR TITLE
Update StorageSettings.strings (fix French typos)

### DIFF
--- a/Maccy/Settings/fr.lproj/StorageSettings.strings
+++ b/Maccy/Settings/fr.lproj/StorageSettings.strings
@@ -2,7 +2,7 @@
 "Save" = "Sauver :";
 "Files" = "Fichiers";
 "Images" = "Images";
-"Text" = "Texte";
+"Text" = "Textes";
 "SaveDescription" = "Modifiez les types de contenu copié à stocker.";
 "Size" = "Taille :";
 "SizeTooltip" = "Nombre d'éléments à garder dans l'historique.\nPar défaut : 200.";


### PR DESCRIPTION
I replace all straight quotes (') with curved quotes (’) for better typography. Apple uses curved quotes in French text. I add plural to the French "Texte" (in fact, **Text** must probably be plural because **Files** and **Images** are plural).