### PR TITLE
Fix typo in Spanish localization for LaunchAtLogin

### DIFF
--- a/Maccy/Settings/es.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/es.lproj/GeneralSettings.strings
@@ -1,5 +1,5 @@
 "Title" = "General";
-"LaunchAtLogin" = "Abrir al inciar sesión";
+"LaunchAtLogin" = "Abrir al iniciar sesión";
 "CheckForUpdates" = "Buscar actualizaciones automáticamente";
 "CheckNow" = "Comprobar ahora";
 "Open" = "Abrir:";


### PR DESCRIPTION
I’d also replace “Buscar:” with “Búsqueda:”, which is a better fit here.