### PR TITLE
Match stepper max with text field max for history size

### DIFF
--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -96,7 +96,7 @@ struct StorageSettingsPane: View {
           TextField("", value: $size, formatter: sizeFormatter)
             .frame(width: 80)
             .help(Text("SizeTooltip", tableName: "StorageSettings"))
-          Stepper("", value: $size, in: 1...9999)
+          Stepper("", value: $size, in: 1...999)
             .labelsHidden()
           Text(Storage.shared.size)
             .controlSize(.small)


### PR DESCRIPTION
Really a completion of 83fc71a, which enforces a maximum history size of 999 but only for changes made via the text field itself. In contrast, you can go up to 9999 via the stepper, since its upper bound in the range was never changed from 9999. 

It's obviously undesirable to have two different "maximum" values.

The change just narrows the stepper range from `1...9999` to `1...999`.