### PR TITLE
Fixes unexpected behavior of previews still showing up while sharing the screen

### DIFF
--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -66,6 +66,8 @@ struct ContentView: View {
         popover.animates = false
         // Prevent NSPopover from becoming first responder.
         popover.behavior = .semitransient
+        // Prevent popover from showing while sharing the screen
+        popover.contentViewController?.view.window?.sharingType = .none
       }
     }
   }


### PR DESCRIPTION
After using #1130 locally, I realized that the preview pop-up are still showing when sharing the screen. This could lead to the user unkowingly sharing private info with others.

Since we can't add ".sharingType" to the preview, I fixed it by disabling the preview when the user chooses to have privacy mode. Tested it in google meet with myself and it's working.

Since this disables a feature when activated, I made the decision to make the default value to false, so by default there would be no privacy.