### PR TITLE
Update menu shortcut to Cmd+Shift+V and add iTerm image paste support

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -112,9 +112,19 @@ class Clipboard {
   func paste() {
     Accessibility.check()
 
+    // Check if destination app is iTerm and clipboard contains an image
+    let destinationApp = NSWorkspace.shared.frontmostApplication
+    let isIterm = destinationApp?.bundleIdentifier == "com.googlecode.iterm2"
+    let imageTypes: Set<NSPasteboard.PasteboardType> = [.png, .tiff, .jpeg, .heic]
+    let pasteboardTypes = Set(pasteboard.types ?? [])
+    let hasImage = !imageTypes.isDisjoint(with: pasteboardTypes)
+
+    // Use Control modifier for iTerm with images, otherwise use Command
+    let pasteModifiers: NSEvent.ModifierFlags = (isIterm && hasImage) ? .control : KeyChord.pasteKeyModifiers
+
     // Add flag that left/right modifier key has been pressed.
     // See https://github.com/TermiT/Flycut/pull/18 for details.
-    let cmdFlag = CGEventFlags(rawValue: UInt64(KeyChord.pasteKeyModifiers.rawValue) | 0x000008)
+    let cmdFlag = CGEventFlags(rawValue: UInt64(pasteModifiers.rawValue) | 0x000008)
     var vCode = Sauce.shared.keyCode(for: KeyChord.pasteKey)
 
     // Force QWERTY keycode when keyboard layout switches to

--- a/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
+++ b/Maccy/Extensions/KeyboardShortcuts.Name+Shortcuts.swift
@@ -1,7 +1,7 @@
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
-  static let popup = Self("popup", default: Shortcut(.c, modifiers: [.command, .shift]))
+  static let popup = Self("popup", default: Shortcut(.v, modifiers: [.command, .shift]))
   static let pin = Self("pin", default: Shortcut(.p, modifiers: [.option]))
   static let delete = Self("delete", default: Shortcut(.delete, modifiers: [.option]))
 }


### PR DESCRIPTION
- Changed default menu popup shortcut from Cmd+Shift+C to Cmd+Shift+V
- Added smart paste detection for iTerm2: when pasting images into iTerm, automatically uses Ctrl+V instead of Cmd+V to ensure proper image handling
- The paste logic now detects the destination app and clipboard content type to determine the appropriate keyboard modifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)