### PR TITLE
Add Pinned Management Section and UI Polish

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		DAEE38471E3DBEB100DD2966 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEE38461E3DBEB100DD2966 /* AppDelegate.swift */; };
 		DAFE2DDA268A521B00990986 /* String+Shortened.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DD9268A521A00990986 /* String+Shortened.swift */; };
 		DAFE2DE9268A9B1B00990986 /* HistoryItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */; };
+		DAFED0C22D5E0A5B00ABCDEF /* PinnedSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFED0C12D5E0A5B00ABCDEF /* PinnedSectionView.swift */; };
 		DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */; };
 /* End PBXBuildFile section */
 
@@ -517,6 +518,7 @@
 		DAF750022C517B400027DBCE /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/StorageSettings.strings"; sourceTree = "<group>"; };
 		DAFE2DD9268A521A00990986 /* String+Shortened.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Shortened.swift"; sourceTree = "<group>"; };
 		DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemTests.swift; sourceTree = "<group>"; };
+		DAFED0C12D5E0A5B00ABCDEF /* PinnedSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedSectionView.swift; sourceTree = "<group>"; };
 		DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardShortcuts.Name+Shortcuts.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -648,6 +650,7 @@
 				DA1969132C3F11D600258481 /* PreviewItemView.swift */,
 				DA1969172C3F327500258481 /* SearchFieldView.swift */,
 				DAA072D02C4089D3006DDFD2 /* VisualEffectView.swift */,
+				DAFED0C12D5E0A5B00ABCDEF /* PinnedSectionView.swift */,
 				DA555F112CF155A2009608BD /* WrappingTextView.swift */,
 			);
 			path = Views;
@@ -1102,6 +1105,7 @@
 				DA3BCB942C3EECBB00B01BC1 /* HistoryItemDecorator.swift in Sources */,
 				DAE28500232257D20080E394 /* ColorImage.swift in Sources */,
 				DA7A753E26A52F0F00DC16EF /* NSImage+Names.swift in Sources */,
+				DAFED0C22D5E0A5B00ABCDEF /* PinnedSectionView.swift in Sources */,
 				DA20FA782B082E1A00056DD5 /* NSSound+Named.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1663,7 +1667,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = VN2LG9M3Z8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1698,7 +1702,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 58;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = VN2LG9M3Z8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -58,4 +58,5 @@ extension Defaults.Keys {
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
   static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: false)
+  static let pinnedOrder = Key<[String]>("pinnedOrder", default: [])
 }

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -11,6 +11,8 @@ class AppState: Sendable {
   var popup: Popup
   var history: History
   var footer: Footer
+  // 管理固定区域的开关（弹出面板顶部“Pinned”区域的“管理”模式）
+  var pinnedManageMode: Bool = false
 
   var scrollTarget: UUID?
   var selection: UUID? {

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -5,24 +5,46 @@ struct HistoryItemView: View {
   @Bindable var item: HistoryItemDecorator
 
   @Environment(AppState.self) private var appState
+  @State private var isHovering: Bool = false
 
   var body: some View {
-    ListItemView(
-      id: item.id,
-      appIcon: item.applicationImage,
-      image: item.thumbnailImage,
-      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
-      attributedTitle: item.attributedTitle,
-      shortcuts: item.shortcuts,
-      isSelected: item.isSelected
-    ) {
-      Text(verbatim: item.title)
+    ZStack(alignment: .trailing) {
+      ListItemView(
+        id: item.id,
+        appIcon: item.applicationImage,
+        image: item.thumbnailImage,
+        accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
+        attributedTitle: item.attributedTitle,
+        shortcuts: item.shortcuts,
+        isSelected: item.isSelected
+      ) {
+        Text(verbatim: item.title)
+      }
+
+      if item.isUnpinned {
+        HStack(spacing: 6) {
+          // Pin quick action
+          Button(action: { appState.history.togglePin(item) }) {
+            Image(systemName: "pin")
+          }
+          .help("Pin")
+          .buttonStyle(.borderless)
+          .controlSize(.small)
+
+          // Separator only if numeric shortcuts are present (first 9 visible unpinned items)
+          if !item.shortcuts.isEmpty {
+            Rectangle()
+              .frame(width: 1, height: 14)
+              .foregroundStyle(.separator)
+              .padding(.leading, 4)
+          }
+        }
+        .opacity(isHovering ? 1 : 0)
+        .padding(.trailing, 50) // leave room for shortcut badges on the far right
+      }
     }
-    .onTapGesture {
-      appState.history.select(item)
-    }
-    .popover(isPresented: $item.showPreview, arrowEdge: .trailing) {
-      PreviewItemView(item: item)
-    }
+    .onTapGesture { appState.history.select(item) }
+    .onHover { hovering in isHovering = hovering }
+    .popover(isPresented: $item.showPreview, arrowEdge: .trailing) { PreviewItemView(item: item) }
   }
 }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -24,25 +24,7 @@ struct HistoryListView: View {
 
   var body: some View {
     if pinTo == .top {
-      LazyVStack(spacing: 0) {
-        ForEach(pinnedItems) { item in
-          HistoryItemView(item: item)
-        }
-
-        if showPinsSeparator {
-          Divider()
-            .padding(.horizontal, 10)
-            .padding(.vertical, 3)
-        }
-      }
-      .background {
-        GeometryReader { geo in
-          Color.clear
-            .task(id: geo.size.height) {
-              appState.popup.pinnedItemsHeight = geo.size.height
-            }
-        }
-      }
+      PinnedSectionView()
     }
 
     ScrollView {

--- a/Maccy/Views/PinnedSectionView.swift
+++ b/Maccy/Views/PinnedSectionView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct PinnedSectionView: View {
+  @Environment(AppState.self) private var appState
+
+  private var pinnedItems: [HistoryItemDecorator] {
+    appState.history.pinnedItems.filter(\.isVisible)
+  }
+  private var unpinnedItemsVisible: [HistoryItemDecorator] {
+    appState.history.unpinnedItems.filter(\.isVisible)
+  }
+  private var showPinsSeparator: Bool {
+    !pinnedItems.isEmpty && !unpinnedItemsVisible.isEmpty && appState.history.searchQuery.isEmpty
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      // Header
+      HStack {
+        Text("Pinned")
+          .foregroundStyle(.secondary)
+        Spacer()
+        Button(appState.pinnedManageMode ? "Done" : "Manage") {
+          appState.pinnedManageMode.toggle()
+        }
+        .controlSize(.small)
+        .buttonStyle(.link)
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 4)
+      .background(.clear)
+
+      // Pinned items content
+      LazyVStack(spacing: 0) {
+        ForEach(pinnedItems) { item in
+          if appState.pinnedManageMode {
+            PinnedManageRow(item: item)
+          } else {
+            HistoryItemView(item: item)
+          }
+        }
+
+        if showPinsSeparator {
+          Divider()
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+        }
+      }
+    }
+    .background {
+      GeometryReader { geo in
+        Color.clear
+          .task(id: geo.size.height) {
+            appState.popup.pinnedItemsHeight = geo.size.height
+          }
+      }
+    }
+  }
+}
+
+struct PinnedManageRow: View {
+  @Bindable var item: HistoryItemDecorator
+  @Environment(AppState.self) private var appState
+
+  var body: some View {
+    ZStack(alignment: .trailing) {
+      HistoryItemView(item: item)
+
+      HStack(spacing: 6) {
+        Button(action: { moveUp() }) {
+          Image(systemName: "chevron.up")
+        }
+        .help("Move Up")
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+
+        Button(action: { moveDown() }) {
+          Image(systemName: "chevron.down")
+        }
+        .help("Move Down")
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+
+        Button(action: { unpin() }) {
+          Image(systemName: "pin.slash")
+        }
+        .help("Unpin")
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+      }
+      .padding(.trailing, 60)
+    }
+  }
+
+  private func unpin() {
+    appState.history.togglePin(item)
+  }
+
+  private func moveUp() {
+    Task { @MainActor in
+      appState.history.movePinnedUp(item)
+    }
+  }
+
+  private func moveDown() {
+    Task { @MainActor in
+      appState.history.movePinnedDown(item)
+    }
+  }
+}


### PR DESCRIPTION
<img width="990" height="402" alt="image" src="https://github.com/user-attachments/assets/d6dae16c-dfcb-46e5-99ec-25675fdd142a" />
**Motivation**
Pinned items are a user's curated shortlist. Giving them a dedicated area and an easy way to reorder or unpin them makes day-to-day use faster and more intuitive. Persisting the pinned order removes the frustration of reordering after every app relaunch. The UI tweaks keep the numeric shortcut badges readable and add a convenient Pin action to normal history items without cluttering the interface.
**Changes**

- New PinnedSectionView at the top of the popup:

Shows a "Pinned" header with a "Manage"/"Done" toggle.
In manage mode, each pinned item exposes "Unpin" and "Move Up"/"Move Down" controls.
Adds a divider between pinned and unpinned lists when there’s no search query and both sections are present.

- Stable pinned order persistence:

Defaults.pinnedOrder stores the user-defined pin order.
Sorter.sort now respects Defaults.pinnedOrder when assembling the list, honoring the user's pins position preference.
History.togglePin updates Defaults.pinnedOrder on pin/unpin actions; History.movePinnedUp/Down adjusts the order and persists it.

- UI Refinements:

Increased the trailing padding of pinned item management controls to prevent them from overlapping with the right-side shortcut badges.
Added a hover-only quick "Pin" button on the right side of unpinned items.
When numeric shortcut badges are present, a thin separator is inserted to visually distinguish them from the new "Pin" action.

