### PR TITLE
Update license year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Alex Rodionov
+Copyright (c) 2026 Alex Rodionov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I have updated the outdated `LICENSE` file by changing the year to 2026, which was originally 2025.