### PR TITLE
Fix window not growing automatically when history items are added 

### DIFF
--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -55,7 +55,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
         .ignoresSafeArea()
         .gesture(DragGesture()
           .onEnded { _ in
-            self.saveWindowFrame(frame: self.frame)
+            self.saveWindowPosition()
         })
     )
   }
@@ -95,14 +95,17 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     }
   }
 
-  func saveWindowFrame(frame: NSRect) {
-    Defaults[.windowSize] = frame.size
-
+  func saveWindowPosition() {
     if let screenFrame = screen?.visibleFrame {
       let anchorX = frame.minX + frame.width / 2 - screenFrame.minX
       let anchorY = frame.maxY - screenFrame.minY
       Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
     }
+  }
+
+  func saveWindowFrame(frame: NSRect) {
+    Defaults[.windowSize] = frame.size
+    saveWindowPosition()
   }
 
   func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {


### PR DESCRIPTION
### Problem
Users reported that the Maccy window stays stuck at a small size even as more items are added to the clipboard history. They only see a few items and have to manually resize the window to see more, even though they never manually resized it smaller in the first place.

### Root Cause
When users repositioned the Maccy window by dragging it, the `DragGesture.onEnded` handler was calling `saveWindowFrame()`, which saved both the window position and size to user defaults.
If the window was dragged while it was small (e.g., when there were only a few history items), this inadvertently saved the small size as the user's preference. Future automatic content-based resizes were then capped at this accidentally-saved small size due to the `min()` constraint in `verticallyResize()`.

### Sequence:
1. User opens Maccy with 3 items → window is 150px tall
2. User drags window to reposition it → saves 150px height to defaults
3. User copies 50 more items → auto-resize tries to grow to 500px
4. `min(500, 150) = 150` → window stays stuck at 150px

### Solution
- Separated window position saving from window size saving:
- Created `saveWindowPosition()` method that only saves the window position
- Updated `saveWindowFrame()` to save size and delegate position saving to `saveWindowPosition()`
- Changed `DragGesture` handler to call `saveWindowPosition()` instead of `saveWindowFrame()`