### PR TITLE
Make popover open through shortcut

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
+		2F3DCE9E2D9A8E84001DE666 /* PopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3DCE9D2D9A8E7A001DE666 /* PopoverView.swift */; };
 		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
 		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
@@ -163,6 +164,7 @@
 		1180C7372826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
+		2F3DCE9D2D9A8E7A001DE666 /* PopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -615,6 +617,7 @@
 				DAA072E82C42C6AA006DDFD2 /* ListItemTitleView.swift */,
 				DAA072E22C41D1D5006DDFD2 /* ListItemView.swift */,
 				DA5078982CF2676400215488 /* MouseMovedViewModifer.swift */,
+				2F3DCE9D2D9A8E7A001DE666 /* PopoverView.swift */,
 				DA5E627E2C39E53F00F4C710 /* PreviewItemView.strings */,
 				DA1969132C3F11D600258481 /* PreviewItemView.swift */,
 				DA1969172C3F327500258481 /* SearchFieldView.swift */,
@@ -988,6 +991,7 @@
 				DAB082962A2B7B850053E463 /* AppStoreReview.swift in Sources */,
 				2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */,
 				DA13D7D22C19F91B00FA9E23 /* Defaults.Keys+Names.swift in Sources */,
+				2F3DCE9E2D9A8E84001DE666 /* PopoverView.swift in Sources */,
 				DA1969102C3F0AAC00258481 /* KeyShortcut.swift in Sources */,
 				DA9C3C622C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift in Sources */,
 				DA243D142C2F66DD0012A27F /* Storage.swift in Sources */,

--- a/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -4,4 +4,5 @@ extension KeyboardShortcuts.Name {
   static let popup = Self("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
   static let pin = Self("pin", default: Shortcut(.p, modifiers: [.option]))
   static let delete = Self("delete", default: Shortcut(.delete, modifiers: [.option]))
+  static let togglePreview = Self("togglePreview", default: Shortcut(.i, modifiers: [.command]))
 }

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -118,6 +118,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
   override func close() {
     super.close()
+    AppState.shared.showPreview = false
     isPresented = false
     statusBarButton?.isHighlighted = false
   }

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -17,6 +17,9 @@ enum KeyChord: CaseIterable {
   static var pinKey: Key? { Sauce.shared.key(shortcut: .pin) }
   static var pinModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .pin)?.modifiers }
 
+  static var previewKey: Key? { Sauce.shared.key(shortcut: .togglePreview) }
+  static var previewModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .togglePreview)?.modifiers }
+
   case clearHistory
   case clearHistoryAll
   case clearSearch
@@ -32,6 +35,7 @@ enum KeyChord: CaseIterable {
   case pinOrUnpin
   case selectCurrentItem
   case close
+  case togglePreview
   case unknown
 
   init(_ event: NSEvent?) {
@@ -102,6 +106,8 @@ enum KeyChord: CaseIterable {
       self = .selectCurrentItem
     case (.escape, _):
       self = .close
+    case (KeyChord.previewKey, KeyChord.previewModifiers):
+      self = .togglePreview
     case (_, _) where !modifierFlags.isDisjoint(with: [.command, .control, .option]):
       self = .ignored
     default:

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -26,6 +26,10 @@ class HistoryItem {
        let character = Sauce.shared.character(for: Int(pinKey.QWERTYKeyCode), cocoaModifiers: []) {
       keys.remove(character)
     }
+    if let previewKey = KeyChord.previewKey,
+       let character = Sauce.shared.character(for: Int(previewKey.QWERTYKeyCode), cocoaModifiers: []) {
+      keys.remove(character)
+    }
 
     return keys
   }

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -4,7 +4,7 @@ import Foundation
 import Settings
 
 @Observable
-class AppState: Sendable {
+final class AppState: Sendable {
   static let shared = AppState()
 
   var appDelegate: AppDelegate?
@@ -39,6 +39,14 @@ class AppState: Sendable {
         selection = hoverSelection
       }
     }
+  }
+
+  var showPreview: Bool = false
+  var previewItem: HistoryItemDecorator? {
+    get {
+      return showPreview ? history.selectedItem : nil
+    }
+    set {}
   }
 
   var searchVisible: Bool {
@@ -93,7 +101,6 @@ class AppState: Sendable {
   }
 
   func highlightPrevious() {
-    isKeyboardNavigating = true
     if let selectedItem = history.selectedItem {
       if let nextItem = history.items.filter(\.isVisible).item(before: selectedItem) {
         selectFromKeyboardNavigation(nextItem.id)

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -10,7 +10,6 @@ class HistoryItemDecorator: Identifiable, Hashable {
     return lhs.id == rhs.id
   }
 
-  static var previewThrottler = Throttler(minimumDelay: Double(Defaults[.previewDelay]) / 1000)
   static var previewImageSize: NSSize { NSScreen.forPopup?.visibleFrame.size ?? NSSize(width: 2048, height: 1536) }
   static var thumbnailImageSize: NSSize { NSSize(width: 340, height: Defaults[.imageMaxHeight]) }
 
@@ -20,21 +19,8 @@ class HistoryItemDecorator: Identifiable, Hashable {
   var attributedTitle: AttributedString?
 
   var isVisible: Bool = true
-  var isSelected: Bool = false {
-    didSet {
-      if isSelected {
-        Self.previewThrottler.throttle {
-          Self.previewThrottler.minimumDelay = 0.2
-          self.showPreview = true
-        }
-      } else {
-        Self.previewThrottler.cancel()
-        self.showPreview = false
-      }
-    }
-  }
+  var isSelected: Bool = false
   var shortcuts: [KeyShortcut] = []
-  var showPreview: Bool = false
 
   var application: String? {
     if item.universalClipboard {

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -40,12 +40,17 @@ struct GeneralSettingsPane: View {
         KeyboardShortcuts.Recorder(for: .pin)
           .help(Text("PinTooltip", tableName: "GeneralSettings"))
       }
-      Settings.Section(
-        bottomDivider: true,
-        label: { Text("Delete", tableName: "GeneralSettings") }
+      Settings.Section(label: { Text("Delete", tableName: "GeneralSettings") }
       ) {
         KeyboardShortcuts.Recorder(for: .delete)
           .help(Text("DeleteTooltip", tableName: "GeneralSettings"))
+      }
+      Settings.Section(
+        bottomDivider: true,
+        label: { Text("ShowInfo", tableName: "GeneralSettings") }
+      ) {
+        KeyboardShortcuts.Recorder(for: .togglePreview)
+          .help(Text("ShowInfoTooltip", tableName: "GeneralSettings"))
       }
 
       Settings.Section(

--- a/Maccy/Settings/en.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/en.lproj/GeneralSettings.strings
@@ -8,6 +8,8 @@
 "PinTooltip" = "Shortcut key to pin history item.\nDefault: ⌥P.";
 "Delete" = "Delete:";
 "DeleteTooltip" = "Shortcut key to delete history item.\nDefault: ⌥⌫.";
+"ShowInfo" = "Toggle info:";
+"ShowInfoTooltip" = "Show popup with additinal information.\nDefault: ⌘I";
 "Behavior" = "Behavior:";
 "PasteAutomatically" = "Paste automatically";
 "PasteWithoutFormatting" = "Paste without formatting";

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -37,6 +37,13 @@ struct ContentView: View {
       .onMouseMove {
         appState.isKeyboardNavigating = false
       }
+      .background {
+        PopoverView(item: $appState.previewItem) { content in
+          if let item = content {
+            PreviewItemView(item: item)
+          }
+        }
+      }
       .task {
         try? await appState.history.load()
       }
@@ -59,13 +66,9 @@ struct ContentView: View {
         scenePhase = .background
       }
     }
-    .onReceive(NotificationCenter.default.publisher(for: NSPopover.willShowNotification)) {
-      if let popover = $0.object as? NSPopover {
-        // Prevent NSPopover from showing close animation when
-        // quickly toggling FloatingPanel while popover is visible.
-        popover.animates = false
-        // Prevent NSPopover from becoming first responder.
-        popover.behavior = .semitransient
+    .onReceive(NotificationCenter.default.publisher(for: NSPopover.didCloseNotification)) {
+      if $0.object is NSPopover {
+        appState.showPreview = false
       }
     }
   }

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -20,8 +20,5 @@ struct HistoryItemView: View {
     .onTapGesture {
       appState.history.select(item)
     }
-    .popover(isPresented: $item.showPreview, arrowEdge: .trailing) {
-      PreviewItemView(item: item)
-    }
   }
 }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -66,8 +66,6 @@ struct HistoryListView: View {
         .onChange(of: scenePhase) {
           if scenePhase == .active {
             searchFocused = true
-            HistoryItemDecorator.previewThrottler.minimumDelay = Double(previewDelay) / 1000
-            HistoryItemDecorator.previewThrottler.cancel()
             appState.isKeyboardNavigating = true
             appState.selection = appState.history.unpinnedItems.first?.id ?? appState.history.pinnedItems.first?.id
           } else {

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -105,6 +105,9 @@ struct KeyHandlingView<Content: View>: View {
         case .close:
           appState.popup.close()
           return .handled
+        case .togglePreview:
+          appState.showPreview = !appState.showPreview
+          return .handled
         default:
           ()
         }

--- a/Maccy/Views/PopoverView.swift
+++ b/Maccy/Views/PopoverView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct PopoverView<Value, T: View>: NSViewRepresentable {
+  @Binding private var item: Value?
+  private let content: (Value?) -> T
+  private var lastItem: Value? = nil
+
+  init(item: Binding<Value?>, @ViewBuilder content: @escaping (Value?) -> T) {
+    self._item = item
+    self.content = content
+  }
+
+  func makeNSView(context: Context) -> NSView {
+    return .init()
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    let coordinator = context.coordinator
+    let currentItem = item
+    coordinator.popover.contentViewController = NSHostingController(rootView: content(currentItem ?? coordinator.lastItem))
+    coordinator.lastItem = currentItem
+    coordinator.visibilityDidChange(currentItem != nil, in: nsView)
+  }
+
+  func makeCoordinator() -> Coordinator {
+    let coordinator = Coordinator(popover: .init())
+    coordinator.popover.contentViewController = NSHostingController(rootView: content(nil))
+    return coordinator
+  }
+
+  @MainActor
+  final class Coordinator: NSObject, NSPopoverDelegate {
+    fileprivate let popover: NSPopover
+    fileprivate var lastItem: Value? = nil
+    var oldFrame: NSRect = .zero
+
+
+    fileprivate init(popover: NSPopover) {
+      self.popover = popover
+      super.init()
+      popover.delegate = self
+
+      // Prevent NSPopover from becoming first responder.
+      popover.behavior = .semitransient
+    }
+
+    fileprivate func visibilityDidChange(_ isVisible: Bool, in view: NSView) {
+      if isVisible {
+        if oldFrame == .zero {
+          oldFrame = view.frame
+        } else {
+          view.frame = oldFrame
+        }
+
+        popover.show(relativeTo: .zero, of: view, preferredEdge: .maxX)
+        // Ugly hack to hide the anchor arrow
+        view.frame = NSMakeRect(-1000, 0, 10, 10)
+
+      } else if popover.isShown {
+        popover.close()
+      }
+    }
+  }
+}

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -6,6 +6,12 @@ struct PreviewItemView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
+      Image(systemName: "info.circle")
+        .imageScale(.large)
+        .padding(.bottom, 3)
+        .padding(.top, -6)
+        .padding(.leading, -3)
+
       if let image = item.previewImage {
         Image(nsImage: image)
           .resizable()
@@ -56,6 +62,7 @@ struct PreviewItemView: View {
           NSLocalizedString("PinKey", tableName: "PreviewItemView", comment: "")
             .replacingOccurrences(of: "{pinKey}", with: pinKey.description)
         )
+        .textScale(.secondary)
       }
 
       if let deleteKey = KeyboardShortcuts.Shortcut(name: .delete) {
@@ -63,6 +70,15 @@ struct PreviewItemView: View {
           NSLocalizedString("DeleteKey", tableName: "PreviewItemView", comment: "")
             .replacingOccurrences(of: "{deleteKey}", with: deleteKey.description)
         )
+        .textScale(.secondary)
+      }
+
+      if let previewKey = KeyboardShortcuts.Shortcut(name: .togglePreview) {
+        Text(
+          NSLocalizedString("PreviewKey", tableName: "PreviewItemView", comment: "")
+            .replacingOccurrences(of: "{previewKey}", with: previewKey.description)
+        )
+        .textScale(.secondary)
       }
     }
     .controlSize(.small)

--- a/Maccy/Views/en.lproj/PreviewItemView.strings
+++ b/Maccy/Views/en.lproj/PreviewItemView.strings
@@ -4,3 +4,4 @@
 "NumberOfCopies" = "Number of copies:";
 "PinKey" = "Press {pinKey} to (un)pin.";
 "DeleteKey" = "Press {deleteKey} to delete.";
+"PreviewKey" = "Press {previewKey} to hide.";


### PR DESCRIPTION
This PR implements a mechanism to open the preview popover using a configurable shortcut (`cmd I` by default). If the selected history item changes the content changes without the popover being dismissed and shown again. It still makes use of a `NSPopover` the way the code is structured it could be replaced by a custom component instead if needed.

Currently it replaces the auto show behaviour but this could easily be adjusted to be supported too. Also the popover doesn't seem to size itself accordingly to the current monitor bounds and might exceed the edge if text is very wide. I think this is also manageable to fix, but I wanted to get some feedback first. I could also imagine to make the popover movable for the user. Though I am not sure, whether this is something we would want to persist (or just reset each time visibility is toggled).

I will provide translations for the relevant settings once it is clear how to move forward with this.

I posted a video of how it looks a while back: https://github.com/p0deje/Maccy/issues/819#issuecomment-2267491100