### PR TITLE
Add side-by-side preview panel

### DIFF
--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -25,16 +25,13 @@ class HistoryItemDecorator: Identifiable, Hashable {
       if isSelected {
         Self.previewThrottler.throttle {
           Self.previewThrottler.minimumDelay = 0.2
-          self.showPreview = true
         }
       } else {
         Self.previewThrottler.cancel()
-        self.showPreview = false
       }
     }
   }
   var shortcuts: [KeyShortcut] = []
-  var showPreview: Bool = false
 
   var application: String? {
     if item.universalClipboard {

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -24,11 +24,5 @@ struct HistoryItemView: View {
     .onTapGesture {
       appState.history.select(item)
     }
-    .popover(isPresented: $item.showPreview, arrowEdge: .trailing) {
-      PreviewItemView(item: item)
-        .onAppear {
-          item.ensurePreviewImage()
-        }
-    }
   }
 }

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -2,72 +2,35 @@ import KeyboardShortcuts
 import SwiftUI
 
 struct PreviewItemView: View {
-  weak var item: HistoryItemDecorator?
+  @Bindable var item: HistoryItemDecorator
 
   var body: some View {
-    if let item = item {
-      VStack(alignment: .leading, spacing: 0) {
+    VStack(alignment: .leading, spacing: 0) {
+      if item.item.image != nil {
         if let image = item.previewImage {
           Image(nsImage: image)
             .resizable()
             .aspectRatio(contentMode: .fit)
+            .frame(maxWidth: .infinity)
             .clipShape(.rect(cornerRadius: 5))
         } else {
-          ScrollView {
-            WrappingTextView {
-              Text(item.text)
-                .font(.body)
-            }
-          }
+          ProgressView()
+            .frame(maxWidth: .infinity, minHeight: 200)
         }
-
-        Divider()
-          .padding(.vertical)
-
-        if let application = item.application {
-          HStack(spacing: 3) {
-            Text("Application", tableName: "PreviewItemView")
-            Image(nsImage: item.applicationImage.nsImage)
-              .resizable()
-              .frame(width: 11, height: 11)
-            Text(application)
-          }
-        }
-
-        HStack(spacing: 3) {
-          Text("FirstCopyTime", tableName: "PreviewItemView")
-          Text(item.item.firstCopiedAt, style: .date)
-          Text(item.item.firstCopiedAt, style: .time)
-        }
-
-        HStack(spacing: 3) {
-          Text("LastCopyTime", tableName: "PreviewItemView")
-          Text(item.item.lastCopiedAt, style: .date)
-          Text(item.item.lastCopiedAt, style: .time)
-        }
-
-        HStack(spacing: 3) {
-          Text("NumberOfCopies", tableName: "PreviewItemView")
-          Text(String(item.item.numberOfCopies))
-        }
-        .padding(.bottom)
-
-        if let pinKey = KeyboardShortcuts.Shortcut(name: .pin) {
-          Text(
-            NSLocalizedString("PinKey", tableName: "PreviewItemView", comment: "")
-              .replacingOccurrences(of: "{pinKey}", with: pinKey.description)
-          )
-        }
-
-        if let deleteKey = KeyboardShortcuts.Shortcut(name: .delete) {
-          Text(
-            NSLocalizedString("DeleteKey", tableName: "PreviewItemView", comment: "")
-              .replacingOccurrences(of: "{deleteKey}", with: deleteKey.description)
-          )
-        }
+      } else {
+        Text(item.text)
+          .font(.body)
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .topLeading)
       }
-      .controlSize(.small)
-      .padding()
+    }
+    .controlSize(.small)
+    .padding()
+    .frame(maxWidth: .infinity, alignment: .topLeading)
+    .task(id: item.id) {
+      await MainActor.run {
+        item.ensurePreviewImage()
+      }
     }
   }
 }


### PR DESCRIPTION
# Add side-by-side preview panel

## Summary

This PR refactors the preview functionality from a popover to a side-by-side panel layout, providing a more persistent and accessible preview experience. 

<img width="844" alt="Screenshot 2025-06-15 at 08 01 27" src="https://github.com/user-attachments/assets/c69fb6e9-11e2-41c1-8508-932e8157fed4" />

_Originally posted by @p0deje in https://github.com/p0deje/Maccy/issues/1114#issuecomment-2974028258_

## Changes

- **ContentView.swift**: 
  - Replaced single-column layout with a two-column HStack layout
  - Added a preview panel on the right side that displays selected item details
  - Moved metadata (application, copy times, number of copies) and keyboard shortcuts to a footer section in the preview panel

- **HistoryItemView.swift**:
  - Removed popover-based preview functionality

- **PreviewItemView.swift**:
  - Simplified the view to focus on content display (images or text)
  - Changed from optional weak reference to required `@Bindable` property
  - Removed metadata display (moved to footer in ContentView)

## Benefits

- **Better UX**: Preview is always visible when an item is selected, eliminating the need to wait for a popover
- **More space**: Side-by-side layout provides more room for previewing content
- **Consistent layout**: Preview panel aligns with the main list structure
- **Improved accessibility**: Metadata and shortcuts are always visible in the preview footer

## Technical Details

- Uses `HStack` with `.layoutPriority(1)` for equal-width distribution
- ScrollView in preview panel with proper layout constraints
- Maintains original code style and formatting conventions
- All text uses localization strings (no hardcoded text)

## Testing

- [x] Preview displays correctly when item is selected
- [x] Images load and display properly
- [x] Text content is scrollable
- [x] Metadata footer shows correct information
- [x] Keyboard shortcuts display correctly
- [x] Layout works with different window sizes
- [x] No constraint conflicts or layout errors

## Screenshots

_Add screenshots here if available_

## Related Issues

_Link to any related issues or feature requests_

