### PR TITLE
Implement paste stack

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
+		2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -164,6 +165,7 @@
 		0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWorkspace+ApplicationName.swift"; sourceTree = "<group>"; };
 		1180C7372826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightReaderModifier.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -637,6 +639,7 @@
 				DAA072DC2C41C61F006DDFD2 /* FooterItemView.swift */,
 				DAA072E02C41C6E8006DDFD2 /* FooterView.swift */,
 				DA1969192C3F369800258481 /* HeaderView.swift */,
+				2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */,
 				DA1969112C3F0DD200258481 /* HistoryItemView.swift */,
 				DAA072D42C40AC52006DDFD2 /* HistoryListView.swift */,
 				DA19690D2C3EEFA900258481 /* KeyboardShortcutView.swift */,
@@ -1056,6 +1059,7 @@
 				DA689FCC2C1D1D510009B887 /* MenuIcon.swift in Sources */,
 				DAAEB196219694AE00A7883C /* About.swift in Sources */,
 				DA6D98E22AEABE03008A77CE /* Accessibility.swift in Sources */,
+				2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */,
 				DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */,
 				DA1969212C3F6C6800258481 /* HistoryItemAction.swift in Sources */,
 				0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		2F0EC7812E773F1D003E2EA9 /* PasteStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */; };
 		2F0EC7852E774083003E2EA9 /* PasteStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7842E77407C003E2EA9 /* PasteStackView.swift */; };
 		2F0EC7872E774099003E2EA9 /* PasteStackItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */; };
+		2F0EC7892E7743D9003E2EA9 /* HoverSelectionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7882E7743D9003E2EA9 /* HoverSelectionModifier.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -178,6 +179,7 @@
 		2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStack.swift; sourceTree = "<group>"; };
 		2F0EC7842E77407C003E2EA9 /* PasteStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStackView.swift; sourceTree = "<group>"; };
 		2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStackItemView.swift; sourceTree = "<group>"; };
+		2F0EC7882E7743D9003E2EA9 /* HoverSelectionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverSelectionModifier.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -654,6 +656,7 @@
 				2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */,
 				DA1969112C3F0DD200258481 /* HistoryItemView.swift */,
 				DAA072D42C40AC52006DDFD2 /* HistoryListView.swift */,
+				2F0EC7882E7743D9003E2EA9 /* HoverSelectionModifier.swift */,
 				DA19690D2C3EEFA900258481 /* KeyboardShortcutView.swift */,
 				DA19691E2C3F5F0600258481 /* KeyHandlingView.swift */,
 				DAA072E82C42C6AA006DDFD2 /* ListItemTitleView.swift */,
@@ -1103,6 +1106,7 @@
 				DA81D674252A056B009977BC /* Throttler.swift in Sources */,
 				DA05B5112C234CB2006980FE /* MaccyApp.swift in Sources */,
 				2F0EC77F2E773DBA003E2EA9 /* MultipleSelectionListView.swift in Sources */,
+				2F0EC7892E7743D9003E2EA9 /* HoverSelectionModifier.swift in Sources */,
 				DA13D7DE2C1A436E00FA9E23 /* AppIntentError.swift in Sources */,
 				2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */,
 				DAA072D72C41C574006DDFD2 /* AppState.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
 		2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */; };
 		2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77A2E772899003E2EA9 /* PinsView.swift */; };
+		2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77C2E773314003E2EA9 /* Selection.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -168,6 +169,7 @@
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightReaderModifier.swift; sourceTree = "<group>"; };
 		2F0EC77A2E772899003E2EA9 /* PinsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsView.swift; sourceTree = "<group>"; };
+		2F0EC77C2E773314003E2EA9 /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -785,6 +787,7 @@
 				DA689FC52C1D14F10009B887 /* PopupPosition.swift */,
 				DAC14123232367B200FCFA30 /* Search.swift */,
 				2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */,
+				2F0EC77C2E773314003E2EA9 /* Selection.swift */,
 				DAA5ACC92C1BEE8A00B58513 /* SoftwareUpdater.swift */,
 				DA696BCD240177E800DE80CF /* Sorter.swift */,
 				DA243D132C2F66DD0012A27F /* Storage.swift */,
@@ -1028,6 +1031,7 @@
 				DAB082962A2B7B850053E463 /* AppStoreReview.swift in Sources */,
 				2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */,
 				DA13D7D22C19F91B00FA9E23 /* Defaults.Keys+Names.swift in Sources */,
+				2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */,
 				DA1969102C3F0AAC00258481 /* KeyShortcut.swift in Sources */,
 				DA9C3C622C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift in Sources */,
 				DA243D142C2F66DD0012A27F /* Storage.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
 		2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */; };
+		2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77A2E772899003E2EA9 /* PinsView.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -166,6 +167,7 @@
 		1180C7372826B6140086870C /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightReaderModifier.swift; sourceTree = "<group>"; };
+		2F0EC77A2E772899003E2EA9 /* PinsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsView.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -647,6 +649,7 @@
 				DAA072E82C42C6AA006DDFD2 /* ListItemTitleView.swift */,
 				DAA072E22C41D1D5006DDFD2 /* ListItemView.swift */,
 				DA5078982CF2676400215488 /* MouseMovedViewModifer.swift */,
+				2F0EC77A2E772899003E2EA9 /* PinsView.swift */,
 				DA5E627E2C39E53F00F4C710 /* PreviewItemView.strings */,
 				DA1969132C3F11D600258481 /* PreviewItemView.swift */,
 				DA1969172C3F327500258481 /* SearchFieldView.swift */,
@@ -1074,6 +1077,7 @@
 				DA696BCE240177E800DE80CF /* Sorter.swift in Sources */,
 				DAA072E92C42C6AA006DDFD2 /* ListItemTitleView.swift in Sources */,
 				DABDE97F2974706C005B32E9 /* KeyboardLayout.swift in Sources */,
+				2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */,
 				DA49EE7928B594DC002752E0 /* NSRunningApplication+WindowFrame.swift in Sources */,
 				DAA54BFA2C3C951900B7FDD8 /* FloatingPanel.swift in Sources */,
 				DA3BCB922C3EEC3C00B01BC1 /* History.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77A2E772899003E2EA9 /* PinsView.swift */; };
 		2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77C2E773314003E2EA9 /* Selection.swift */; };
 		2F0EC77F2E773DBA003E2EA9 /* MultipleSelectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */; };
+		2F0EC7812E773F1D003E2EA9 /* PasteStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -172,6 +173,7 @@
 		2F0EC77A2E772899003E2EA9 /* PinsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsView.swift; sourceTree = "<group>"; };
 		2F0EC77C2E773314003E2EA9 /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleSelectionListView.swift; sourceTree = "<group>"; };
+		2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStack.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -762,6 +764,7 @@
 		DAEE38451E3DBEB100DD2966 /* Maccy */ = {
 			isa = PBXGroup;
 			children = (
+				2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */,
 				2FBB7A252B5FECBB00C65BBE /* Extensions */,
 				DA68F91F28BD819E007E2F25 /* Intents */,
 				DA05B50F2C234C1C006980FE /* Models */,
@@ -1038,6 +1041,7 @@
 				DA1969102C3F0AAC00258481 /* KeyShortcut.swift in Sources */,
 				DA9C3C622C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift in Sources */,
 				DA243D142C2F66DD0012A27F /* Storage.swift in Sources */,
+				2F0EC7812E773F1D003E2EA9 /* PasteStack.swift in Sources */,
 				DA5078992CF2676B00215488 /* MouseMovedViewModifer.swift in Sources */,
 				DA19690E2C3EEFA900258481 /* KeyboardShortcutView.swift in Sources */,
 				DA243D122C2F64830012A27F /* ContentView.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */; };
 		2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77A2E772899003E2EA9 /* PinsView.swift */; };
 		2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77C2E773314003E2EA9 /* Selection.swift */; };
+		2F0EC77F2E773DBA003E2EA9 /* MultipleSelectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -170,6 +171,7 @@
 		2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightReaderModifier.swift; sourceTree = "<group>"; };
 		2F0EC77A2E772899003E2EA9 /* PinsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsView.swift; sourceTree = "<group>"; };
 		2F0EC77C2E773314003E2EA9 /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
+		2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleSelectionListView.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -651,6 +653,7 @@
 				DAA072E82C42C6AA006DDFD2 /* ListItemTitleView.swift */,
 				DAA072E22C41D1D5006DDFD2 /* ListItemView.swift */,
 				DA5078982CF2676400215488 /* MouseMovedViewModifer.swift */,
+				2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */,
 				2F0EC77A2E772899003E2EA9 /* PinsView.swift */,
 				DA5E627E2C39E53F00F4C710 /* PreviewItemView.strings */,
 				DA1969132C3F11D600258481 /* PreviewItemView.swift */,
@@ -1089,6 +1092,7 @@
 				DA6491B029ABCF2400837D93 /* NSScreen+ForPopup.swift in Sources */,
 				DA81D674252A056B009977BC /* Throttler.swift in Sources */,
 				DA05B5112C234CB2006980FE /* MaccyApp.swift in Sources */,
+				2F0EC77F2E773DBA003E2EA9 /* MultipleSelectionListView.swift in Sources */,
 				DA13D7DE2C1A436E00FA9E23 /* AppIntentError.swift in Sources */,
 				2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */,
 				DAA072D72C41C574006DDFD2 /* AppState.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77C2E773314003E2EA9 /* Selection.swift */; };
 		2F0EC77F2E773DBA003E2EA9 /* MultipleSelectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */; };
 		2F0EC7812E773F1D003E2EA9 /* PasteStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */; };
+		2F0EC7852E774083003E2EA9 /* PasteStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7842E77407C003E2EA9 /* PasteStackView.swift */; };
+		2F0EC7872E774099003E2EA9 /* PasteStackItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
@@ -174,6 +176,8 @@
 		2F0EC77C2E773314003E2EA9 /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleSelectionListView.swift; sourceTree = "<group>"; };
 		2F0EC7802E773F1D003E2EA9 /* PasteStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStack.swift; sourceTree = "<group>"; };
+		2F0EC7842E77407C003E2EA9 /* PasteStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStackView.swift; sourceTree = "<group>"; };
+		2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStackItemView.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
@@ -656,6 +660,8 @@
 				DAA072E22C41D1D5006DDFD2 /* ListItemView.swift */,
 				DA5078982CF2676400215488 /* MouseMovedViewModifer.swift */,
 				2F0EC77E2E773DBA003E2EA9 /* MultipleSelectionListView.swift */,
+				2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */,
+				2F0EC7842E77407C003E2EA9 /* PasteStackView.swift */,
 				2F0EC77A2E772899003E2EA9 /* PinsView.swift */,
 				DA5E627E2C39E53F00F4C710 /* PreviewItemView.strings */,
 				DA1969132C3F11D600258481 /* PreviewItemView.swift */,
@@ -1101,6 +1107,7 @@
 				2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */,
 				DAA072D72C41C574006DDFD2 /* AppState.swift in Sources */,
 				DA9C3C5E2C20E1190056795D /* IgnoreApplicationsSettingsView.swift in Sources */,
+				2F0EC7872E774099003E2EA9 /* PasteStackItemView.swift in Sources */,
 				DA20FA722B082DD600056DD5 /* Notifier.swift in Sources */,
 				DAA072DB2C41C5DD006DDFD2 /* FooterItem.swift in Sources */,
 				DA689FC62C1D14F10009B887 /* PopupPosition.swift in Sources */,
@@ -1122,6 +1129,7 @@
 				DA3BCB942C3EECBB00B01BC1 /* HistoryItemDecorator.swift in Sources */,
 				DAE28500232257D20080E394 /* ColorImage.swift in Sources */,
 				DA7A753E26A52F0F00DC16EF /* NSImage+Names.swift in Sources */,
+				2F0EC7852E774083003E2EA9 /* PasteStackView.swift in Sources */,
 				DA20FA782B082E1A00056DD5 /* NSSound+Named.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		2FA81FE02E43D9B700C12F92 /* Dictionary+RemoveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */; };
 		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
 		2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94D2E774B570093D72C /* NavigationManager.swift */; };
+		2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94F2E7808420093D72C /* AppImageView.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
@@ -186,6 +187,7 @@
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -650,6 +652,7 @@
 		DA19690C2C3EEF9300258481 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2FF2E94F2E7808420093D72C /* AppImageView.swift */,
 				DAA072DE2C41C63C006DDFD2 /* ConfirmationView.swift */,
 				DA243D112C2F64820012A27F /* ContentView.swift */,
 				DAA072DC2C41C61F006DDFD2 /* FooterItemView.swift */,
@@ -1045,6 +1048,7 @@
 			files = (
 				DA19691C2C3F3EAC00258481 /* Collection+Surrounding.swift in Sources */,
 				DA1969142C3F11D600258481 /* PreviewItemView.swift in Sources */,
+				2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */,
 				DAA072D52C40AC52006DDFD2 /* HistoryListView.swift in Sources */,
 				DAB082962A2B7B850053E463 /* AppStoreReview.swift in Sources */,
 				2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -18,8 +18,10 @@
 		2F0EC7892E7743D9003E2EA9 /* HoverSelectionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7882E7743D9003E2EA9 /* HoverSelectionModifier.swift */; };
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
+		2F1BF75F2E84369800B2EC23 /* ItemsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1BF75E2E84369800B2EC23 /* ItemsProtocol.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
+		2F476EEC2E7892DB00C780B0 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
 		2FA81FE02E43D9B700C12F92 /* Dictionary+RemoveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */; };
 		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
@@ -183,11 +185,13 @@
 		2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStackItemView.swift; sourceTree = "<group>"; };
 		2F0EC7882E7743D9003E2EA9 /* HoverSelectionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverSelectionModifier.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
+		2F1BF75E2E84369800B2EC23 /* ItemsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsProtocol.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
+		2FFF8BCF2CE2116600235A78 /* Data+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Encoding.swift"; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -798,6 +802,7 @@
 				DAA54BF92C3C951900B7FDD8 /* FloatingPanel.swift */,
 				DA689FC92C1D18890009B887 /* HighlightMatch.swift */,
 				DA1969202C3F6C6800258481 /* HistoryItemAction.swift */,
+				2F1BF75E2E84369800B2EC23 /* ItemsProtocol.swift */,
 				DABDE97E2974706C005B32E9 /* KeyboardLayout.swift */,
 				DAD665652898A1C000975096 /* KeyChord.swift */,
 				DA19690F2C3F0AAC00258481 /* KeyShortcut.swift */,
@@ -1090,9 +1095,11 @@
 				DA689FCC2C1D1D510009B887 /* MenuIcon.swift in Sources */,
 				DAAEB196219694AE00A7883C /* About.swift in Sources */,
 				DA6D98E22AEABE03008A77CE /* Accessibility.swift in Sources */,
+				2F476EEC2E7892DB00C780B0 /* (null) in Sources */,
 				2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */,
 				DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */,
 				DA1969212C3F6C6800258481 /* HistoryItemAction.swift in Sources */,
+				2F1BF75F2E84369800B2EC23 /* ItemsProtocol.swift in Sources */,
 				0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */,
 				DA19691A2C3F369800258481 /* HeaderView.swift in Sources */,
 				DA555F082CF0F994009608BD /* ApplicationImageCache.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
 		2FA81FE02E43D9B700C12F92 /* Dictionary+RemoveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */; };
 		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
+		2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94D2E774B570093D72C /* NavigationManager.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
@@ -184,6 +185,7 @@
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
+		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 		DA3BCB902C3EEC1000B01BC1 /* Observables */ = {
 			isa = PBXGroup;
 			children = (
+				2FF2E94D2E774B570093D72C /* NavigationManager.swift */,
 				DAA072D62C41C574006DDFD2 /* AppState.swift */,
 				DAA072D82C41C5AD006DDFD2 /* Footer.swift */,
 				DAA072DA2C41C5DD006DDFD2 /* FooterItem.swift */,
@@ -1061,6 +1064,7 @@
 				DA13D7D82C1A223E00FA9E23 /* Select.swift in Sources */,
 				DA689FC82C1D15140009B887 /* PinsPosition.swift in Sources */,
 				DA13D7D92C1A223E00FA9E23 /* Get.swift in Sources */,
+				2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */,
 				DA1969182C3F327500258481 /* SearchFieldView.swift in Sources */,
 				DAE8F5D42C43262B00851CA9 /* Popup.swift in Sources */,
 				DA13D7DA2C1A223E00FA9E23 /* Clear.swift in Sources */,

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -154,6 +154,12 @@ class Clipboard {
 
     changeCount = pasteboard.changeCount
 
+    if pasteboard.pasteboardItems?.contains(where: { $0.types.contains(.fromMaccy) }) != true {
+      // External copy occurred. Stop the current paste stack.
+      // Maybe queue it into the paste stack? Configurable behaviour?
+      AppState.shared.history.interruptPasteStack()
+    }
+
     if Defaults[.ignoreEvents] {
       if Defaults[.ignoreOnlyNextEvent] {
         Defaults[.ignoreEvents] = false

--- a/Maccy/Extensions/Collection+Surrounding.swift
+++ b/Maccy/Extensions/Collection+Surrounding.swift
@@ -1,28 +1,34 @@
 extension Collection where Element: Equatable {
-  func item(after: Element) -> Element? {
+  func item(after: Element, where predicate: (Element) -> Bool) -> Element? {
     guard let currentIndex = firstIndex(of: after) else {
       return nil
     }
 
-    let nextIndex = index(currentIndex, offsetBy: 1)
-    if nextIndex < endIndex {
-      return self[nextIndex]
-    } else {
-      return nil
+    var nextIndex = index(currentIndex, offsetBy: 1)
+    while nextIndex < endIndex {
+      let item = self[nextIndex]
+      if predicate(item) {
+        return item
+      }
+      nextIndex = index(nextIndex, offsetBy: 1)
     }
+    return nil
   }
 
-  func item(before: Element) -> Element? {
+  func item(before: Element, where predicate: (Element) -> Bool) -> Element? {
     guard let currentIndex = firstIndex(of: before) else {
       return nil
     }
 
-    let prevIndex = index(currentIndex, offsetBy: -1)
-    if prevIndex >= startIndex {
-      return self[prevIndex]
-    } else {
-      return nil
+    var prevIndex = index(currentIndex, offsetBy: -1)
+    while prevIndex >= startIndex {
+      let item = self[prevIndex]
+      if predicate(item) {
+        return item
+      }
+      prevIndex = index(prevIndex, offsetBy: -1)
     }
+    return nil
   }
 
   func between(from fromElement: Element, to toElement: Element, inOrder: Bool = false) -> [Element]? {

--- a/Maccy/Extensions/Collection+Surrounding.swift
+++ b/Maccy/Extensions/Collection+Surrounding.swift
@@ -25,14 +25,21 @@ extension Collection where Element: Equatable {
     }
   }
 
-  func between(from fromElement: Element, to toElement: Element) -> Self.SubSequence? {
+  func between(from fromElement: Element, to toElement: Element, inOrder: Bool = false) -> [Element]? {
     guard let fromIndex = firstIndex(of: fromElement) else {
       return nil
     }
     guard let toIndex = firstIndex(of: toElement) else {
       return nil
     }
-    return self[Swift.min(fromIndex, toIndex)...Swift.max(fromIndex, toIndex)]
+    let startIndex = Swift.min(fromIndex, toIndex)
+    let endIndex = Swift.max(fromIndex, toIndex)
+    let items = self[startIndex...endIndex]
+    if !inOrder && fromIndex > toIndex {
+      return items.reversed()
+    } else {
+      return Array(items)
+    }
   }
 }
 

--- a/Maccy/Extensions/Collection+Surrounding.swift
+++ b/Maccy/Extensions/Collection+Surrounding.swift
@@ -25,4 +25,38 @@ extension Collection where Element: Equatable {
     }
   }
 
+  func between(from fromElement: Element, to toElement: Element) -> Self.SubSequence? {
+    guard let fromIndex = firstIndex(of: fromElement) else {
+      return nil
+    }
+    guard let toIndex = firstIndex(of: toElement) else {
+      return nil
+    }
+    return self[Swift.min(fromIndex, toIndex)...Swift.max(fromIndex, toIndex)]
+  }
+}
+
+extension Array where Element: Equatable {
+  func nearest(to element: Element, where condition: (Element) -> Bool) -> Element? {
+    guard let currentIndex = firstIndex(of: element) else {
+      return nil
+    }
+    let nextNearest = self[currentIndex...].firstIndex(where: { condition($0) })
+    let previousNearest = self[...currentIndex].lastIndex(where: { condition($0) })
+    switch (nextNearest, previousNearest) {
+    case (nil, nil):
+      return nil
+    case (.some(let index), .none):
+      return self[currentIndex + index]
+    case (.none, .some(let index)):
+      return self[index]
+    case (.some(let index1), .some(let index2)):
+      let pos1 = currentIndex + index1
+      let pos2 = index2
+      return abs(pos1 - currentIndex) < abs(pos2 - currentIndex)
+      ? self[pos1]
+      : self[pos2]
+    }
+
+  }
 }

--- a/Maccy/Intents/Get.swift
+++ b/Maccy/Intents/Get.swift
@@ -34,7 +34,7 @@ struct Get: AppIntent, CustomIntentMigratedAppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<HistoryItemAppEntity> {
     var item: HistoryItem?
     if selected {
-      item = AppState.shared.history.selectedItem?.item
+      item = AppState.shared.history.selection.first?.item
     } else {
       let index = number - positionOffset
       if AppState.shared.history.items.count >= index {

--- a/Maccy/Intents/Get.swift
+++ b/Maccy/Intents/Get.swift
@@ -34,7 +34,7 @@ struct Get: AppIntent, CustomIntentMigratedAppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<HistoryItemAppEntity> {
     var item: HistoryItem?
     if selected {
-      item = AppState.shared.history.selection.first?.item
+      item = AppState.shared.navigator.selection.first?.item
     } else {
       let index = number - positionOffset
       if AppState.shared.history.items.count >= index {

--- a/Maccy/ItemsProtocol.swift
+++ b/Maccy/ItemsProtocol.swift
@@ -1,0 +1,50 @@
+
+protocol HasVisibility {
+  var isVisible: Bool { get }
+}
+
+protocol ItemsContainer {
+  associatedtype Item
+  var containerVisible: Bool { get }
+  var items: [Item] { get set }
+}
+
+extension ItemsContainer {
+    var containerVisible: Bool { true }
+}
+
+private extension ItemsContainer where Item: HasVisibility {}
+
+extension ItemsContainer where Item: HasVisibility {
+
+  var visibleItems: [Item] {
+    guard containerVisible else { return [] }
+    return self.items.lazy.filter(\.isVisible)
+  }
+
+  var firstVisibleItem: Item? {
+    guard containerVisible else { return nil }
+    return self.items.first(where: \.isVisible)
+  }
+  func firstVisibleItem(where predicate: (Item) -> Bool) -> Item? {
+    guard containerVisible else { return nil }
+    return self.items.first { $0.isVisible && predicate($0) }
+  }
+  var lastVisibleItem: Item? {
+    guard containerVisible else { return nil }
+    return self.items.last(where: \.isVisible)
+  }
+  func lastVisibleItem(where predicate: (Item) -> Bool) -> Item? {
+    guard containerVisible else { return nil }
+    return self.items.last { $0.isVisible && predicate($0) }
+  }
+}
+
+extension ItemsContainer where Item: HasVisibility, Item: Equatable {
+  func visibleItem(before: Item) -> Item? {
+    return self.items.item(before: before, where: \.isVisible)
+  }
+  func visibleItem(after: Item) -> Item? {
+    return self.items.item(after: after, where: \.isVisible)
+  }
+}

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -28,6 +28,10 @@ enum KeyChord: CaseIterable {
   case moveToLast
   case moveToPrevious
   case moveToFirst
+  case extendToNext
+  case extendToLast
+  case extendToPrevious
+  case extendToFirst
   case openPreferences
   case pinOrUnpin
   case selectCurrentItem
@@ -73,22 +77,32 @@ enum KeyChord: CaseIterable {
       self = .deleteOneCharFromSearch
     case (.w, [.control]):
       self = .deleteLastWordFromSearch
+    case (.downArrow, [.shift]),
+         (.n, [.control, .shift]):
+      self = .extendToNext
     case (.downArrow, []),
-         (.downArrow, [.shift]),
          (.n, [.control]),
-         (.n, [.control, .shift]),
          (.j, [.control]):
       self = .moveToNext
+    case (.downArrow, [.command, .shift]),
+         (.downArrow, [.option, .shift]),
+         (.n, [.control, .option, .shift]):
+       self = .extendToLast
     case (.downArrow, _) where modifierFlags.contains(.command) || modifierFlags.contains(.option),
          (.n, [.control, .option]),
          (.pageDown, []):
       self = .moveToLast
+    case (.upArrow, [.shift]),
+         (.p, [.control, .shift]):
+      self = .extendToPrevious
     case (.upArrow, []),
-         (.upArrow, [.shift]),
          (.p, [.control]),
-         (.p, [.control, .shift]),
          (.k, [.control]):
       self = .moveToPrevious
+    case (.upArrow, [.command, .shift]),
+         (.upArrow, [.option, .shift]),
+         (.p, [.control, .option, .shift]):
+        self = .extendToFirst
     case (.upArrow, _) where modifierFlags.contains(.command) || modifierFlags.contains(.option),
          (.p, [.control, .option]),
          (.pageUp, []):

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -63,7 +63,8 @@ enum KeyChord: CaseIterable {
     self.init(key, modifierFlags)
   }
 
-  init(_ key: Key, _ modifierFlags: NSEvent.ModifierFlags) { // swiftlint:disable:this cyclomatic_complexity
+  // swiftlint:disable:next cyclomatic_complexity function_body_length
+  init(_ key: Key, _ modifierFlags: NSEvent.ModifierFlags) {
     switch (key, modifierFlags) {
     case (.delete, [.command, .option]):
       self = .clearHistory

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -36,7 +36,6 @@ class AppState: Sendable {
     }
   }
 
-
   func select(item: HistoryItemDecorator? = nil, footerItem: FooterItem? = nil) {
     withTransaction(Transaction()) {
       selectWithoutScrolling(item: item, footerItem: footerItem)
@@ -255,6 +254,46 @@ class AppState: Sendable {
       selectFromKeyboardNavigation(footerItem: footer.lastVisibleItem)
     } else {
       selectFromKeyboardNavigation(footerItem: footer.firstVisibleItem)
+    }
+  }
+
+  func extendHighlightToNext() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.visibleItems.item(after: leadItem) else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
+    } else {
+      highlightNext()
+    }
+  }
+
+  func extendHighlightToPrevious() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.visibleItems.item(before: leadItem) else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
+    } else {
+      highlightPrevious()
+    }
+  }
+
+  func extendHighlightToFirst() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.firstVisibleItem else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
+    } else {
+      highlightFirst()
+    }
+  }
+
+  func extendHighlightToLast() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.lastVisibleItem else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
+    } else {
+      highlightFirst()
     }
   }
 

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -178,7 +178,7 @@ class AppState: Sendable {
     if !history.selection.isEmpty {
       if isMultiSelectInProgress {
         isManualMultiSelect = false
-        // TODO: Start paste stack
+        history.startPasteStack()
       } else {
         history.select(history.selection.first)
       }

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -6,158 +6,13 @@ import SwiftUI
 
 @Observable
 class AppState: Sendable {
-  static let shared = AppState()
+  static let shared = AppState(history: History.shared, footer: Footer())
 
   var appDelegate: AppDelegate?
   var popup: Popup
   var history: History
   var footer: Footer
-
-  var scrollTarget: UUID?
-  var leadSelection: UUID? {
-    if let item = leadHistoryItem {
-      return item.id
-    }
-    if let footerItem = footer.selectedItem {
-      return footerItem.id
-    }
-    return history.pasteStack?.id
-  }
-  private(set) var leadHistoryItem: HistoryItemDecorator?
-
-  var pasteStackSelected: Bool {
-    return leadSelection == history.pasteStack?.id
-  }
-
-  private func scroll(to id: UUID?, item: HistoryItemDecorator? = nil) {
-    scrollTarget = id
-  }
-
-  func select(id: UUID) {
-    if let item = history.items.first(where: { $0.id == id }) {
-      select(item: item, footerItem: nil)
-    } else if let item = footer.items.first(where: { $0.id == id }) {
-      select(item: nil, footerItem: item)
-    } else {
-      select(item: nil, footerItem: nil)
-    }
-  }
-
-  func select(item: HistoryItemDecorator? = nil, footerItem: FooterItem? = nil) {
-    withTransaction(Transaction()) {
-      selectWithoutScrolling(item: item, footerItem: footerItem)
-      scroll(to: item?.id, item: item)
-    }
-  }
-
-  func addToSelection(item: HistoryItemDecorator) {
-    var newSelectionState = history.selection
-
-    if item.isSelected {
-      if history.selection.count <= 1 {
-        isManualMultiSelect = !isManualMultiSelect
-      } else {
-        newSelectionState.remove(item)
-      }
-    } else {
-      newSelectionState.add(item)
-    }
-
-    withTransaction(Transaction()) {
-      history.selection = newSelectionState
-      leadHistoryItem = item
-      scrollTarget = leadSelection
-    }
-  }
-
-  func extendSelection(
-    from fromItem: HistoryItemDecorator,
-    to toItem: HistoryItemDecorator,
-    isRange: Bool
-  ) {
-    var newSelectionState = history.selection
-
-    if isRange {
-      if let itemRange = history.visibleItems.between(
-        from: fromItem,
-        to: toItem
-      ) {
-        newSelectionState = Selection(items: Array(itemRange))
-      }
-    } else {
-      if toItem.isSelected {
-        newSelectionState.remove(fromItem)
-      } else {
-        newSelectionState.add(toItem)
-      }
-    }
-
-    withTransaction(Transaction()) {
-      history.selection = newSelectionState
-      leadHistoryItem = toItem
-      scrollTarget = leadSelection
-    }
-  }
-
-  func selectWithoutScrolling(id: UUID) {
-    if let stack = history.pasteStack,
-       stack.id == id {
-      selectWithoutScrolling(item: nil, footerItem: nil)
-    } else if let item = history.items.first(where: { $0.id == id }) {
-      if !isMultiSelectInProgress {
-        selectWithoutScrolling(item: item, footerItem: nil)
-      }
-    } else if let item = footer.items.first(where: { $0.id == id }) {
-      selectWithoutScrolling(item: nil, footerItem: item)
-    } else {
-      selectWithoutScrolling(item: nil, footerItem: nil)
-    }
-  }
-
-  func selectWithoutScrolling(
-    item: HistoryItemDecorator? = nil,
-    footerItem: FooterItem? = nil
-  ) {
-    if let item = item {
-      selectInHistory(item)
-    } else if let footerItem = footerItem {
-      selectInFooter(footerItem)
-    } else {
-      leadHistoryItem = nil
-      history.selection = .init()
-      footer.selectedItem = nil
-    }
-  }
-
-  private func selectInHistory(_ item: HistoryItemDecorator) {
-    leadHistoryItem = item
-    history.selection = .init(items: [item])
-    footer.selectedItem = nil
-  }
-
-  private func selectInFooter(_ item: FooterItem) {
-    leadHistoryItem = nil
-    if !isMultiSelectInProgress {
-      history.selection = .init()
-    }
-    footer.selectedItem = item
-  }
-
-  private var isManualMultiSelect: Bool = false
-  var isMultiSelectInProgress: Bool {
-    return isManualMultiSelect || history.selection.count > 1
-  }
-
-  var hoverSelectionWhileKeyboardNavigating: UUID?
-  var isKeyboardNavigating: Bool = true {
-    didSet {
-      if !isKeyboardNavigating && !isMultiSelectInProgress,
-         let hoverSelection = hoverSelectionWhileKeyboardNavigating {
-        hoverSelectionWhileKeyboardNavigating = nil
-        select(id: hoverSelection)
-      }
-    }
-  }
+  var navigator: NavigationManager
 
   var searchVisible: Bool {
     if !Defaults[.showSearch] { return false }
@@ -177,20 +32,21 @@ class AppState: Sendable {
   private let about = About()
   private var settingsWindowController: SettingsWindowController?
 
-  init() {
-    history = History.shared
-    footer = Footer()
+  init(history: History, footer: Footer) {
+    self.history = history
+    self.footer = footer
     popup = Popup()
+    navigator = NavigationManager(history: history, footer: footer)
   }
 
   @MainActor
   func select() {
-    if !history.selection.isEmpty {
-      if isMultiSelectInProgress {
-        isManualMultiSelect = false
-        history.startPasteStack()
+    if !navigator.selection.isEmpty {
+      if navigator.isMultiSelectInProgress {
+        navigator.isManualMultiSelect = false
+        history.startPasteStack(selection: &navigator.selection)
       } else {
-        history.select(history.selection.first)
+        history.select(navigator.selection.first)
       }
     } else if let item = footer.selectedItem {
       // TODO: Use item.suppressConfirmation, but it's not updated!
@@ -202,135 +58,6 @@ class AppState: Sendable {
     } else {
       Clipboard.shared.copy(history.searchQuery)
       history.searchQuery = ""
-    }
-  }
-
-  private func selectFromKeyboardNavigation(
-    item: HistoryItemDecorator? = nil,
-    footerItem: FooterItem? = nil
-  ) {
-    isKeyboardNavigating = true
-    isManualMultiSelect = false
-    select(item: item, footerItem: footerItem)
-  }
-
-  private func extendHistorySelectionFromKeyboardNavigation(
-    from fromItem: HistoryItemDecorator,
-    to toItem: HistoryItemDecorator,
-    isRange: Bool
-  ) {
-    isKeyboardNavigating = true
-    extendSelection(from: fromItem, to: toItem, isRange: isRange)
-  }
-
-  func highlightFirst() {
-    if let item = history.items.first(where: \.isVisible) {
-      selectFromKeyboardNavigation(item: item)
-    }
-  }
-
-  func highlightPrevious() {
-    guard let lead = leadSelection else { return }
-
-    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = history.visibleItems.item(before: historyItem) {
-        selectFromKeyboardNavigation(item: nextItem)
-      } else if history.pasteStack != nil {
-        selectFromKeyboardNavigation(item: nil)
-      } else {
-        highlightFirst()
-      }
-    } else if let footerItem = footer.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = footer.visibleItems.item(before: footerItem) {
-        selectFromKeyboardNavigation(footerItem: nextItem)
-      } else if let nextItem = history.lastVisibleItem {
-        selectFromKeyboardNavigation(item: nextItem)
-      }
-    }
-  }
-
-  func highlightNext(allowCycle: Bool = false) {
-    guard let lead = leadSelection else { return }
-
-    if leadSelection == history.pasteStack?.id {
-      highlightFirst()
-      return
-    }
-
-    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = history.visibleItems.item(after: historyItem) {
-        selectFromKeyboardNavigation(item: nextItem)
-      } else if let nextItem = footer.firstVisibleItem {
-        selectFromKeyboardNavigation(footerItem: nextItem)
-      } else if allowCycle {
-        highlightFirst()
-      }
-    } else if let footerItem = footer.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = footer.visibleItems.item(after: footerItem) {
-        selectFromKeyboardNavigation(footerItem: nextItem)
-      } else if let nextItem = footer.firstVisibleItem {
-        selectFromKeyboardNavigation(footerItem: nextItem)
-      } else if allowCycle {
-        // End of footer; cycle to the beginning
-        highlightFirst()
-      }
-    }
-  }
-
-  func highlightLast() {
-    guard let lead = leadSelection else { return }
-
-    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
-      if historyItem == history.lastVisibleItem,
-         let nextItem = footer.firstVisibleItem {
-        selectFromKeyboardNavigation(footerItem: nextItem)
-      } else {
-        selectFromKeyboardNavigation(item: history.lastVisibleItem)
-      }
-    } else if footer.selectedItem != nil {
-      selectFromKeyboardNavigation(footerItem: footer.lastVisibleItem)
-    } else {
-      selectFromKeyboardNavigation(footerItem: footer.firstVisibleItem)
-    }
-  }
-
-  func extendHighlightToNext() {
-    if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
-      guard let nextItem = history.visibleItems.item(after: leadItem) else { return }
-      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
-    } else {
-      highlightNext()
-    }
-  }
-
-  func extendHighlightToPrevious() {
-    if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
-      guard let nextItem = history.visibleItems.item(before: leadItem) else { return }
-      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
-    } else {
-      highlightPrevious()
-    }
-  }
-
-  func extendHighlightToFirst() {
-    if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
-      guard let nextItem = history.firstVisibleItem else { return }
-      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
-    } else {
-      highlightFirst()
-    }
-  }
-
-  func extendHighlightToLast() {
-    if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
-      guard let nextItem = history.lastVisibleItem else { return }
-      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
-    } else {
-      highlightFirst()
     }
   }
 

--- a/Maccy/Observables/Footer.swift
+++ b/Maccy/Observables/Footer.swift
@@ -2,7 +2,7 @@ import Defaults
 import SwiftUI
 
 @Observable
-class Footer {
+class Footer: ItemsContainer {
   var items: [FooterItem] = []
 
   var selectedItem: FooterItem? {
@@ -20,18 +20,8 @@ class Footer {
   private var showFooter: Bool {
     return Defaults[.showFooter]
   }
-
-  var visibleItems: [FooterItem] {
-    guard showFooter else { return [] }
-    return self.items.filter(\.isVisible)
-  }
-  var firstVisibleItem: FooterItem? {
-    guard showFooter else { return nil }
-    return self.items.first(where: \.isVisible)
-  }
-  var lastVisibleItem: FooterItem? {
-    guard showFooter else { return nil }
-    return self.items.last(where: \.isVisible)
+  var containerVisible: Bool {
+    return showFooter
   }
 
   init() { // swiftlint:disable:this function_body_length

--- a/Maccy/Observables/Footer.swift
+++ b/Maccy/Observables/Footer.swift
@@ -17,6 +17,23 @@ class Footer {
     set: { Defaults[.suppressClearAlert] = $0 }
   )
 
+  private var showFooter: Bool {
+    return Defaults[.showFooter]
+  }
+
+  var visibleItems: [FooterItem] {
+    guard showFooter else { return [] }
+    return self.items.filter(\.isVisible)
+  }
+  var firstVisibleItem: FooterItem? {
+    guard showFooter else { return nil }
+    return self.items.first(where: \.isVisible)
+  }
+  var lastVisibleItem: FooterItem? {
+    guard showFooter else { return nil }
+    return self.items.last(where: \.isVisible)
+  }
+
   init() { // swiftlint:disable:this function_body_length
     items = [
       FooterItem(

--- a/Maccy/Observables/FooterItem.swift
+++ b/Maccy/Observables/FooterItem.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 @Observable
-class FooterItem: Equatable, Identifiable {
+class FooterItem: Equatable, Identifiable, HasVisibility {
   struct Confirmation {
     var message: LocalizedStringKey
     var comment: LocalizedStringKey

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -15,12 +15,6 @@ class History { // swiftlint:disable:this type_body_length
 
   var items: [HistoryItemDecorator] = []
   var pasteStack: PasteStack?
-  var selection: Selection<HistoryItemDecorator> = Selection() {
-    willSet {
-      selection.forEach { _, item in item.selectionIndex = -1 }
-      newValue.forEach { index, item in item.selectionIndex = index }
-    }
-  }
 
   var pinnedItems: [HistoryItemDecorator] { items.filter(\.isPinned) }
   var unpinnedItems: [HistoryItemDecorator] { items.filter(\.isUnpinned) }
@@ -31,9 +25,9 @@ class History { // swiftlint:disable:this type_body_length
         updateItems(search.search(string: searchQuery, within: all))
 
         if searchQuery.isEmpty {
-          AppState.shared.select(item: unpinnedItems.first)
+          AppState.shared.navigator.select(item: unpinnedItems.first)
         } else {
-          AppState.shared.highlightFirst()
+          AppState.shared.navigator.highlightFirst()
         }
 
         AppState.shared.popup.needsResize = true
@@ -350,7 +344,7 @@ class History { // swiftlint:disable:this type_body_length
   }
 
   @MainActor
-  func startPasteStack() {
+  func startPasteStack(selection: inout Selection<HistoryItemDecorator>) {
     guard let item = selection.first else { return }
     PasteStack.initializeIfNeeded()
 
@@ -453,7 +447,7 @@ class History { // swiftlint:disable:this type_body_length
 
     updateUnpinnedShortcuts()
     if item.isUnpinned {
-      AppState.shared.scrollTarget = item.id
+      AppState.shared.navigator.scrollTarget = item.id
     }
   }
 

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -14,10 +14,10 @@ class History { // swiftlint:disable:this type_body_length
   let logger = Logger(label: "org.p0deje.Maccy")
 
   var items: [HistoryItemDecorator] = []
-  var selectedItem: HistoryItemDecorator? {
+  var selection: Selection<HistoryItemDecorator> = Selection() {
     willSet {
-      selectedItem?.isSelected = false
-      newValue?.isSelected = true
+      selection.forEach { _, item in item.selectionIndex = -1 }
+      newValue.forEach { index, item in item.selectionIndex = index }
     }
   }
 
@@ -30,7 +30,7 @@ class History { // swiftlint:disable:this type_body_length
         updateItems(search.search(string: searchQuery, within: all))
 
         if searchQuery.isEmpty {
-          AppState.shared.selection = unpinnedItems.first?.id
+          AppState.shared.select(item: unpinnedItems.first)
         } else {
           AppState.shared.highlightFirst()
         }
@@ -55,6 +55,16 @@ class History { // swiftlint:disable:this type_body_length
 
     let key = Sauce.shared.key(for: Int(event.keyCode))
     return items.first { $0.shortcuts.contains(where: { $0.key == key }) }
+  }
+
+  var visibleItems: [HistoryItemDecorator] {
+    return self.items.filter(\.isVisible)
+  }
+  var firstVisibleItem: HistoryItemDecorator? {
+    return self.items.first(where: \.isVisible)
+  }
+  var lastVisibleItem: HistoryItemDecorator? {
+    return self.items.last(where: \.isVisible)
   }
 
   private let search = Search()

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -11,7 +11,7 @@ import SwiftData
 // swiftlint:disable file_length
 
 @Observable
-class History { // swiftlint:disable:this type_body_length
+class History: ItemsContainer { // swiftlint:disable:this type_body_length
   static let shared = History()
   let logger = Logger(label: "org.p0deje.Maccy")
 
@@ -52,16 +52,6 @@ class History { // swiftlint:disable:this type_body_length
 
     let key = Sauce.shared.key(for: Int(event.keyCode))
     return items.first { $0.shortcuts.contains(where: { $0.key == key }) }
-  }
-
-  var visibleItems: [HistoryItemDecorator] {
-    return self.items.filter(\.isVisible)
-  }
-  var firstVisibleItem: HistoryItemDecorator? {
-    return self.items.first(where: \.isVisible)
-  }
-  var lastVisibleItem: HistoryItemDecorator? {
-    return self.items.last(where: \.isVisible)
   }
 
   private let search = Search()

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -514,7 +514,7 @@ class History { // swiftlint:disable:this type_body_length
     }
 
     var index = 1
-    for item in visibleUnpinnedItems.prefix(10) {
+    for item in visibleUnpinnedItems.prefix(9) {
       item.shortcuts = KeyShortcut.create(character: String(index))
       index += 1
     }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -8,6 +8,8 @@ import Sauce
 import Settings
 import SwiftData
 
+// swiftlint:disable file_length
+
 @Observable
 class History { // swiftlint:disable:this type_body_length
   static let shared = History()

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -349,7 +349,6 @@ class History { // swiftlint:disable:this type_body_length
 
     items = all
 
-    searchQuery = ""
     updateUnpinnedShortcuts()
     if item.isUnpinned {
       AppState.shared.scrollTarget = item.id

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -20,7 +20,7 @@ class HistoryItemDecorator: Identifiable, Hashable {
   var attributedTitle: AttributedString?
 
   var isVisible: Bool = true
-  var isSelected: Bool = false {
+  var selectionIndex: Int = -1 {
     didSet {
       if isSelected {
         Self.previewThrottler.throttle {
@@ -32,6 +32,9 @@ class HistoryItemDecorator: Identifiable, Hashable {
         self.showPreview = false
       }
     }
+  }
+  var isSelected: Bool {
+    return selectionIndex != -1
   }
   var shortcuts: [KeyShortcut] = []
   var showPreview: Bool = false

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -5,7 +5,7 @@ import Observation
 import Sauce
 
 @Observable
-class HistoryItemDecorator: Identifiable, Hashable {
+class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   static func == (lhs: HistoryItemDecorator, rhs: HistoryItemDecorator) -> Bool {
     return lhs.id == rhs.id
   }

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 @Observable
-class NavigationManager {
+class NavigationManager { // swiftlint:disable:this type_body_length
   private var history: History
   private var footer: Footer
 

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -101,9 +101,10 @@ class NavigationManager { // swiftlint:disable:this type_body_length
     if isRange {
       if let itemRange = history.visibleItems.between(
         from: fromItem,
-        to: toItem
+        to: toItem,
+        inOrder: false
       ) {
-        newSelectionState = Selection(items: Array(itemRange))
+        newSelectionState = Selection(items: itemRange)
       }
     } else {
       if toItem.isSelected {

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -1,0 +1,296 @@
+import Foundation
+import SwiftUI
+
+@Observable
+class NavigationManager {
+  private var history: History
+  private var footer: Footer
+
+  init(history: History, footer: Footer) {
+    self.history = history
+    self.footer = footer
+  }
+
+  var selection: Selection<HistoryItemDecorator> = Selection() {
+    willSet {
+      selection.forEach { _, item in item.selectionIndex = -1 }
+      newValue.forEach { index, item in item.selectionIndex = index }
+    }
+  }
+
+  var scrollTarget: UUID?
+  var leadSelection: UUID? {
+    if let item = leadHistoryItem {
+      return item.id
+    }
+    if let footerItem = footer.selectedItem {
+      return footerItem.id
+    }
+    return history.pasteStack?.id
+  }
+  private(set) var leadHistoryItem: HistoryItemDecorator?
+
+  var pasteStackSelected: Bool {
+    return leadSelection == history.pasteStack?.id
+  }
+
+  var isManualMultiSelect: Bool = false
+  var isMultiSelectInProgress: Bool {
+    return isManualMultiSelect || selection.count > 1
+  }
+
+  var hoverSelectionWhileKeyboardNavigating: UUID?
+  var isKeyboardNavigating: Bool = true {
+    didSet {
+      if !isKeyboardNavigating && !isMultiSelectInProgress,
+         let hoverSelection = hoverSelectionWhileKeyboardNavigating {
+        hoverSelectionWhileKeyboardNavigating = nil
+        select(id: hoverSelection)
+      }
+    }
+  }
+
+  private func scroll(to id: UUID?, item: HistoryItemDecorator? = nil) {
+    scrollTarget = id
+  }
+
+  func select(id: UUID) {
+    if let item = history.items.first(where: { $0.id == id }) {
+      select(item: item, footerItem: nil)
+    } else if let item = footer.items.first(where: { $0.id == id }) {
+      select(item: nil, footerItem: item)
+    } else {
+      select(item: nil, footerItem: nil)
+    }
+  }
+
+  func select(item: HistoryItemDecorator? = nil, footerItem: FooterItem? = nil) {
+    withTransaction(Transaction()) {
+      selectWithoutScrolling(item: item, footerItem: footerItem)
+      scroll(to: item?.id, item: item)
+    }
+  }
+
+  func addToSelection(item: HistoryItemDecorator) {
+    var newSelectionState = selection
+
+    if item.isSelected {
+      if newSelectionState.count <= 1 {
+        isManualMultiSelect = !isManualMultiSelect
+      } else {
+        newSelectionState.remove(item)
+      }
+    } else {
+      newSelectionState.add(item)
+    }
+
+    withTransaction(Transaction()) {
+      selection = newSelectionState
+      leadHistoryItem = item
+      scrollTarget = leadSelection
+    }
+  }
+
+  func extendSelection(
+    from fromItem: HistoryItemDecorator,
+    to toItem: HistoryItemDecorator,
+    isRange: Bool
+  ) {
+    var newSelectionState = selection
+
+    if isRange {
+      if let itemRange = history.visibleItems.between(
+        from: fromItem,
+        to: toItem
+      ) {
+        newSelectionState = Selection(items: Array(itemRange))
+      }
+    } else {
+      if toItem.isSelected {
+        newSelectionState.remove(fromItem)
+      } else {
+        newSelectionState.add(toItem)
+      }
+    }
+
+    withTransaction(Transaction()) {
+      selection = newSelectionState
+      leadHistoryItem = toItem
+      scrollTarget = leadSelection
+    }
+  }
+
+  func selectWithoutScrolling(id: UUID) {
+    if let stack = history.pasteStack,
+       stack.id == id {
+      selectWithoutScrolling(item: nil, footerItem: nil)
+    } else if let item = history.items.first(where: { $0.id == id }) {
+      if !isMultiSelectInProgress {
+        selectWithoutScrolling(item: item, footerItem: nil)
+      }
+    } else if let item = footer.items.first(where: { $0.id == id }) {
+      selectWithoutScrolling(item: nil, footerItem: item)
+    } else {
+      selectWithoutScrolling(item: nil, footerItem: nil)
+    }
+  }
+
+  func selectWithoutScrolling(
+    item: HistoryItemDecorator? = nil,
+    footerItem: FooterItem? = nil
+  ) {
+    if let item = item {
+      selectInHistory(item)
+    } else if let footerItem = footerItem {
+      selectInFooter(footerItem)
+    } else {
+      leadHistoryItem = nil
+      selection = .init()
+      footer.selectedItem = nil
+    }
+  }
+
+  private func selectInHistory(_ item: HistoryItemDecorator) {
+    leadHistoryItem = item
+    selection = .init(items: [item])
+    footer.selectedItem = nil
+  }
+
+  private func selectInFooter(_ item: FooterItem) {
+    leadHistoryItem = nil
+    if !isMultiSelectInProgress {
+      selection = .init()
+    }
+    footer.selectedItem = item
+  }
+
+  private func selectFromKeyboardNavigation(
+    item: HistoryItemDecorator? = nil,
+    footerItem: FooterItem? = nil
+  ) {
+    isKeyboardNavigating = true
+    isManualMultiSelect = false
+    select(item: item, footerItem: footerItem)
+  }
+
+  private func extendHistorySelectionFromKeyboardNavigation(
+    from fromItem: HistoryItemDecorator,
+    to toItem: HistoryItemDecorator,
+    isRange: Bool
+  ) {
+    isKeyboardNavigating = true
+    extendSelection(from: fromItem, to: toItem, isRange: isRange)
+  }
+
+  func highlightFirst() {
+    if let item = history.items.first(where: \.isVisible) {
+      selectFromKeyboardNavigation(item: item)
+    }
+  }
+
+  func highlightPrevious() {
+    guard let lead = leadSelection else { return }
+
+    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
+      if let nextItem = history.visibleItems.item(before: historyItem) {
+        selectFromKeyboardNavigation(item: nextItem)
+      } else if history.pasteStack != nil {
+        selectWithoutScrolling(item: nil)
+      } else {
+        highlightFirst()
+      }
+    } else if let footerItem = footer.visibleItems.first(where: { $0.id == lead }) {
+      if let nextItem = footer.visibleItems.item(before: footerItem) {
+        selectFromKeyboardNavigation(footerItem: nextItem)
+      } else if let nextItem = history.lastVisibleItem {
+        selectFromKeyboardNavigation(item: nextItem)
+      }
+    }
+  }
+
+  func highlightNext(allowCycle: Bool = false) {
+    guard let lead = leadSelection else { return }
+
+    if leadSelection == history.pasteStack?.id {
+      highlightFirst()
+      return
+    }
+
+    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
+      if let nextItem = history.visibleItems.item(after: historyItem) {
+        selectFromKeyboardNavigation(item: nextItem)
+      } else if let nextItem = footer.firstVisibleItem {
+        selectFromKeyboardNavigation(footerItem: nextItem)
+      } else if allowCycle {
+        highlightFirst()
+      }
+    } else if let footerItem = footer.visibleItems.first(where: { $0.id == lead }) {
+      if let nextItem = footer.visibleItems.item(after: footerItem) {
+        selectFromKeyboardNavigation(footerItem: nextItem)
+      } else if let nextItem = footer.firstVisibleItem {
+        selectFromKeyboardNavigation(footerItem: nextItem)
+      } else if allowCycle {
+        // End of footer; cycle to the beginning
+        highlightFirst()
+      }
+    }
+  }
+
+  func highlightLast() {
+    guard let lead = leadSelection else { return }
+
+    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
+      if historyItem == history.lastVisibleItem,
+         let nextItem = footer.firstVisibleItem {
+        selectFromKeyboardNavigation(footerItem: nextItem)
+      } else {
+        selectFromKeyboardNavigation(item: history.lastVisibleItem)
+      }
+    } else if footer.selectedItem != nil {
+      selectFromKeyboardNavigation(footerItem: footer.lastVisibleItem)
+    } else {
+      selectFromKeyboardNavigation(footerItem: footer.firstVisibleItem)
+    }
+  }
+
+  func extendHighlightToNext() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.visibleItems.item(after: leadItem) else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
+    } else {
+      highlightNext()
+    }
+  }
+
+  func extendHighlightToPrevious() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.visibleItems.item(before: leadItem) else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
+    } else {
+      highlightPrevious()
+    }
+  }
+
+  func extendHighlightToFirst() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.firstVisibleItem else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
+    } else {
+      highlightFirst()
+    }
+  }
+
+  func extendHighlightToLast() {
+    if let leadSelection,
+       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.lastVisibleItem else { return }
+      extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
+    } else {
+      highlightFirst()
+    }
+  }
+
+}

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -184,7 +184,7 @@ class NavigationManager { // swiftlint:disable:this type_body_length
   }
 
   func highlightFirst() {
-    if let item = history.items.first(where: \.isVisible) {
+    if let item = history.firstVisibleItem {
       selectFromKeyboardNavigation(item: item)
     }
   }
@@ -192,16 +192,16 @@ class NavigationManager { // swiftlint:disable:this type_body_length
   func highlightPrevious() {
     guard let lead = leadSelection else { return }
 
-    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = history.visibleItems.item(before: historyItem) {
+    if let historyItem = history.firstVisibleItem(where: { $0.id == lead }) {
+      if let nextItem = history.visibleItem(before: historyItem) {
         selectFromKeyboardNavigation(item: nextItem)
       } else if history.pasteStack != nil {
         selectWithoutScrolling(item: nil)
       } else {
         highlightFirst()
       }
-    } else if let footerItem = footer.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = footer.visibleItems.item(before: footerItem) {
+    } else if let footerItem = footer.firstVisibleItem(where: { $0.id == lead }) {
+      if let nextItem = footer.visibleItem(before: footerItem) {
         selectFromKeyboardNavigation(footerItem: nextItem)
       } else if let nextItem = history.lastVisibleItem {
         selectFromKeyboardNavigation(item: nextItem)
@@ -217,16 +217,16 @@ class NavigationManager { // swiftlint:disable:this type_body_length
       return
     }
 
-    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = history.visibleItems.item(after: historyItem) {
+    if let historyItem = history.firstVisibleItem(where: { $0.id == lead }) {
+      if let nextItem = history.visibleItem(after: historyItem) {
         selectFromKeyboardNavigation(item: nextItem)
       } else if let nextItem = footer.firstVisibleItem {
         selectFromKeyboardNavigation(footerItem: nextItem)
       } else if allowCycle {
         highlightFirst()
       }
-    } else if let footerItem = footer.visibleItems.first(where: { $0.id == lead }) {
-      if let nextItem = footer.visibleItems.item(after: footerItem) {
+    } else if let footerItem = footer.firstVisibleItem(where: { $0.id == lead }) {
+      if let nextItem = footer.visibleItem(after: footerItem) {
         selectFromKeyboardNavigation(footerItem: nextItem)
       } else if let nextItem = footer.firstVisibleItem {
         selectFromKeyboardNavigation(footerItem: nextItem)
@@ -240,7 +240,7 @@ class NavigationManager { // swiftlint:disable:this type_body_length
   func highlightLast() {
     guard let lead = leadSelection else { return }
 
-    if let historyItem = history.visibleItems.first(where: { $0.id == lead }) {
+    if let historyItem = history.firstVisibleItem(where: { $0.id == lead }) {
       if historyItem == history.lastVisibleItem,
          let nextItem = footer.firstVisibleItem {
         selectFromKeyboardNavigation(footerItem: nextItem)
@@ -256,8 +256,8 @@ class NavigationManager { // swiftlint:disable:this type_body_length
 
   func extendHighlightToNext() {
     if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
-      guard let nextItem = history.visibleItems.item(after: leadItem) else { return }
+       let leadItem = history.firstVisibleItem(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.visibleItem(after: leadItem) else { return }
       extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
     } else {
       highlightNext()
@@ -266,8 +266,8 @@ class NavigationManager { // swiftlint:disable:this type_body_length
 
   func extendHighlightToPrevious() {
     if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
-      guard let nextItem = history.visibleItems.item(before: leadItem) else { return }
+       let leadItem = history.firstVisibleItem(where: {$0.id == leadSelection}) {
+      guard let nextItem = history.visibleItem(before: leadItem) else { return }
       extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: false)
     } else {
       highlightPrevious()
@@ -276,7 +276,7 @@ class NavigationManager { // swiftlint:disable:this type_body_length
 
   func extendHighlightToFirst() {
     if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+       let leadItem = history.firstVisibleItem(where: {$0.id == leadSelection}) {
       guard let nextItem = history.firstVisibleItem else { return }
       extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
     } else {
@@ -286,7 +286,7 @@ class NavigationManager { // swiftlint:disable:this type_body_length
 
   func extendHighlightToLast() {
     if let leadSelection,
-       let leadItem = history.visibleItems.first(where: {$0.id == leadSelection}) {
+       let leadItem = history.firstVisibleItem(where: {$0.id == leadSelection}) {
       guard let nextItem = history.lastVisibleItem else { return }
       extendHistorySelectionFromKeyboardNavigation(from: leadItem, to: nextItem, isRange: true)
     } else {

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -121,7 +121,7 @@ class Popup {
   private func handleKeyDown(_ event: NSEvent) -> NSEvent? {
     if isHotKeyCode(Int(event.keyCode)) {
       if let item = History.shared.pressedShortcutItem {
-        AppState.shared.select(item: item)
+        AppState.shared.navigator.select(item: item)
         Task { @MainActor in
           AppState.shared.history.select(item)
         }
@@ -134,7 +134,7 @@ class Popup {
       }
 
       if state == .cycle {
-        AppState.shared.highlightNext(allowCycle: true)
+        AppState.shared.navigator.highlightNext(allowCycle: true)
         return nil
       }
 

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -40,7 +40,8 @@ class Popup {
   var needsResize = false
   var height: CGFloat = 0
   var headerHeight: CGFloat = 0
-  var pinnedItemsHeight: CGFloat = 0
+  var extraTopHeight: CGFloat = 0
+  var extraBottomHeight: CGFloat = 0
   var footerHeight: CGFloat = 0
 
   private var eventsMonitor: Any?
@@ -89,7 +90,7 @@ class Popup {
   }
 
   func resize(height: CGFloat) {
-    self.height = height + headerHeight + pinnedItemsHeight + footerHeight + (Popup.verticalPadding * 2)
+    self.height = height + headerHeight + extraTopHeight + extraBottomHeight + footerHeight
     AppState.shared.appDelegate?.panel.verticallyResize(to: self.height)
     needsResize = false
   }

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -120,7 +120,7 @@ class Popup {
   private func handleKeyDown(_ event: NSEvent) -> NSEvent? {
     if isHotKeyCode(Int(event.keyCode)) {
       if let item = History.shared.pressedShortcutItem {
-        AppState.shared.selection = item.id
+        AppState.shared.select(item: item)
         Task { @MainActor in
           AppState.shared.history.select(item)
         }

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -21,6 +21,7 @@ class Popup {
   static let horizontalSeparatorPadding = 6.0
   static let verticalPadding: CGFloat = 5
   static let horizontalPadding: CGFloat = 5
+  static let scrollFixPadding: CGFloat = 2
 
   // Radius used for items inset by the padding. Ensures they visually have the same curvature
   // as the menu.

--- a/Maccy/PasteStack.swift
+++ b/Maccy/PasteStack.swift
@@ -1,0 +1,38 @@
+import Foundation
+import AppKit
+
+class PasteStack: Identifiable {
+  private static var listener: Any?
+
+  static func initializeIfNeeded() {
+    guard listener == nil else { return }
+    Accessibility.check()
+
+    var pasteDown: Bool = false
+    listener = NSEvent.addGlobalMonitorForEvents(matching: [.keyUp, .keyDown]) { event in
+      switch event.type {
+      case .keyDown:
+        if event.keyCode == KeyChord.pasteKey.QWERTYKeyCode
+           && event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command] {
+          pasteDown = true
+        }
+      case .keyUp:
+        if pasteDown && event.keyCode == KeyChord.pasteKey.QWERTYKeyCode {
+          pasteDown = false
+          AppState.shared.history.handlePasteStack()
+        }
+      default:
+        break
+      }
+    }
+  }
+
+  var id: UUID = UUID()
+  var items: [HistoryItemDecorator] = []
+  var modifierFlags: NSEvent.ModifierFlags
+
+  init(items: [HistoryItemDecorator], modifierFlags: NSEvent.ModifierFlags) {
+    self.items = items
+    self.modifierFlags = modifierFlags
+  }
+}

--- a/Maccy/Selection.swift
+++ b/Maccy/Selection.swift
@@ -1,0 +1,37 @@
+import AppKit
+
+struct Selection<Item: Equatable> {
+  var items: [Item]
+
+  init(items: [Item] = []) {
+    self.items = items
+  }
+
+  var isEmpty: Bool {
+    return items.isEmpty
+  }
+
+  var count: Int {
+    return items.count
+  }
+
+  var first: Item? {
+    return items.first
+  }
+
+  func first(where condition: (Item) -> Bool) -> Item? {
+    return items.first(where: condition)
+  }
+
+  func forEach(_ body: (Int, Item) throws -> Void) rethrows {
+    try items.enumerated().forEach(body)
+  }
+
+  mutating func remove(_ item: Item) {
+    items.removeAll { $0 == item }
+  }
+
+  mutating func add(_ item: Item) {
+    items.append(item)
+  }
+}

--- a/Maccy/Views/AppImageView.swift
+++ b/Maccy/Views/AppImageView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct AppImageView: View {
+  let appImage: ApplicationImage
+  let size: CGSize
+
+  var body: some View {
+    Image(nsImage: appImage.nsImage)
+      .resizable()
+      .frame(width: size.width, height: size.height)
+  }
+}

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -33,7 +33,6 @@ struct ContentView: View {
       }
       .animation(.default.speed(3), value: appState.history.items)
       .animation(.easeInOut(duration: 0.2), value: appState.searchVisible)
-      .padding(.vertical, Popup.verticalPadding)
       .padding(.horizontal, Popup.horizontalPadding)
       .onAppear {
         searchFocused = true

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -39,7 +39,7 @@ struct ContentView: View {
         searchFocused = true
       }
       .onMouseMove {
-        appState.isKeyboardNavigating = false
+        appState.navigator.isKeyboardNavigating = false
       }
       .task {
         try? await appState.history.load()

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -32,6 +32,7 @@ struct ContentView: View {
         }
       }
       .animation(.default.speed(3), value: appState.history.items)
+      .animation(.default.speed(3), value: appState.history.pasteStack?.id)
       .animation(.easeInOut(duration: 0.2), value: appState.searchVisible)
       .padding(.horizontal, Popup.horizontalPadding)
       .onAppear {

--- a/Maccy/Views/FooterItemView.swift
+++ b/Maccy/Views/FooterItemView.swift
@@ -5,7 +5,7 @@ struct FooterItemView: View {
 
   var body: some View {
     ConfirmationView(item: item) {
-      ListItemView(id: item.id, shortcuts: item.shortcuts, isSelected: item.isSelected) {
+      ListItemView(id: item.id, selectionId: item.id, shortcuts: item.shortcuts, isSelected: item.isSelected) {
         Text(LocalizedStringKey(item.title))
       }
     }

--- a/Maccy/Views/FooterView.swift
+++ b/Maccy/Views/FooterView.swift
@@ -21,8 +21,8 @@ struct FooterView: View {
   var body: some View {
     VStack(spacing: 0) {
       Divider()
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
+        .padding(.horizontal, Popup.horizontalSeparatorPadding)
+        .padding(.bottom, Popup.verticalSeparatorPadding)
 
       ZStack {
         FooterItemView(item: footer.items[0])
@@ -54,15 +54,9 @@ struct FooterView: View {
         FooterItemView(item: item)
       }
     }
-    .background {
-      GeometryReader { geo in
-        Color.clear
-          .task(id: geo.size.height) {
-            appState.popup.footerHeight = geo.size.height
-          }
-      }
-    }
     .opacity(showFooter ? 1 : 0)
     .frame(maxHeight: showFooter ? nil : 0)
+    .padding(.bottom, showFooter ? Popup.verticalPadding : 0)
+    .readHeight(appState, into: \.popup.footerHeight)
   }
 }

--- a/Maccy/Views/FooterView.swift
+++ b/Maccy/Views/FooterView.swift
@@ -37,7 +37,7 @@ struct FooterView: View {
           footer.items[0].isVisible = false
           footer.items[1].isVisible = true
           if appState.footer.selectedItem == footer.items[0] {
-            appState.selection = footer.items[1].id
+            appState.select(footerItem: footer.items[1])
           }
         } else {
           clearOpacity = 1
@@ -45,7 +45,7 @@ struct FooterView: View {
           footer.items[0].isVisible = true
           footer.items[1].isVisible = false
           if appState.footer.selectedItem == footer.items[1] {
-            appState.selection = footer.items[0].id
+            appState.select(footerItem: footer.items[0])
           }
         }
       }

--- a/Maccy/Views/FooterView.swift
+++ b/Maccy/Views/FooterView.swift
@@ -37,7 +37,7 @@ struct FooterView: View {
           footer.items[0].isVisible = false
           footer.items[1].isVisible = true
           if appState.footer.selectedItem == footer.items[0] {
-            appState.select(footerItem: footer.items[1])
+            appState.navigator.select(footerItem: footer.items[1])
           }
         } else {
           clearOpacity = 1
@@ -45,7 +45,7 @@ struct FooterView: View {
           footer.items[0].isVisible = true
           footer.items[1].isVisible = false
           if appState.footer.selectedItem == footer.items[1] {
-            appState.select(footerItem: footer.items[0])
+            appState.navigator.select(footerItem: footer.items[0])
           }
         }
       }

--- a/Maccy/Views/HeaderView.swift
+++ b/Maccy/Views/HeaderView.swift
@@ -34,13 +34,6 @@ struct HeaderView: View {
     // 2px is needed to prevent items from showing behind top pinned items during scrolling
     // https://github.com/p0deje/Maccy/issues/832
     .padding(.bottom, appState.searchVisible ? 5 : 2)
-    .background {
-      GeometryReader { geo in
-        Color.clear
-          .task(id: geo.size.height) {
-            appState.popup.headerHeight = geo.size.height
-          }
-      }
-    }
+    .readHeight(appState, into: \.popup.headerHeight)
   }
 }

--- a/Maccy/Views/HeaderView.swift
+++ b/Maccy/Views/HeaderView.swift
@@ -30,10 +30,11 @@ struct HeaderView: View {
     }
     .frame(height: appState.searchVisible ? Popup.itemHeight + 3 : 0)
     .opacity(appState.searchVisible ? 1 : 0)
-    .padding(.horizontal, 10)
+    .padding(.horizontal, showTitle ? 5 : 0)
     // 2px is needed to prevent items from showing behind top pinned items during scrolling
     // https://github.com/p0deje/Maccy/issues/832
-    .padding(.bottom, appState.searchVisible ? 5 : 2)
+    .padding(.top, appState.searchVisible ? Popup.verticalPadding : Popup.scrollFixPadding)
+    .background(.clear)
     .readHeight(appState, into: \.popup.headerHeight)
   }
 }

--- a/Maccy/Views/HeightReaderModifier.swift
+++ b/Maccy/Views/HeightReaderModifier.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct HeightReaderModifier<State>: ViewModifier {
+  let state: State
+  let keyPath: ReferenceWritableKeyPath<State, CGFloat>
+
+  func body(content: Content) -> some View {
+    content.background(
+      GeometryReader { geo in
+        Color.clear
+          .task(id: geo.size.height) {
+            state[keyPath: keyPath] = geo.size.height
+          }
+      }
+    )
+  }
+}
+
+extension View {
+  func readHeight<State>(
+    _ state: State,
+    into keyPath: ReferenceWritableKeyPath<State, CGFloat>
+  ) -> some View {
+    modifier(HeightReaderModifier(state: state, keyPath: keyPath))
+  }
+}

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -34,6 +34,7 @@ struct HistoryItemView: View {
   var body: some View {
     ListItemView(
       id: item.id,
+      selectionId: item.id,
       appIcon: item.applicationImage,
       image: item.thumbnailImage,
       accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -8,7 +8,7 @@ struct HistoryItemView: View {
   var index: Int
 
   private var visualIndex: Int? {
-    if appState.isMultiSelectInProgress && item.selectionIndex >= 0 {
+    if appState.navigator.isMultiSelectInProgress && item.selectionIndex >= 0 {
       return item.selectionIndex
     }
     return nil
@@ -51,7 +51,7 @@ struct HistoryItemView: View {
     }
     .onTapGesture {
       if NSEvent.modifierFlags.contains(.command) {
-        appState.addToSelection(item: item)
+        appState.navigator.addToSelection(item: item)
       } else {
         Task {
           appState.history.select(item)

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -3,6 +3,31 @@ import SwiftUI
 
 struct HistoryItemView: View {
   @Bindable var item: HistoryItemDecorator
+  var previous: HistoryItemDecorator?
+  var next: HistoryItemDecorator?
+  var index: Int
+
+  private var visualIndex: Int? {
+    if appState.isMultiSelectInProgress && item.selectionIndex >= 0 {
+      return item.selectionIndex
+    }
+    return nil
+  }
+
+  private var selectionAppearance: SelectionAppearance {
+    let previousSelected = previous?.isSelected ?? false
+    let nextSelected = next?.isSelected ?? false
+    switch (previousSelected, nextSelected) {
+    case (true, false):
+      return .topConnection
+    case (false, true):
+      return .bottomConnection
+    case (true, true):
+      return .topBottomConnection
+    default:
+      return .none
+    }
+  }
 
   @Environment(AppState.self) private var appState
 
@@ -14,7 +39,8 @@ struct HistoryItemView: View {
       accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
-      isSelected: item.isSelected
+      isSelected: item.isSelected,
+      selectionAppearance: selectionAppearance
     ) {
       Text(verbatim: item.title)
     }

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -22,7 +22,13 @@ struct HistoryItemView: View {
       item.ensureThumbnailImage()
     }
     .onTapGesture {
-      appState.history.select(item)
+      if NSEvent.modifierFlags.contains(.command) {
+        appState.addToSelection(item: item)
+      } else {
+        Task {
+          appState.history.select(item)
+        }
+      }
     }
     .popover(isPresented: $item.showPreview, arrowEdge: .trailing) {
       PreviewItemView(item: item)

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -41,6 +41,7 @@ struct HistoryItemView: View {
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
       isSelected: item.isSelected,
+      selectionIndex: visualIndex,
       selectionAppearance: selectionAppearance
     ) {
       Text(verbatim: item.title)

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -101,7 +101,7 @@ struct HistoryListView: View {
             HistoryItemDecorator.previewThrottler.minimumDelay = Double(previewDelay) / 1000
             HistoryItemDecorator.previewThrottler.cancel()
             appState.isKeyboardNavigating = true
-            appState.selection = appState.history.unpinnedItems.first?.id ?? appState.history.pinnedItems.first?.id
+            appState.select(item: appState.history.unpinnedItems.first ?? appState.history.pinnedItems.first)
           } else {
             modifierFlags.flags = []
             appState.isKeyboardNavigating = true

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -76,6 +76,7 @@ struct HistoryListView: View {
       }
     }
     .padding(.top, topSeparatorVisible ? topPadding : 0)
+    .readHeight(appState, into: \.popup.extraTopHeight)
 
     ScrollView {
       ScrollViewReader { proxy in
@@ -135,5 +136,6 @@ struct HistoryListView: View {
       }
     }
     .padding(.bottom, bottomSeparatorVisible ? bottomPadding : 0)
+    .readHeight(appState, into: \.popup.extraBottomHeight)
   }
 }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -20,15 +20,22 @@ struct HistoryListView: View {
     appState.history.unpinnedItems.filter(\.isVisible)
   }
   private var showPinsSeparator: Bool {
-    pinsVisible && !unpinnedItems.isEmpty && appState.history.searchQuery.isEmpty
+    pinsVisible && !unpinnedItems.isEmpty
   }
 
   private var pinsVisible: Bool {
     return !pinnedItems.isEmpty
   }
 
+  private var pasteStackVisible: Bool {
+    if let stack = appState.history.pasteStack,
+       !stack.items.isEmpty {
+      return true
+    }
+    return false
+  }
+
   private var topPadding: CGFloat {
-    // TODO Comment
     return appState.searchVisible
       ? Popup.verticalSeparatorPadding
       : (Popup.verticalSeparatorPadding - Popup.scrollFixPadding)
@@ -63,10 +70,19 @@ struct HistoryListView: View {
   var body: some View {
     let topPinsVisible = pinTo == .top && pinsVisible
     let bottomPinsVisible = pinTo == .bottom && pinsVisible
-    let topSeparatorVisible = topPinsVisible
+    let topSeparatorVisible = topPinsVisible || pasteStackVisible
     let bottomSeparatorVisible = bottomPinsVisible
 
     VStack(spacing: 0) {
+      if let stack = appState.history.pasteStack,
+         !stack.items.isEmpty {
+        PasteStackView(stack: stack)
+
+        if topPinsVisible {
+          separator()
+        }
+      }
+
       if topPinsVisible {
         PinsView(items: pinnedItems)
       }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -99,15 +99,15 @@ struct HistoryListView: View {
         MultipleSelectionListView(items: unpinnedItems) { previous, item, next, index in
           HistoryItemView(item: item, previous: previous, next: next, index: index)
         }
-        .task(id: appState.scrollTarget) {
-          guard appState.scrollTarget != nil else { return }
+        .task(id: appState.navigator.scrollTarget) {
+          guard appState.navigator.scrollTarget != nil else { return }
 
           try? await Task.sleep(for: .milliseconds(10))
           guard !Task.isCancelled else { return }
 
-          if let selection = appState.scrollTarget {
+          if let selection = appState.navigator.scrollTarget {
             proxy.scrollTo(selection)
-            appState.scrollTarget = nil
+            appState.navigator.scrollTarget = nil
           }
         }
         .onChange(of: scenePhase) {
@@ -115,11 +115,11 @@ struct HistoryListView: View {
             searchFocused = true
             HistoryItemDecorator.previewThrottler.minimumDelay = Double(previewDelay) / 1000
             HistoryItemDecorator.previewThrottler.cancel()
-            appState.isKeyboardNavigating = true
-            appState.select(item: appState.history.unpinnedItems.first ?? appState.history.pinnedItems.first)
+            appState.navigator.isKeyboardNavigating = true
+            appState.navigator.select(item: appState.history.unpinnedItems.first ?? appState.history.pinnedItems.first)
           } else {
             modifierFlags.flags = []
-            appState.isKeyboardNavigating = true
+            appState.navigator.isKeyboardNavigating = true
           }
         }
         // Calculate the total height inside a scroll view.

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -35,14 +35,7 @@ struct HistoryListView: View {
             .padding(.vertical, 3)
         }
       }
-      .background {
-        GeometryReader { geo in
-          Color.clear
-            .task(id: geo.size.height) {
-              appState.popup.pinnedItemsHeight = geo.size.height
-            }
-        }
-      }
+      .readHeight(appState, into: \.popup.pinnedItemsHeight)
     }
 
     ScrollView {
@@ -105,14 +98,7 @@ struct HistoryListView: View {
           HistoryItemView(item: item)
         }
       }
-      .background {
-        GeometryReader { geo in
-          Color.clear
-            .task(id: geo.size.height) {
-              appState.popup.pinnedItemsHeight = geo.size.height
-            }
-        }
-      }
+      .readHeight(appState, into: \.popup.pinnedItemsHeight)
     }
   }
 }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -79,10 +79,8 @@ struct HistoryListView: View {
 
     ScrollView {
       ScrollViewReader { proxy in
-        LazyVStack(spacing: 0) {
-          ForEach(unpinnedItems) { item in
-            HistoryItemView(item: item)
-          }
+        MultipleSelectionListView(items: unpinnedItems) { previous, item, next, index in
+          HistoryItemView(item: item, previous: previous, next: next, index: index)
         }
         .task(id: appState.scrollTarget) {
           guard appState.scrollTarget != nil else { return }

--- a/Maccy/Views/HoverSelectionModifier.swift
+++ b/Maccy/Views/HoverSelectionModifier.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+private struct HoverSelectionModifier: ViewModifier {
+  @Environment(AppState.self) private var appState
+  var id: UUID
+
+  func body(content: Content) -> some View {
+    content.onHover { hovering in
+      if hovering {
+        if !appState.isKeyboardNavigating && !appState.isMultiSelectInProgress {
+          appState.selectWithoutScrolling(id: id)
+        } else {
+          appState.hoverSelectionWhileKeyboardNavigating = id
+        }
+      }
+    }
+  }
+}
+
+extension View {
+  func hoverSelectionId(_ id: UUID) -> some View {
+    modifier(HoverSelectionModifier(id: id))
+  }
+}

--- a/Maccy/Views/HoverSelectionModifier.swift
+++ b/Maccy/Views/HoverSelectionModifier.swift
@@ -7,10 +7,10 @@ private struct HoverSelectionModifier: ViewModifier {
   func body(content: Content) -> some View {
     content.onHover { hovering in
       if hovering {
-        if !appState.isKeyboardNavigating && !appState.isMultiSelectInProgress {
-          appState.selectWithoutScrolling(id: id)
+        if !appState.navigator.isKeyboardNavigating && !appState.navigator.isMultiSelectInProgress {
+          appState.navigator.selectWithoutScrolling(id: id)
         } else {
-          appState.hoverSelectionWhileKeyboardNavigating = id
+          appState.navigator.hoverSelectionWhileKeyboardNavigating = id
         }
       }
     }

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -56,8 +56,14 @@ struct KeyHandlingView<Content: View>: View {
           searchQuery = ""
           return .handled
         case .deleteCurrentItem:
-          if let leadItem = appState.leadHistoryItem,
-             let item = appState.history.visibleItems.nearest(to: leadItem, where: { !$0.isSelected }) {
+          if appState.pasteStackSelected {
+            appState.history.interruptPasteStack()
+            appState.highlightFirst()
+          } else if let leadItem = appState.leadHistoryItem,
+            let item = appState.history.visibleItems.nearest(
+              to: leadItem,
+              where: { !$0.isSelected }
+            ) {
             withTransaction(Transaction()) {
               appState.history.selection.forEach { _, item in
                 appState.history.delete(item)

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -56,19 +56,19 @@ struct KeyHandlingView<Content: View>: View {
           searchQuery = ""
           return .handled
         case .deleteCurrentItem:
-          if appState.pasteStackSelected {
+          if appState.navigator.pasteStackSelected {
             appState.history.interruptPasteStack()
-            appState.highlightFirst()
-          } else if let leadItem = appState.leadHistoryItem,
+            appState.navigator.highlightFirst()
+          } else if let leadItem = appState.navigator.leadHistoryItem,
             let item = appState.history.visibleItems.nearest(
               to: leadItem,
               where: { !$0.isSelected }
             ) {
             withTransaction(Transaction()) {
-              appState.history.selection.forEach { _, item in
+              appState.navigator.selection.forEach { _, item in
                 appState.history.delete(item)
               }
-              appState.select(item: item)
+              appState.navigator.select(item: item)
             }
           }
           return .handled
@@ -91,59 +91,59 @@ struct KeyHandlingView<Content: View>: View {
             return .ignored
           }
 
-          appState.highlightNext()
+          appState.navigator.highlightNext()
           return .handled
         case .moveToLast:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
 
-          appState.highlightLast()
+          appState.navigator.highlightLast()
           return .handled
         case .moveToPrevious:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
 
-          appState.highlightPrevious()
+          appState.navigator.highlightPrevious()
           return .handled
         case .moveToFirst:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
 
-          appState.highlightFirst()
+          appState.navigator.highlightFirst()
           return .handled
         case .extendToNext:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
-          appState.extendHighlightToNext()
+          appState.navigator.extendHighlightToNext()
           return .handled
         case .extendToLast:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
-          appState.extendHighlightToLast()
+          appState.navigator.extendHighlightToLast()
           return .handled
         case .extendToPrevious:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
-          appState.extendHighlightToPrevious()
+          appState.navigator.extendHighlightToPrevious()
           return .handled
         case .extendToFirst:
           guard NSApp.characterPickerWindow == nil else {
             return .ignored
           }
-          appState.extendHighlightToFirst()
+          appState.navigator.extendHighlightToFirst()
           return .handled
         case .openPreferences:
           appState.openPreferences()
           return .handled
         case .pinOrUnpin:
           withTransaction(Transaction()) {
-            appState.history.selection.forEach { _, item in
+            appState.navigator.selection.forEach { _, item in
               appState.history.togglePin(item)
             }
           }
@@ -159,7 +159,7 @@ struct KeyHandlingView<Content: View>: View {
         }
 
         if let item = appState.history.pressedShortcutItem {
-          appState.select(item: item)
+          appState.navigator.select(item: item)
           Task {
             try? await Task.sleep(for: .milliseconds(50))
             appState.history.select(item)

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -108,6 +108,30 @@ struct KeyHandlingView<Content: View>: View {
 
           appState.highlightFirst()
           return .handled
+        case .extendToNext:
+          guard NSApp.characterPickerWindow == nil else {
+            return .ignored
+          }
+          appState.extendHighlightToNext()
+          return .handled
+        case .extendToLast:
+          guard NSApp.characterPickerWindow == nil else {
+            return .ignored
+          }
+          appState.extendHighlightToLast()
+          return .handled
+        case .extendToPrevious:
+          guard NSApp.characterPickerWindow == nil else {
+            return .ignored
+          }
+          appState.extendHighlightToPrevious()
+          return .handled
+        case .extendToFirst:
+          guard NSApp.characterPickerWindow == nil else {
+            return .ignored
+          }
+          appState.extendHighlightToFirst()
+          return .handled
         case .openPreferences:
           appState.openPreferences()
           return .handled

--- a/Maccy/Views/KeyboardShortcutView.swift
+++ b/Maccy/Views/KeyboardShortcutView.swift
@@ -17,7 +17,9 @@ struct KeyboardShortcutView: View {
 
   var body: some View {
     HStack(spacing: 1) {
-      Text(modifiers).frame(width: 55, alignment: .trailing)
+      ForEach(Array(modifiers.unicodeScalars), id: \.self) { scalar in
+          Text(String(scalar))
+      }
       Text(character).frame(width: 12, alignment: .center)
     }
     .lineLimit(1)

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -51,9 +51,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       if showIcons, let appIcon {
         VStack {
           Spacer(minLength: 0)
-          Image(nsImage: appIcon.nsImage)
-            .resizable()
-            .frame(width: 15, height: 15)
+          AppImageView(appImage: appIcon, size: NSSize(width: 15, height: 15))
           Spacer(minLength: 0)
         }
         .padding(.leading, 4)

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -28,8 +28,9 @@ enum SelectionAppearance {
   }
 }
 
-struct ListItemView<Title: View>: View {
-  var id: UUID
+struct ListItemView<Title: View, ID: Hashable>: View {
+  var id: ID
+  var selectionId: UUID
   var appIcon: ApplicationImage?
   var image: NSImage?
   var accessoryImage: NSImage?
@@ -104,9 +105,9 @@ struct ListItemView<Title: View>: View {
     .onHover { hovering in
       if hovering {
         if !appState.isKeyboardNavigating {
-          appState.selectWithoutScrolling(id: id)
+          appState.selectWithoutScrolling(id: selectionId)
         } else {
-          appState.hoverSelectionWhileKeyboardNavigating = id
+          appState.hoverSelectionWhileKeyboardNavigating = selectionId
         }
       }
     }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -76,7 +76,7 @@ struct ListItemView<Title: View>: View {
     .onHover { hovering in
       if hovering {
         if !appState.isKeyboardNavigating {
-          appState.selectWithoutScrolling(id)
+          appState.selectWithoutScrolling(id: id)
         } else {
           appState.hoverSelectionWhileKeyboardNavigating = id
         }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -37,6 +37,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   var attributedTitle: AttributedString?
   var shortcuts: [KeyShortcut]
   var isSelected: Bool
+  var selectionIndex: Int?
   var help: LocalizedStringKey?
   var selectionAppearance: SelectionAppearance = .none
   @ViewBuilder var title: () -> Title
@@ -81,18 +82,31 @@ struct ListItemView<Title: View, ID: Hashable>: View {
 
       Spacer()
 
-      if !shortcuts.isEmpty {
-        ZStack {
-          ForEach(shortcuts) { shortcut in
-            KeyboardShortcutView(shortcut: shortcut)
-              .opacity(shortcut.isVisible(shortcuts, modifierFlags.flags) ? 1 : 0)
+      HStack(spacing: 5) {
+        if let index = selectionIndex {
+          Text("\(index + 1)")
+            .font(.caption)
+            .frame(minWidth: 10, alignment: .center)
+            .padding(3)
+            .background(
+              Color.secondary.opacity(isSelected ? 0.5 : 0.8),
+              in: Capsule()
+            )
+            .foregroundStyle(Color.white)
+        }
+
+        if !shortcuts.isEmpty {
+          ZStack(alignment: .trailing) {
+            ForEach(shortcuts) { shortcut in
+              let visible = shortcut.isVisible(shortcuts, modifierFlags.flags)
+              KeyboardShortcutView(shortcut: shortcut)
+                .opacity(visible ? 1 : 0)
+                .frame(width: visible ? nil : 0)
+            }
           }
         }
-        .padding(.trailing, 10)
-      } else {
-        Spacer()
-          .frame(width: 50)
       }
+      .padding(.trailing, 10)
     }
     .frame(minHeight: Popup.itemHeight)
     .id(id)

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -102,15 +102,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
     // The slight opcaity white background is a workaround
     .background(isSelected ? Color.accentColor.opacity(0.8) : .white.opacity(0.001))
     .clipShape(selectionAppearance.rect(cornerRadius: Popup.cornerRadius))
-    .onHover { hovering in
-      if hovering {
-        if !appState.isKeyboardNavigating {
-          appState.selectWithoutScrolling(id: selectionId)
-        } else {
-          appState.hoverSelectionWhileKeyboardNavigating = selectionId
-        }
-      }
-    }
+    .hoverSelectionId(selectionId)
     .help(help ?? "")
   }
 }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -1,6 +1,33 @@
 import Defaults
 import SwiftUI
 
+enum SelectionAppearance {
+  case none
+  case topConnection
+  case bottomConnection
+  case topBottomConnection
+
+  func rect(cornerRadius: CGFloat) -> some Shape {
+    var cornerRadii = RectangleCornerRadii()
+    switch self {
+    case .none:
+      cornerRadii.topLeading = cornerRadius
+      cornerRadii.topTrailing = cornerRadius
+      cornerRadii.bottomLeading = cornerRadius
+      cornerRadii.bottomTrailing = cornerRadius
+    case .topConnection:
+      cornerRadii.bottomLeading = cornerRadius
+      cornerRadii.bottomTrailing = cornerRadius
+    case .bottomConnection:
+      cornerRadii.topLeading = cornerRadius
+      cornerRadii.topTrailing = cornerRadius
+    case .topBottomConnection:
+      break
+    }
+    return .rect(cornerRadii: cornerRadii)
+  }
+}
+
 struct ListItemView<Title: View>: View {
   var id: UUID
   var appIcon: ApplicationImage?
@@ -10,6 +37,7 @@ struct ListItemView<Title: View>: View {
   var shortcuts: [KeyShortcut]
   var isSelected: Bool
   var help: LocalizedStringKey?
+  var selectionAppearance: SelectionAppearance = .none
   @ViewBuilder var title: () -> Title
 
   @Default(.showApplicationIcons) private var showIcons
@@ -72,7 +100,7 @@ struct ListItemView<Title: View>: View {
     // macOS 26 broke hovering if no background is present.
     // The slight opcaity white background is a workaround
     .background(isSelected ? Color.accentColor.opacity(0.8) : .white.opacity(0.001))
-    .clipShape(.rect(cornerRadius: Popup.cornerRadius))
+    .clipShape(selectionAppearance.rect(cornerRadius: Popup.cornerRadius))
     .onHover { hovering in
       if hovering {
         if !appState.isKeyboardNavigating {

--- a/Maccy/Views/MultipleSelectionListView.swift
+++ b/Maccy/Views/MultipleSelectionListView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct MultipleSelectionListView<Element, ID, Content>: View
+    where ID: Hashable, Content: View, ID == Element.ID, Element: Identifiable {
+  var items: [Element]
+  var content: (Element?, Element, Element?, Int) -> Content
+
+  var body: some View {
+    LazyVStack(spacing: 0) {
+      ForEach(Array(items.enumerated()), id: \.element.id) { (index, element) in
+        let previous = index > 0 ? items[index - 1] : nil
+        let next = index < items.count - 1 ? items[index + 1] : nil
+        content(previous, element, next, index)
+      }
+    }
+  }
+}

--- a/Maccy/Views/PasteStackItemView.swift
+++ b/Maccy/Views/PasteStackItemView.swift
@@ -31,6 +31,7 @@ struct PasteStackItemView: View {
       attributedTitle: item.attributedTitle,
       shortcuts: [],
       isSelected: isSelected,
+      selectionIndex: index,
       selectionAppearance: .none
     ) {
       Text(verbatim: item.title)

--- a/Maccy/Views/PasteStackItemView.swift
+++ b/Maccy/Views/PasteStackItemView.swift
@@ -1,0 +1,39 @@
+import Defaults
+import SwiftUI
+
+private struct PasteStackId: Hashable {
+  var pasteStackId: UUID
+  var itemId: UUID
+
+  static func == (lhs: PasteStackId, rhs: PasteStackId) -> Bool {
+    return lhs.pasteStackId == rhs.pasteStackId && lhs.itemId == rhs.itemId
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(pasteStackId)
+    hasher.combine(itemId)
+  }
+}
+
+struct PasteStackItemView: View {
+  var stack: PasteStack
+  var item: HistoryItemDecorator
+  var index: Int?
+  var isSelected: Bool
+
+  var body: some View {
+    ListItemView(
+      id: PasteStackId(pasteStackId: stack.id, itemId: item.id),
+      selectionId: stack.id,
+      appIcon: item.applicationImage,
+      image: index != nil ? item.thumbnailImage : nil,
+      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
+      attributedTitle: item.attributedTitle,
+      shortcuts: [],
+      isSelected: isSelected,
+      selectionAppearance: .none
+    ) {
+      Text(verbatim: item.title)
+    }
+  }
+}

--- a/Maccy/Views/PasteStackView.swift
+++ b/Maccy/Views/PasteStackView.swift
@@ -83,7 +83,11 @@ struct PasteStackView: View {
             isSelected: appState.navigator.pasteStackSelected
           )
           .opacity(index > 0 ? 0 : 1)
-          .background(appState.navigator.pasteStackSelected ? Color.accentColor.opacity(0.8) : .clear)
+          .background(
+            appState.navigator.pasteStackSelected
+              ? Color.accentColor.opacity(0.8)
+              : Color(nsColor: .tertiarySystemFill).opacity(0.8)
+          )
           .background(.thinMaterial)
           .clipShape(SelectionAppearance.none.rect(cornerRadius: Popup.cornerRadius))
           .shadow(

--- a/Maccy/Views/PasteStackView.swift
+++ b/Maccy/Views/PasteStackView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct CollapsedStackItem<Content: View>: View {
+  let maxItems: Int
+  let index: Int
+  let open: Bool
+
+  @State var height: CGFloat = -1
+  var content: () -> Content
+
+  private var offset: Double {
+    if open || index == 0 {
+      return 0
+    }
+    if index + 1 > maxItems {
+      return -height
+    }
+    return -height * 0.75
+  }
+
+  private var scale: Double {
+    if open {
+      return 1
+    }
+    return pow(0.98, Double(index))
+  }
+
+  private var opacity: Double {
+    if open {
+      return 1
+    }
+    if index + 1 > maxItems {
+      return 0
+    }
+    return pow(0.95, Double(index))
+  }
+
+  var body: some View {
+    content()
+      .background(
+        GeometryReader { geo in
+          Color.clear
+            .task(id: geo.size.height) {
+              DispatchQueue.main.async {
+                height = geo.size.height
+              }
+            }
+        }
+      )
+      .offset(y: offset)
+      .padding(.bottom, offset)
+      .opacity(opacity)
+      .scaleEffect(scale, anchor: .center)
+      .zIndex(Double(-index))
+  }
+}
+
+struct PasteStackView: View {
+  var stack: PasteStack
+  var open: Bool = false
+
+  @Environment(AppState.self) private var appState
+
+  private func indexTagFor(_ index: Int) -> Int? {
+    if open {
+      return index
+    }
+    if index == 0 {
+      return stack.items.count - 1
+    }
+    return nil
+  }
+
+  var body: some View {
+    let maxItems = min(3, stack.items.count)
+    LazyVStack(spacing: 0) {
+      ForEach(Array(stack.items[..<maxItems].enumerated()), id: \.element.id) { (index, element) in
+        CollapsedStackItem(maxItems: maxItems, index: index, open: open) {
+          PasteStackItemView(
+            stack: self.stack,
+            item: element,
+            index: indexTagFor(index),
+            isSelected: appState.pasteStackSelected
+          )
+          .opacity(index > 0 ? 0 : 1)
+          .background(appState.pasteStackSelected ? Color.accentColor.opacity(0.8) : .clear)
+          .background(.thinMaterial)
+          .clipShape(SelectionAppearance.none.rect(cornerRadius: Popup.cornerRadius))
+          .shadow(
+            color: Color(.sRGBLinear, white: 0, opacity: open ? 0 : 0.1),
+            radius: 2,
+            y: 2
+          )
+        }
+      }
+    }
+    .onHover { hovering in
+      if hovering {
+        if !appState.isKeyboardNavigating {
+          appState.selectWithoutScrolling(id: stack.id)
+        } else {
+          appState.hoverSelectionWhileKeyboardNavigating = stack.id
+        }
+      }
+    }
+  }
+}

--- a/Maccy/Views/PasteStackView.swift
+++ b/Maccy/Views/PasteStackView.swift
@@ -94,14 +94,6 @@ struct PasteStackView: View {
         }
       }
     }
-    .onHover { hovering in
-      if hovering {
-        if !appState.isKeyboardNavigating {
-          appState.selectWithoutScrolling(id: stack.id)
-        } else {
-          appState.hoverSelectionWhileKeyboardNavigating = stack.id
-        }
-      }
-    }
+    .hoverSelectionId(stack.id)
   }
 }

--- a/Maccy/Views/PasteStackView.swift
+++ b/Maccy/Views/PasteStackView.swift
@@ -80,10 +80,10 @@ struct PasteStackView: View {
             stack: self.stack,
             item: element,
             index: indexTagFor(index),
-            isSelected: appState.pasteStackSelected
+            isSelected: appState.navigator.pasteStackSelected
           )
           .opacity(index > 0 ? 0 : 1)
-          .background(appState.pasteStackSelected ? Color.accentColor.opacity(0.8) : .clear)
+          .background(appState.navigator.pasteStackSelected ? Color.accentColor.opacity(0.8) : .clear)
           .background(.thinMaterial)
           .clipShape(SelectionAppearance.none.rect(cornerRadius: Popup.cornerRadius))
           .shadow(

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct PinsView: View {
+  @Environment(AppState.self) private var appState
+
+  var items: [HistoryItemDecorator]
+
+  var body: some View {
+    LazyVStack(spacing: 0) {
+      ForEach(items) { item in
+        HistoryItemView(item: item)
+      }
+    }
+    .readHeight(appState, into: \.popup.pinnedItemsHeight)
+  }
+}

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -9,6 +9,5 @@ struct PinsView: View {
     MultipleSelectionListView(items: items) { previous, item, next, index in
       HistoryItemView(item: item, previous: previous, next: next, index: index)
     }
-    .readHeight(appState, into: \.popup.pinnedItemsHeight)
   }
 }

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -6,10 +6,8 @@ struct PinsView: View {
   var items: [HistoryItemDecorator]
 
   var body: some View {
-    LazyVStack(spacing: 0) {
-      ForEach(items) { item in
-        HistoryItemView(item: item)
-      }
+    MultipleSelectionListView(items: items) { previous, item, next, index in
+      HistoryItemView(item: item, previous: previous, next: next, index: index)
     }
     .readHeight(appState, into: \.popup.pinnedItemsHeight)
   }

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -27,9 +27,7 @@ struct PreviewItemView: View {
         if let application = item.application {
           HStack(spacing: 3) {
             Text("Application", tableName: "PreviewItemView")
-            Image(nsImage: item.applicationImage.nsImage)
-              .resizable()
-              .frame(width: 11, height: 11)
+            AppImageView(appImage: item.applicationImage, size: NSSize(width: 11, height: 11))
             Text(application)
           }
         }


### PR DESCRIPTION
This is an implementation of the paste stack proposed in https://github.com/p0deje/Maccy/issues/1175#issuecomment-3179700597.

The basis for this is an added multiple selection functionality. To select multiple items one can either use one of the following keyboard shortcuts
- `SHIFT + DownArrow`/`CTRL + SHIFT + n`: Extend the selection to the next item
- `SHIFT + CMD/Option + DownArrow`/`CONTR + OPTION + SHIFT + n`: Extend the selection to the last item
- `SHIFT + UpArrow`/`CTRL + SHIFT + p`: Extend the selection to the previous item
- `SHIFT + CMD/Option + UpArrow`/`CONTR + OPTION + SHIFT + p`: Extend the selection to the first item 

or `CMD + Click` with the mouse to select additional items.

The order they are selected in is displayed next to the item content.
Once more than one item is selected moving the mouse over other items no longer auto selects the item as this would make mouse selection impossible and make accidentally clearing the whole selection to easy.

Pinning and deleting multiple items works as expected.

One can then use any of the existing shortcuts to create a **paste stack**.
This immediately copies the first selected item to the clipboard ready to paste. Once the item has been pasted it is removed from the top of the paste stack and the next item is automatically copied to the clipboard. The paste stack remembers the shortcut used to create the stack i.e. if the "copy without formatting" shortcut was used then all subsequent copies will also be copied without formatting.

Note that the "paste automatically" option does not work with paste stacks. Pasting always has to be initiated by the user.
I did not manage to listen for `CMD + V` using the carbon api without the shortcut being consumed (with the result that pasting becomes impossible). This feature therefore requires accessibility permissions as it globally listens for `CMD+V` key presses. 

The current paste stack is displayed at the top of the history list. The number displays the current number of items in the stack.

<img width="381" height="417" alt="SCR-20250915-jwmx" src="https://github.com/user-attachments/assets/cb85512f-9b4c-41f7-870c-4df4d2aa12aa" />

Here is a video of the behaviour in action. The visuals are slightly outdated but the user interaction hasn't changed since:

https://github.com/user-attachments/assets/e2d0478f-f0b5-4150-9cec-1ba90f4f4f45

It can be selected like any other entry. To discard the current paste stack simply delete it using `OPTION + Backspace`.

If any other copy happens while the paste stack is active (either through Maccy or otherwise) the stack is discarded. Feedback on this would be welcome as I had no better idea what the behaviour should be in this case.

The paste stack does not reorder any items in the history list on its own. The items get moved to the start of the list just as if they were copied regularly. After pasting all items of the stack this effectively puts the items of the paste stack at the start of the history list in reverse oder (Assuming sorting by time of last copy).

I have tried to group the changes into logical steps. Every commit should compile on its own, but there may be things included in some changes, which are only used in a later commit.

Relates to #1175 #239