### PR TITLE
Add extract text from image feature to clipboard preview

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -837,7 +837,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1520;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = p0deje;
 				TargetAttributes = {
 					DA0EE7B5204657830025FC60 = {
@@ -893,6 +893,7 @@
 				sl,
 				be,
 				uz,
+				Base,
 			);
 			mainGroup = DAEE383A1E3DBEB100DD2966;
 			packageReferences = (
@@ -1604,7 +1605,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 56;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = FDKGBRDG44;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1618,7 +1619,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 2.4.1;
-				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.Maccy;
+				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.Maccy.Danny;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1639,7 +1640,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 56;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = FDKGBRDG44;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1653,7 +1654,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 2.4.1;
-				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.Maccy;
+				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.Maccy.Danny;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/Maccy.xcodeproj/xcshareddata/xcschemes/Maccy.xcscheme
+++ b/Maccy.xcodeproj/xcshareddata/xcschemes/Maccy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -4,4 +4,5 @@ extension KeyboardShortcuts.Name {
   static let popup = Self("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
   static let pin = Self("pin", default: Shortcut(.p, modifiers: [.option]))
   static let delete = Self("delete", default: Shortcut(.delete, modifiers: [.option]))
+  static let extractText = Self("extractText", default: Shortcut(.t, modifiers: [.option]))
 }

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -1,8 +1,12 @@
 import KeyboardShortcuts
 import SwiftUI
+import Vision
 
 struct PreviewItemView: View {
   var item: HistoryItemDecorator
+  @State private var isExtracting = false
+  @State private var showAlert = false
+  @State private var alertMessage = ""
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -11,6 +15,22 @@ struct PreviewItemView: View {
           .resizable()
           .aspectRatio(contentMode: .fit)
           .clipShape(.rect(cornerRadius: 5))
+        // Extract Text Button and Shortcut
+        HStack {
+          Spacer()
+          Button(action: {
+            extractText(from: image)
+          }) {
+            if isExtracting {
+              ProgressView()
+            } else {
+              Label("Extract Text", systemImage: "text.viewfinder")
+            }
+          }
+          .help("Extract text from this image and copy to clipboard")
+          .padding(.top, 8)
+          .disabled(isExtracting)
+        }
       } else {
         ScrollView {
           WrappingTextView {
@@ -67,5 +87,40 @@ struct PreviewItemView: View {
     }
     .controlSize(.small)
     .padding()
+    .alert(alertMessage, isPresented: $showAlert) {
+      Button("OK", role: .cancel) { }
+    }
+  }
+
+  private func extractText(from image: NSImage) {
+    isExtracting = true
+    guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+      isExtracting = false
+      return
+    }
+    let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+    let request = VNRecognizeTextRequest { request, error in
+      DispatchQueue.main.async {
+        isExtracting = false
+        if let results = request.results as? [VNRecognizedTextObservation] {
+          let recognizedStrings = results.compactMap { $0.topCandidates(1).first?.string }
+          let extractedText = recognizedStrings.joined(separator: "\n")
+          if !extractedText.isEmpty {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(extractedText, forType: .string)
+          }
+        }
+      }
+    }
+    request.recognitionLevel = .accurate
+    DispatchQueue.global(qos: .userInitiated).async {
+      do {
+        try requestHandler.perform([request])
+      } catch {
+        DispatchQueue.main.async {
+          isExtracting = false
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This feature aims to allows users to extract text from images in their clipboard history using Apple’s Vision framework.

When previewing an image in the clipboard history, an “Extract Text” button appears.
Clicking the button runs OCR on the image and copies the extracted text directly to the clipboard.
The feature is only visible for image items.
No popups or alerts are shown; feedback is via clipboard update.

![ScreenRecording2025-07-27at11 55 15PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/c0d75fc7-f3d7-4caf-a09f-ac7018588e7a)


Technical notes:
Uses Apple’s Vision framework for OCR (macOS 10.15+).
UI/UX is minimal and consistent with the Maccy's design.
Tested on:
macOS Sequoia 15.5, Xcode 16.43