### PR TITLE
Add option to push pasted item to bottom of the list

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -54,6 +54,7 @@ extension Defaults.Keys {
   static let showTitle = Key<Bool>("showTitle", default: true)
   static let size = Key<Int>("historySize", default: 200)
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
+  static let pushPastedToBottom = Key<Bool>("pushPastedToBottom", default: false)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -58,6 +58,7 @@ struct StorageSettingsPane: View {
 
   @Default(.size) private var size
   @Default(.sortBy) private var sortBy
+  @Default(.pushPastedToBottom) private var pushPastedToBottom
 
   @State private var viewModel = ViewModel()
 
@@ -115,6 +116,14 @@ struct StorageSettingsPane: View {
         .frame(width: 160)
         .help(Text("SortByTooltip", tableName: "StorageSettings"))
       }
+
+      Settings.Section(
+        label: { Text("On item paste (only via Maccy!)", tableName: "StorageSettings") }
+      ) {
+        Toggle(
+          isOn: $pushPastedToBottom,
+          label: { Text("push item to bottom of list", tableName: "StorageSettings") }
+        )
     }
   }
 }

--- a/Maccy/Sorter.swift
+++ b/Maccy/Sorter.swift
@@ -23,20 +23,30 @@ class Sorter {
     }
   }
 
-  func sort(_ items: [HistoryItem], by: By = Defaults[.sortBy]) -> [HistoryItem] {
-    return items
+  func sort(_ items: [HistoryItem], by: By = Defaults[.sortBy], pushPastedToBottom: Bool = Defaults[.pushPastedToBottom]) -> [HistoryItem] {
+    var sortedItems = items
       .sorted(by: { return bySortingAlgorithm($0, $1, by) })
-      .sorted(by: byPinned)
+
+    if pushPastedToBottom {
+      sortedItems.sort {
+        $0.lastPastedAt < $1.lastPastedAt
+      }
+    }
+
+    return sortedItems
+      .sort(by: byPinned)
   }
 
   private func bySortingAlgorithm(_ lhs: HistoryItem, _ rhs: HistoryItem, _ by: By) -> Bool {
     switch by {
     case .firstCopiedAt:
       return lhs.firstCopiedAt > rhs.firstCopiedAt
+    case .lastCopiedAt:
+      return lhs.lastCopiedAt > rhs.lastCopiedAt
     case .numberOfCopies:
       return lhs.numberOfCopies > rhs.numberOfCopies
     default:
-      return lhs.lastCopiedAt > rhs.lastCopiedAt
+      throw Error("unsupported sorting criterion")
     }
   }
 


### PR DESCRIPTION
Add the option to move the item you just pasted (via the Maccy ui, while the "paste automatically" option is enabled, either by pressing it or hitting enter with it is selected)

This is implemented by adding an extra sort criterion behind a boolean flag (in Defaults)

This pull request is still a WIP, just to show a minimal sample implementation of this issue: https://github.com/p0deje/Maccy/issues/1175

Things that are still missing:
- I'm not sure yet!

(please excuse the slight refactor in `bySortingAlgorithm`, it is not required for this pull request)