### PR TITLE
Update FAQ with workaround for system level blocked shortcuts in secu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Maccy works on macOS Sonoma 14 or higher.
   * [When assigning a hotkey to open Maccy, it says that this hotkey is already used in some system setting.](#when-assigning-a-hotkey-to-open-maccy-it-says-that-this-hotkey-is-already-used-in-some-system-setting)
   * [How to restore hidden footer?](#how-to-restore-hidden-footer)
   * [How to ignore copies from Universal Clipboard?](#how-to-ignore-copies-from-universal-clipboard)
+  * [My keyboard shortcut stopped working in password fields. How do I fix this?](#my-keyboard-shortcut-stopped-working-in-password-fields-how-do-i-fix-this)
 * [Translations](#translations)
 * [Motivation](#motivation)
 * [License](#license)
@@ -141,6 +142,10 @@ defaults write org.p0deje.Maccy showFooter 1
 
 1. Open Preferences -> Ignore -> Pasteboard Types.
 2. Add `com.apple.is-remote-clipboard`.
+
+### My keyboard shortcut stopped working in password fields. How do I fix this?
+
+If your shortcut produces a character (like `Option+C` → "ç"), macOS security may block it in password fields. Use [Karabiner-Elements](https://karabiner-elements.pqrs.org/) to remap your shortcut to a different combination like `Cmd+Shift+C`. [See detailed solution](docs/keyboard-shortcut-password-fields.md).
 
 ## Translations
 

--- a/docs/keyboard-shortcut-password-fields.md
+++ b/docs/keyboard-shortcut-password-fields.md
@@ -1,0 +1,82 @@
+# Keyboard Shortcut Not Working in Password Fields
+
+## Problem Description
+
+Some users may experience issues where their Maccy keyboard shortcut stops working, particularly in password fields or secure input contexts. This commonly occurs when using shortcuts that produce visible characters, such as `Option+C` which generates the "ç" character.
+
+## Root Cause
+
+macOS blocks keyboard event listeners that output text in secure fields. When a keyboard combination generates a character (like `Option+C` → "ç"), macOS security features prevent third-party applications from intercepting these key events in password fields and other secure input contexts.
+
+## Easy Solution
+
+Choose Different Shortcut: Select a keyboard combination that doesn't produce visible characters (e.g., Cmd+Shift+V)
+
+## Detailed Solution: If you really want to continue using your current kb shortcut
+
+If you want to use a keyboard shortcut that is used by the system (and produces text output), you can use Karabiner-Elements to remap this shortcut to another keyboard shortcut. For example, remapping `Option+C` to `Cmd+Shift+C`.
+
+### Using Karabiner-Elements
+
+1. **Download and Install Karabiner-Elements**
+
+   - Visit: <https://karabiner-elements.pqrs.org/>
+   - Download and install the application
+   - Grant necessary permissions when prompted
+
+2. **Configure Key Remapping**
+
+   - Open Karabiner-Elements
+   - Navigate to "Complex Modifications"
+   - Click 'Add your own rule'
+   - Paste the following JSON configuration (see example below)
+   - Instructions for editing different key combinations: modify the `key_code` and `modifiers` values as needed
+   - Give your rule a name (Example: "Remap Option+C to Cmd+Shift+C for clipboard manager")
+
+3. **Example Karabiner Rule**
+   This example remaps `Option+C` to `Cmd+Shift+C`:
+
+   ```json
+   {
+     "description": "Remap option+c to cmd+shift+c for Maccy trigger",
+     "manipulators": [
+       {
+         "from": {
+           "key_code": "c",
+           "modifiers": {
+             "mandatory": ["left_alt"],
+             "optional": ["any"]
+           }
+         },
+         "to": [
+           {
+             "key_code": "c",
+             "modifiers": ["left_command", "left_shift"]
+           }
+         ],
+         "type": "basic"
+       }
+     ]
+   }
+   ```
+
+4. **Update Maccy Settings**
+   - Open Maccy preferences
+   - Set the keyboard shortcut to match your Karabiner remapping (in this example: `Cmd+Shift+C`)
+   - Test the shortcut in various contexts, including password fields
+
+## Alternative Solutions
+
+- **Choose Different Shortcut**: Select a keyboard combination that doesn't produce visible characters (e.g., `Cmd+Shift+V`)
+- **System Keyboard Settings**: Modify system keyboard shortcuts that might conflict with your desired combination
+
+## Verification
+
+After implementing the solution:
+
+1. Test the shortcut in regular text fields
+2. Test the shortcut in password fields
+3. Test the shortcut in secure applications (banking apps, password managers)
+4. Verify Maccy responds consistently across all contexts
+
+This approach allows you to continue using your preferred key combination while ensuring compatibility with macOS security features.


### PR DESCRIPTION
# Add documentation for keyboard shortcut issues in password fields

## Summary
Adds comprehensive documentation to help users resolve keyboard shortcut conflicts in secure input contexts (password fields, banking apps, etc.).

## Problem Addressed
Users frequently report that their Maccy keyboard shortcuts stop working in password fields, particularly when using shortcuts that produce visible characters like `Option+C` (which generates "ç"). This is due to macOS security features that block third-party keyboard event listeners in secure input contexts.

## Changes
- **New file**: `docs/keyboard-shortcut-password-fields.md`
- Explains the root cause of the issue (macOS security blocking character-producing shortcuts)
- Provides two solution paths:
  - **Easy solution**: Choose different shortcuts that don't produce characters
  - **Advanced solution**: Use Karabiner-Elements to remap shortcuts
- Includes working JSON configuration example for Karabiner-Elements
- Provides verification steps to test the fix

## Key Features
- Clear problem description and technical explanation
- Step-by-step Karabiner-Elements setup instructions
- Ready-to-use JSON configuration example
- Comprehensive testing checklist
- Alternative solutions for different user preferences

## Testing
- Verified JSON configuration syntax for Karabiner-Elements
- Confirmed technical accuracy of macOS security behavior explanation
- Validated that suggested shortcuts avoid character generation

This documentation should significantly reduce support requests related to keyboard shortcut issues in secure contexts.
