### PR TITLE
Make HEX Code visible next to the color image

### DIFF
--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -10,7 +10,8 @@ struct HistoryItemView: View {
     ListItemView(
       id: item.id,
       appIcon: item.applicationImage,
-      image: item.thumbnailImage ?? ColorImage.from(item.title),
+      image: item.thumbnailImage,
+      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
       isSelected: item.isSelected

--- a/Maccy/Views/ListItemTitleView.swift
+++ b/Maccy/Views/ListItemTitleView.swift
@@ -10,13 +10,11 @@ struct ListItemTitleView<Title: View>: View {
         .accessibilityIdentifier("copy-history-item")
         .lineLimit(1)
         .truncationMode(.middle)
-        .padding(.leading, 5)
     } else {
       title()
         .accessibilityIdentifier("copy-history-item")
         .lineLimit(1)
         .truncationMode(.middle)
-        .padding(.leading, 5)
     }
   }
 }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -5,6 +5,7 @@ struct ListItemView<Title: View>: View {
   var id: UUID
   var appIcon: ApplicationImage?
   var image: NSImage?
+  var accessoryImage: NSImage?
   var attributedTitle: AttributedString?
   var shortcuts: [KeyShortcut]
   var isSelected: Bool
@@ -25,19 +26,28 @@ struct ListItemView<Title: View>: View {
             .frame(width: 15, height: 15)
           Spacer(minLength: 0)
         }
-        .padding(.leading, 10)
+        .padding(.leading, 4)
         .padding(.vertical, 5)
+      }
+
+      Spacer()
+        .frame(width: showIcons ? 5 : 10)
+
+      if let accessoryImage {
+        Image(nsImage: accessoryImage)
+          .accessibilityIdentifier("copy-history-item")
+          .padding(.trailing, 5)
+          .padding(.vertical, 5)
       }
 
       if let image {
         Image(nsImage: image)
           .accessibilityIdentifier("copy-history-item")
-          .padding(.leading, showIcons ? 5 : 10)
           .padding(.trailing, 5)
           .padding(.vertical, 5)
       } else {
         ListItemTitleView(attributedTitle: attributedTitle, title: title)
-          .padding(.leading, showIcons ? 0 : 5)
+          .padding(.trailing, 5)
       }
 
       Spacer()


### PR DESCRIPTION
The title says it all. Make the pasteboard string still visible as text if it is detected to be a HEX color. Very useful when copying something that looks like it is a color but actually isn't :)