### PR TITLE
Set window sharing type to .none to block screen capture

### DIFF
--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -27,6 +27,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
     self.statusBarButton = statusBarButton
     self.identifier = NSUserInterfaceItemIdentifier(identifier)
+    self.sharingType = .none
 
     Defaults[.windowSize] = contentRect.size
     delegate = self


### PR DESCRIPTION
## What

This PR sets the sharingType of the FloatingPanel window to .none, effectively preventing the window from being captured in screen recordings or screenshots by other apps.

## Why

Privacy & Security: This ensures that sensitive UI content shown in the floating panel cannot be recorded by screen capture tools.

User trust: Helps reinforce that the app respects user privacy and does not expose clipboard contents or UI overlays unintentionally.

macOS Support: The NSWindow.sharingType property is fully supported on macOS and allows a per-window decision on whether it can be shared.

## Resources
Feature Request: https://github.com/p0deje/Maccy/issues/1126
Apple Developer Docs: https://developer.apple.com/documentation/appkit/nswindow/sharingtype-swift.property