### PR TITLE
Fix clear history confirmation dialogue on enter

### DIFF
--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -70,7 +70,9 @@ class AppState: Sendable {
     if let item = history.selectedItem, history.items.contains(item) {
       history.select(item)
     } else if let item = footer.selectedItem {
-      if item.confirmation != nil {
+      if item.confirmation != nil,
+            let supressConfirmation = item.suppressConfirmation?.wrappedValue,
+         supressConfirmation == false {
         item.showConfirmation = true
       } else {
         item.action()


### PR DESCRIPTION
This PR fixes a recently reported bug(https://github.com/p0deje/Maccy/issues/1102) where clear history confirmation dialogue isnt suppressed even after selecting the `Dont show again` checkbox.

While handling key pressed events in https://github.com/p0deje/Maccy/blob/master/Maccy/Views/KeyHandlingView.swift we only check for the existence for `confirmation` property to decide if we want to show the dialogue. This misses the condition to check for alert suppression, hence we end up showing the dialogue always.



