### PR TITLE
Customize preview item character limit and size

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -43,6 +43,7 @@ extension Defaults.Keys {
   static let popupPosition = Key<PopupPosition>("popupPosition", default: .cursor)
   static let popupScreen = Key<Int>("popupScreen", default: 0)
   static let previewDelay = Key<Int>("previewDelay", default: 1500)
+  static let characterLimit = Key<Int>("characterLimit", default: 10_000)
   static let removeFormattingByDefault = Key<Bool>("removeFormattingByDefault", default: false)
   static let searchMode = Key<Search.Mode>("searchMode", default: .exact)
   static let showFooter = Key<Bool>("showFooter", default: true)

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -54,8 +54,8 @@ class HistoryItemDecorator: Identifiable, Hashable {
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 
-  // 10k characters seems to be more than enough on large displays
-  var text: String { item.previewableText.shortened(to: 10_000) }
+  // Character limit is read from settings. Defaults to 10k
+  var text: String { item.previewableText.shortened(to: Defaults[.characterLimit]) }
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -9,6 +9,7 @@ struct AppearanceSettingsPane: View {
   @Default(.pinTo) private var pinTo
   @Default(.imageMaxHeight) private var imageHeight
   @Default(.previewDelay) private var previewDelay
+  @Default(.characterLimit) private var characterLimit
   @Default(.highlightMatch) private var highlightMatch
   @Default(.menuIcon) private var menuIcon
   @Default(.showInStatusBar) private var showInStatusBar
@@ -45,6 +46,12 @@ struct AppearanceSettingsPane: View {
     let formatter = NumberFormatter()
     formatter.minimum = 200
     formatter.maximum = 100_000
+    return formatter
+  }()
+
+  private let characterLimitFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.maximum = 50_000
     return formatter
   }()
 
@@ -109,6 +116,16 @@ struct AppearanceSettingsPane: View {
             .labelsHidden()
         }
       }
+        
+        Settings.Section(label: { Text("CharacterLimit", tableName: "AppearanceSettings") }) {
+          HStack {
+            TextField("", value: $characterLimit, formatter: characterLimitFormatter)
+              .frame(width: 120)
+              .help(Text("PreviewDelayTooltip", tableName: "AppearanceSettings"))
+            Stepper("", value: $characterLimit, in: 0...50_000)
+              .labelsHidden()
+          }
+        }
 
       Settings.Section(
         bottomDivider: true,

--- a/Maccy/Views/WrappingTextView.swift
+++ b/Maccy/Views/WrappingTextView.swift
@@ -25,7 +25,7 @@ struct WrappingTextView: Layout {
       height = min(scaledSize.height, maxHeight)
     } else {
       width = textSize.width
-      height = min(textSize.height, maxHeight)
+      height = textSize.height
     }
 
     return CGSize(width: width, height: height)


### PR DESCRIPTION
This PR addresses the bug/feature request in https://github.com/p0deje/Maccy/issues/1075.

## Improvement
We set a hard limit on preview item character limit to 10K but this causes some large texts to be cut off. Moving this to setting to allow for customization.

<img width="710" alt="Screenshot 2025-06-08 at 12 01 42 AM" src="https://github.com/user-attachments/assets/a575b7dc-4847-489d-bdf4-40e9920e9219" />

## Bug

We set the preview height to be `min(textSize.height, maxHeight)`  causing the bug observed above. I dont completely understand why we limit it to a minimum. Assigning direct to textSize.height seem to be working properly.
**Will need feedback on if this acceptable.**
