### PR TITLE
Add item editing functionality and project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+## Project Overview
+Maccy is a lightweight, keyboard-first clipboard manager for macOS, written in Swift 5 using SwiftUI and AppKit. Targets macOS 14.0 (Sonoma)+. Licensed under MIT.
+
+## Build & Test
+- **Build:** Open `Maccy.xcodeproj` in Xcode and build the `Maccy` scheme, or use `xcodebuild -scheme Maccy build`
+- **Test:** `xcodebuild -scheme Maccy test` (uses `Maccy.xctestplan`; note: HistoryTests are currently skipped)
+- No Package.swift or Makefile; dependencies are managed directly in the Xcode project
+
+## Project Structure
+- `Maccy/` — Main source (~96 Swift files)
+  - `Models/` — Core Data models (HistoryItem)
+  - `Observables/` — State management (AppState, History, Popup, Footer)
+  - `Extensions/` — Swift extensions (`NSImage+Resized.swift`, etc.)
+  - `Intents/` — Siri Shortcuts / AppIntents
+  - `History.xcdatamodeld/` — Core Data schema
+  - `*.lproj/` — Localizations (16+ languages)
+  - `AppDelegate.swift` — App entry point
+  - `Clipboard.swift` — Clipboard monitoring
+  - `Search.swift` — Search modes (exact, fuzzy, regex, mixed)
+- `MaccyTests/` — Unit tests
+- `MaccyUITests/` — UI tests
+
+## Code Style & Conventions
+- Swift naming conventions (CamelCase types, camelCase members)
+- Extension files use `TypeName+Feature.swift` naming
+- Observer pattern with `AppState`; singletons like `Clipboard.shared`
+- **SwiftLint** (`.swiftlint.yml`): disabled rules — `multiple_closures_with_trailing_closure`, `non_optional_string_data_conversion`, `todo`; line length ignores comments
+
+## Linting & Tools
+- **SwiftLint** — code style enforcement
+- **Periphery** (`.periphery.yml`) — dead code detection (retains ObjC-accessible symbols)
+- **Bartycrouch** (`.bartycrouch.toml`) — localization sync and translation via DeepL

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -31,6 +31,7 @@ enum KeyChord: CaseIterable {
   case openPreferences
   case pinOrUnpin
   case selectCurrentItem
+  case editCurrentItem
   case close
   case unknown
 
@@ -95,6 +96,8 @@ enum KeyChord: CaseIterable {
       self = .moveToFirst
     case (KeyChord.pinKey, KeyChord.pinModifiers):
       self = .pinOrUnpin
+    case (.e, [.command]):
+      self = .editCurrentItem
     case (.comma, [.command]):
       self = .openPreferences
     case (.return, _),

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -335,6 +335,73 @@ class History { // swiftlint:disable:this type_body_length
   }
 
   @MainActor
+  func startEditing(_ item: HistoryItemDecorator?) {
+    guard let item, item.item.text != nil else { return }
+    item.editingText = item.item.text ?? item.title
+    item.isEditing = true
+  }
+
+  @MainActor
+  func saveEditing(_ item: HistoryItemDecorator?) {
+    guard let item, item.isEditing else { return }
+    item.isEditing = false
+
+    let newText = item.editingText
+    guard !newText.isEmpty else {
+      delete(item)
+      return
+    }
+
+    // Update the string content
+    if let content = item.item.contents.first(where: { $0.type == NSPasteboard.PasteboardType.string.rawValue }) {
+      content.value = newText.data(using: .utf8)
+    } else {
+      let content = HistoryItemContent(type: NSPasteboard.PasteboardType.string.rawValue, value: newText.data(using: .utf8))
+      item.item.contents.append(content)
+    }
+
+    item.item.title = item.item.generateTitle()
+    item.title = item.item.title
+
+    Storage.shared.context.processPendingChanges()
+    try? Storage.shared.context.save()
+  }
+
+  @MainActor
+  func cancelEditing(_ item: HistoryItemDecorator?) {
+    guard let item, item.isEditing else { return }
+    item.isEditing = false
+    item.editingText = ""
+    // If the item has no title (newly created), delete it
+    if item.item.title.isEmpty && (item.item.text ?? "").isEmpty {
+      delete(item)
+    }
+  }
+
+  @discardableResult
+  @MainActor
+  func addNew() -> HistoryItemDecorator {
+    let content = HistoryItemContent(
+      type: NSPasteboard.PasteboardType.string.rawValue,
+      value: "".data(using: .utf8)
+    )
+    let historyItem = HistoryItem(contents: [content])
+    historyItem.application = Bundle.main.bundleIdentifier
+    historyItem.title = ""
+
+    if #unavailable(macOS 15.0) {
+      try? insertIntoStorage(historyItem)
+    }
+
+    let decorator = add(historyItem)
+    decorator.editingText = ""
+    decorator.isEditing = true
+
+    AppState.shared.selection = decorator.id
+    return decorator
+  }
+
+  @MainActor
   func togglePin(_ item: HistoryItemDecorator?) {
     guard let item else { return }
 

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -35,6 +35,8 @@ class HistoryItemDecorator: Identifiable, Hashable {
   }
   var shortcuts: [KeyShortcut] = []
   var showPreview: Bool = false
+  var isEditing: Bool = false
+  var editingText: String = ""
 
   var application: String? {
     if item.universalClipboard {

--- a/Maccy/Views/HeaderView.swift
+++ b/Maccy/Views/HeaderView.swift
@@ -27,6 +27,15 @@ struct HeaderView: View {
         }
         // Only reliable way to disable the cursor. allowsHitTesting() does not work
         .offset(y: appState.searchVisible ? 0 : -Popup.itemHeight)
+
+      Button {
+        appState.history.addNew()
+      } label: {
+        Image(systemName: "plus")
+          .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+      .help(Text("add_new"))
     }
     .frame(height: appState.searchVisible ? Popup.itemHeight + 3 : 0)
     .opacity(appState.searchVisible ? 1 : 0)

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -5,8 +5,17 @@ struct HistoryItemView: View {
   @Bindable var item: HistoryItemDecorator
 
   @Environment(AppState.self) private var appState
+  @FocusState private var editFocused: Bool
 
   var body: some View {
+    if item.isEditing {
+      editingView
+    } else {
+      normalView
+    }
+  }
+
+  private var normalView: some View {
     ListItemView(
       id: item.id,
       appIcon: item.applicationImage,
@@ -30,5 +39,67 @@ struct HistoryItemView: View {
           item.ensurePreviewImage()
         }
     }
+    .contextMenu {
+      if item.item.text != nil {
+        Button {
+          appState.history.startEditing(item)
+        } label: {
+          Text("edit")
+        }
+      }
+
+      Button {
+        appState.history.togglePin(item)
+      } label: {
+        Text(item.isPinned ? "unpin" : "pin")
+      }
+
+      Button {
+        appState.history.delete(item)
+      } label: {
+        Text("delete")
+      }
+    }
+  }
+
+  private var editingView: some View {
+    HStack(spacing: 0) {
+      Spacer().frame(width: 10)
+      TextField("", text: $item.editingText, axis: .vertical)
+        .textFieldStyle(.plain)
+        .lineLimit(1...5)
+        .focused($editFocused)
+        .onAppear {
+          editFocused = true
+        }
+        .onSubmit {
+          appState.history.saveEditing(item)
+        }
+        .onExitCommand {
+          appState.history.cancelEditing(item)
+        }
+      Spacer().frame(width: 4)
+      Button {
+        appState.history.saveEditing(item)
+      } label: {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(.green)
+      }
+      .buttonStyle(.plain)
+      .padding(.trailing, 4)
+      Button {
+        appState.history.cancelEditing(item)
+      } label: {
+        Image(systemName: "xmark.circle.fill")
+          .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+      .padding(.trailing, 8)
+    }
+    .frame(minHeight: Popup.itemHeight)
+    .id(item.id)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.accentColor.opacity(0.15))
+    .clipShape(.rect(cornerRadius: Popup.cornerRadius))
   }
 }

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -103,6 +103,9 @@ struct KeyHandlingView<Content: View>: View {
 
           appState.highlightFirst()
           return .handled
+        case .editCurrentItem:
+          appState.history.startEditing(appState.history.selectedItem)
+          return .handled
         case .openPreferences:
           appState.openPreferences()
           return .handled

--- a/Maccy/en.lproj/Localizable.strings
+++ b/Maccy/en.lproj/Localizable.strings
@@ -28,3 +28,8 @@
 "system_settings_pane" = "Privacy & Security settings";
 "system_preferences_name" = "System Preferences";
 "system_preferences_pane" = "Security & Privacy preferences";
+"edit" = "Edit";
+"pin" = "Pin";
+"unpin" = "Unpin";
+"delete" = "Delete";
+"add_new" = "Add new item";


### PR DESCRIPTION
## Summary
This PR adds the ability to edit clipboard history items directly in the UI, along with comprehensive project documentation. Users can now modify text content of existing items or create new items from scratch using a new inline editing interface.

## Key Changes

### Editing Functionality
- **New `KeyChord` case**: Added `editCurrentItem` mapped to `Cmd+E` for quick access to edit mode
- **History methods**: Implemented `startEditing()`, `saveEditing()`, and `cancelEditing()` to manage the editing lifecycle
- **New item creation**: Added `addNew()` method to create empty clipboard items ready for editing
- **HistoryItemDecorator properties**: Added `isEditing` and `editingText` state properties to track editing mode

### UI Updates
- **HistoryItemView**: Refactored to show either normal view or inline editing view based on `isEditing` state
  - Editing view includes a multi-line TextField with save/cancel buttons
  - Added context menu with Edit, Pin/Unpin, and Delete actions
  - Auto-focuses the text field when entering edit mode
- **HeaderView**: Added "+" button to create new clipboard items
- **KeyHandlingView**: Wired up `Cmd+E` to trigger editing for the selected item

### Localization
- Added new string keys: `edit`, `pin`, `unpin`, `delete`, `add_new` to English localizable strings

### Documentation
- **CLAUDE.md**: Added comprehensive project overview including:
  - Project structure and file organization
  - Build and test instructions
  - Code style conventions and naming patterns
  - Linting tools configuration (SwiftLint, Periphery, Bartycrouch)

## Implementation Details
- Editing preserves the original clipboard item structure while updating the string content
- Empty items are automatically deleted when editing is cancelled
- Saving with empty text also deletes the item
- The editing interface uses SwiftUI's `@FocusState` to auto-focus the text field
- Changes are persisted to Core Data storage immediately upon save

https://claude.ai/code/session_014wX55ko1ozMbjn3SbpxMZg