### PR TITLE
Add Secret Functionality with Keyboard Shortcut and UI Updates (Localization Pending)

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -170,7 +170,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   private func disableUnusedGlobalHotkeys() {
-    let names: [KeyboardShortcuts.Name] = [.delete, .pin]
+    let names: [KeyboardShortcuts.Name] = [.delete, .pin, .secret]
     KeyboardShortcuts.disable(names)
 
     NotificationCenter.default.addObserver(

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -100,6 +100,12 @@ class Clipboard {
 
     pasteboard.setString("", forType: .fromMaccy)
     pasteboard.setString(item.application ?? "", forType: .source)
+    
+    // Save secret status
+    if item.secret {
+      pasteboard.setString("1", forType: .secret)
+    }
+    
     sync()
 
     Task {
@@ -216,6 +222,11 @@ class Clipboard {
     historyItem.contents = contents
     historyItem.application = sourceApp?.bundleIdentifier
     historyItem.title = historyItem.generateTitle()
+    
+    // Check if we're copying a secret item from ourselves
+    if pasteboard.string(forType: .secret) != nil {
+      historyItem.secret = true
+    }
 
     onNewCopyHooks.forEach({ $0(historyItem) })
   }

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -100,12 +100,12 @@ class Clipboard {
 
     pasteboard.setString("", forType: .fromMaccy)
     pasteboard.setString(item.application ?? "", forType: .source)
-    
+
     // Save secret status
     if item.secret {
       pasteboard.setString("1", forType: .secret)
     }
-    
+
     sync()
 
     Task {
@@ -222,7 +222,7 @@ class Clipboard {
     historyItem.contents = contents
     historyItem.application = sourceApp?.bundleIdentifier
     historyItem.title = historyItem.generateTitle()
-    
+
     // Check if we're copying a secret item from ourselves
     if pasteboard.string(forType: .secret) != nil {
       historyItem.secret = true

--- a/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -4,4 +4,5 @@ extension KeyboardShortcuts.Name {
   static let popup = Self("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
   static let pin = Self("pin", default: Shortcut(.p, modifiers: [.option]))
   static let delete = Self("delete", default: Shortcut(.delete, modifiers: [.option]))
+  static let secret = Self("secret", default: Shortcut(.s, modifiers: [.option]))
 }

--- a/Maccy/Extensions/NSPasteboard.PasteboardType+Types.swift
+++ b/Maccy/Extensions/NSPasteboard.PasteboardType+Types.swift
@@ -25,4 +25,7 @@ extension NSPasteboard.PasteboardType: Defaults.Serializable {
   // Safari preview and extra metadata that changes frequently.
   static let linkPresentationMetadata = NSPasteboard.PasteboardType(rawValue: "com.apple.linkpresentation.metadata")
   static let customPasteboardData = NSPasteboard.PasteboardType(rawValue: "com.apple.WebKit.custom-pasteboard-data")
+  
+  // Store secret status information
+  static let secret = NSPasteboard.PasteboardType(rawValue: "org.p0deje.Maccy.secret")
 }

--- a/Maccy/Extensions/NSPasteboard.PasteboardType+Types.swift
+++ b/Maccy/Extensions/NSPasteboard.PasteboardType+Types.swift
@@ -25,7 +25,7 @@ extension NSPasteboard.PasteboardType: Defaults.Serializable {
   // Safari preview and extra metadata that changes frequently.
   static let linkPresentationMetadata = NSPasteboard.PasteboardType(rawValue: "com.apple.linkpresentation.metadata")
   static let customPasteboardData = NSPasteboard.PasteboardType(rawValue: "com.apple.WebKit.custom-pasteboard-data")
-  
+
   // Store secret status information
   static let secret = NSPasteboard.PasteboardType(rawValue: "org.p0deje.Maccy.secret")
 }

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -17,6 +17,9 @@ enum KeyChord: CaseIterable {
   static var pinKey: Key? { Sauce.shared.key(shortcut: .pin) }
   static var pinModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .pin)?.modifiers }
 
+  static var secretKey: Key? { Sauce.shared.key(shortcut: .secret) }
+  static var secretModifiers: NSEvent.ModifierFlags? { KeyboardShortcuts.Shortcut(name: .secret)?.modifiers }
+
   case clearHistory
   case clearHistoryAll
   case clearSearch
@@ -30,6 +33,7 @@ enum KeyChord: CaseIterable {
   case moveToFirst
   case openPreferences
   case pinOrUnpin
+  case secretOrUnsecret
   case selectCurrentItem
   case close
   case unknown
@@ -95,6 +99,8 @@ enum KeyChord: CaseIterable {
       self = .moveToFirst
     case (KeyChord.pinKey, KeyChord.pinModifiers):
       self = .pinOrUnpin
+    case (KeyChord.secretKey, KeyChord.secretModifiers):
+      self = .secretOrUnsecret
     case (.comma, [.command]):
       self = .openPreferences
     case (.return, _),

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -48,7 +48,8 @@ class HistoryItem {
     NSPasteboard.PasteboardType.fromMaccy.rawValue,
     NSPasteboard.PasteboardType.linkPresentationMetadata.rawValue,
     NSPasteboard.PasteboardType.customPasteboardData.rawValue,
-    NSPasteboard.PasteboardType.source.rawValue
+    NSPasteboard.PasteboardType.source.rawValue,
+    NSPasteboard.PasteboardType.secret.rawValue
   ]
 
   var application: String?
@@ -56,6 +57,7 @@ class HistoryItem {
   var lastCopiedAt: Date = Date.now
   var numberOfCopies: Int = 1
   var pin: String?
+  var secret: Bool = false
   var title = ""
 
   @Relationship(deleteRule: .cascade)

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -258,7 +258,7 @@ class History { // swiftlint:disable:this type_body_length
         existing.secret = item.item.secret
       }
     }
-    
+
     Task {
       searchQuery = ""
     }
@@ -289,18 +289,18 @@ class History { // swiftlint:disable:this type_body_length
   @MainActor
   func toggleSecret(_ item: HistoryItemDecorator?) {
     guard let item else { return }
-    
+
     item.toggleSecret()
-    
+
     // Update the item title display immediately
     if let index = items.firstIndex(of: item) {
       items[index] = item
     }
-    
+
     if let index = all.firstIndex(of: item) {
       all[index] = item
     }
-    
+
     // If we're viewing the item, update it in realtime
     if item.isSelected {
       selectedItem = item

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -83,7 +83,7 @@ class HistoryItemDecorator: Identifiable, Hashable {
     self.item = item
     self.shortcuts = shortcuts
     self.applicationImage = ApplicationImageCache.shared.getImage(item: item)
-    
+
     if item.secret && item.title.count > 2 {
       let first = String(item.title.prefix(1))
       let last = String(item.title.suffix(1))

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -41,11 +41,18 @@ struct GeneralSettingsPane: View {
           .help(Text("PinTooltip", tableName: "GeneralSettings"))
       }
       Settings.Section(
-        bottomDivider: true,
         label: { Text("Delete", tableName: "GeneralSettings") }
       ) {
         KeyboardShortcuts.Recorder(for: .delete)
           .help(Text("DeleteTooltip", tableName: "GeneralSettings"))
+      }
+
+      Settings.Section(
+        bottomDivider: true,
+        label: { Text("Secret", tableName: "GeneralSettings") }
+      ) {
+        KeyboardShortcuts.Recorder(for: .secret)
+          .help(Text("SecretTooltip", tableName: "GeneralSettings"))
       }
 
       Settings.Section(

--- a/Maccy/Settings/en.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/en.lproj/GeneralSettings.strings
@@ -8,6 +8,8 @@
 "PinTooltip" = "Shortcut key to pin history item.\nDefault: ⌥P.";
 "Delete" = "Delete:";
 "DeleteTooltip" = "Shortcut key to delete history item.\nDefault: ⌥⌫.";
+"Secret" = "Secret:";
+"SecretTooltip" = "Shortcut key to toggle secret mode on history item.\nDefault: ⌥S.";
 "Behavior" = "Behavior:";
 "PasteAutomatically" = "Paste automatically";
 "PasteWithoutFormatting" = "Paste without formatting";

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -99,6 +99,9 @@ struct KeyHandlingView<Content: View>: View {
         case .pinOrUnpin:
           appState.history.togglePin(appState.history.selectedItem)
           return .handled
+        case .secretOrUnsecret:
+          appState.history.toggleSecret(appState.history.selectedItem)
+          return .handled
         case .selectCurrentItem:
           appState.select()
           return .handled

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -51,10 +51,23 @@ struct PreviewItemView: View {
       }
       .padding(.bottom)
 
+      HStack(spacing: 3) {
+        Text("Secret", tableName: "PreviewItemView")
+        Text(item.isSecret ? "Yes" : "No")
+      }
+      .padding(.bottom)
+
       if let pinKey = KeyboardShortcuts.Shortcut(name: .pin) {
         Text(
           NSLocalizedString("PinKey", tableName: "PreviewItemView", comment: "")
             .replacingOccurrences(of: "{pinKey}", with: pinKey.description)
+        )
+      }
+
+      if let secretKey = KeyboardShortcuts.Shortcut(name: .secret) {
+        Text(
+          NSLocalizedString("SecretKey", tableName: "PreviewItemView", comment: "")
+            .replacingOccurrences(of: "{secretKey}", with: secretKey.description)
         )
       }
 

--- a/Maccy/Views/en.lproj/PreviewItemView.strings
+++ b/Maccy/Views/en.lproj/PreviewItemView.strings
@@ -2,5 +2,7 @@
 "FirstCopyTime" = "First copy time:";
 "LastCopyTime" = "Last copy time:";
 "NumberOfCopies" = "Number of copies:";
+"Secret" = "Secret:";
 "PinKey" = "Press {pinKey} to (un)pin.";
+"SecretKey" = "Press {secretKey} to toggle secret.";
 "DeleteKey" = "Press {deleteKey} to delete.";


### PR DESCRIPTION

## This pull request introduces a new "secret" mode for history items in Maccy.

*   **Functionality:** Allows users to mark items as secret, preventing them from being fully displayed.
*   **Keyboard Shortcut:** Adds a keyboard shortcut (\(⌥S\) by default) to toggle the secret mode on a selected history item. Users can customize this shortcut in the settings.

*   **UI Updates:**

    *   Displays a "Secret" label in the preview item view to indicate whether an item is secret.
    *   Obfuscates the title and text of secret items in the list with asterisks (e.g., `f***t`).

    ![Preview for displaying secret](https://github.com/user-attachments/assets/fab1549d-701a-42e0-ab69-786498ab9f67)

<img src="https://github.com/user-attachments/assets/b9a95181-6b8d-4ccb-af53-d00df31e29ac" width="400">

**Remaining Tasks:**

*   **Localization:** Translate the new strings (related to "Secret") in the `GeneralSettings.strings` and `PreviewItemView.strings` files for all supported languages.