### PR TITLE
Fix flashing beam cursor at top of popup

### DIFF
--- a/Maccy/Views/HeaderView.swift
+++ b/Maccy/Views/HeaderView.swift
@@ -25,6 +25,8 @@ struct HeaderView: View {
             searchQuery = ""
           }
         }
+        // Only reliable way to disable the cursor. allowsHitTesting() does not work
+        .offset(y: appState.searchVisible ? 0 : -Popup.itemHeight)
     }
     .frame(height: appState.searchVisible ? Popup.itemHeight + 3 : 0)
     .opacity(appState.searchVisible ? 1 : 0)


### PR DESCRIPTION
With the search bar hidden the text beam cursor would appear when hovering at the top of the window.