### PR TITLE
Enhance Pin Management: Editable Content and Improved UX (Localization Pending)

### DIFF
--- a/Maccy/Settings/PinsSettingsPane.swift
+++ b/Maccy/Settings/PinsSettingsPane.swift
@@ -93,7 +93,7 @@ struct PinsSettingsPane: View {
           PinTitleView(item: item)
         }
         
-        TableColumn(Text("Value", tableName: "PinsSettings")) { item in
+        TableColumn(Text("Content", tableName: "PinsSettings")) { item in
           PinValueView(item: item)
         }
       }

--- a/Maccy/Settings/PinsSettingsPane.swift
+++ b/Maccy/Settings/PinsSettingsPane.swift
@@ -31,20 +31,20 @@ struct PinValueView: View {
   @Bindable var item: HistoryItem
   @State private var editableValue: String
   @State private var isTextContent: Bool
-  
+
   init(item: HistoryItem) {
     self.item = item
     self._editableValue = State(initialValue: item.previewableText)
-    
+
     // Check if this item has editable text content
     let hasPlainText = item.text != nil
     let hasImage = item.image != nil
     let hasFileURLs = !item.fileURLs.isEmpty
-    
+
     // Consider it text content only if it has plain text and doesn't have images or file URLs
     self._isTextContent = State(initialValue: hasPlainText && !hasImage && !hasFileURLs)
   }
-  
+
   var body: some View {
     Group {
       if isTextContent {
@@ -63,11 +63,11 @@ struct PinValueView: View {
       }
     }
   }
-  
+
   private func updateItemContent() {
     // Only update if we're dealing with text content
     guard isTextContent else { return }
-    
+
     // Find string content if it exists
     let stringType = NSPasteboard.PasteboardType.string.rawValue
     if let index = item.contents.firstIndex(where: { $0.type == stringType }) {
@@ -81,7 +81,7 @@ struct PinValueView: View {
         item.contents.append(newContent)
       }
     }
-    
+
     // We don't automatically update title here since we want to preserve
     // OCR-extracted titles for images and other non-text content
   }
@@ -111,7 +111,7 @@ struct PinsSettingsPane: View {
         TableColumn(Text("Alias", tableName: "PinsSettings")) { item in
           PinTitleView(item: item)
         }
-        
+
         TableColumn(Text("Content", tableName: "PinsSettings")) { item in
           PinValueView(item: item)
         }

--- a/Maccy/Settings/en.lproj/PinsSettings.strings
+++ b/Maccy/Settings/en.lproj/PinsSettings.strings
@@ -1,5 +1,5 @@
 "Title" = "Pins";
 "Key" = "Key";
 "Alias" = "Title";
-"Value" = "Value";
-"PinCustomizationDescription" = "You can customize the title, value, and hotkey of every pinned item.\nTo edit, double-click it and enter new value.";
+"Content" = "Content";
+"PinCustomizationDescription" = "You can customize the title, content, and hotkey of every pinned item.\nTo edit, double-click it and enter new value.";

--- a/Maccy/Settings/en.lproj/PinsSettings.strings
+++ b/Maccy/Settings/en.lproj/PinsSettings.strings
@@ -3,4 +3,5 @@
 "Alias" = "Title";
 "Content" = "Content";
 "ContentIsNotText" = "Non-editable content (image or file)";
+"RichTextEditWarning" = "Editing will discard all the formatting";
 "PinCustomizationDescription" = "You can customize the title and hotkey of every pinned item.\nOnly text content can be edited directly. For images, the title may contain OCR-detected text.";

--- a/Maccy/Settings/en.lproj/PinsSettings.strings
+++ b/Maccy/Settings/en.lproj/PinsSettings.strings
@@ -1,4 +1,5 @@
 "Title" = "Pins";
 "Key" = "Key";
 "Alias" = "Title";
-"PinCustomizationDescription" = "You can customize the title and hotkey of every pinned item.\nTo edit, double-click it and enter new value.";
+"Value" = "Value";
+"PinCustomizationDescription" = "You can customize the title, value, and hotkey of every pinned item.\nTo edit, double-click it and enter new value.";

--- a/Maccy/Settings/en.lproj/PinsSettings.strings
+++ b/Maccy/Settings/en.lproj/PinsSettings.strings
@@ -2,4 +2,5 @@
 "Key" = "Key";
 "Alias" = "Title";
 "Content" = "Content";
-"PinCustomizationDescription" = "You can customize the title, content, and hotkey of every pinned item.\nTo edit, double-click it and enter new value.";
+"ContentIsNotText" = "Non-editable content (image or file)";
+"PinCustomizationDescription" = "You can customize the title and hotkey of every pinned item.\nOnly text content can be edited directly. For images, the title may contain OCR-detected text.";

--- a/Maccy/Settings/en.lproj/PinsSettings.strings
+++ b/Maccy/Settings/en.lproj/PinsSettings.strings
@@ -4,4 +4,4 @@
 "Content" = "Content";
 "ContentIsNotText" = "Non-editable content (image or file)";
 "RichTextEditWarning" = "Editing will discard all the formatting";
-"PinCustomizationDescription" = "You can customize the title and hotkey of every pinned item.\nOnly text content can be edited directly. For images, the title may contain OCR-detected text.";
+"PinCustomizationDescription" = "You can customize the title and hotkey of every pinned item.\nOnly text content can be edited directly. To edit, double-click it and enter new value.";


### PR DESCRIPTION
This pull request significantly improves the pin management experience within Maccy by introducing the ability to edit the content of pinned items directly in the settings. It also clarifies the UX around pin titles as discussed in https://github.com/p0deje/Maccy/pull/1078#issuecomment-2843923338

**Editable Pin Content:**
1. Adds a "Content" column to the Pins settings pane, allowing users to modify the text content of their pins.
2. Displays a warning when editing rich text content, informing users that formatting will be discarded.
3. Disables editing for non-text content (images, files), with a clear message indicating why.

**Improved UX:**
1. Addresses user confusion regarding pin titles vs. content. Previously, editing the "Alias" (title) didn't affect the pin's actual content, leading to usability issues.
2. Provides a central location to manage both the title and content of pins, effectively turning Maccy into a mini snippets manager.