### PR TITLE
Clipboard Accumulation: double-tap ⌘C to append copies into a single pasteable item

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -37,7 +37,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Bridge FloatingPanel via AppDelegate.
     AppState.shared.appDelegate = self
 
-    Clipboard.shared.onNewCopy { History.shared.add($0) }
+    Clipboard.shared.onNewCopy { item, isAppend in
+      History.shared.add(item, shouldAppend: isAppend)
+    }
     Clipboard.shared.start()
 
     Task {

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -14,6 +14,8 @@ extension Defaults.Keys {
   static let clearOnQuit = Key<Bool>("clearOnQuit", default: false)
   static let clearSystemClipboard = Key<Bool>("clearSystemClipboard", default: false)
   static let clipboardCheckInterval = Key<Double>("clipboardCheckInterval", default: 0.5)
+  static let appendModeEnabled = Key<Bool>("appendModeEnabled", default: false)
+  static let appendModeTimeWindow = Key<Double>("appendModeTimeWindow", default: 1.0)
   static let enabledPasteboardTypes = Key<Set<NSPasteboard.PasteboardType>>(
     "enabledPasteboardTypes", default: Set(StorageType.all.types)
   )

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -16,6 +16,7 @@ struct GeneralSettingsPane: View {
   @State private var pasteWithoutFormatting = HistoryItemAction.pasteWithoutFormatting.modifierFlags.description
 
   @State private var updater = SoftwareUpdater()
+  @Default(.appendModeTimeWindow) private var appendModeTimeWindow
 
   var body: some View {
     Settings.Container(contentWidth: 450) {
@@ -93,6 +94,24 @@ struct GeneralSettingsPane: View {
         .fixedSize(horizontal: false, vertical: true)
         .foregroundStyle(.gray)
         .controlSize(.small)
+      }
+
+      Settings.Section(
+        bottomDivider: true,
+        label: { Text("AppendMode", tableName: "GeneralSettings") }
+      ) {
+        Defaults.Toggle(key: .appendModeEnabled) {
+          Text("EnableAppendMode", tableName: "GeneralSettings")
+        }
+        .help(Text("EnableAppendModeTooltip", tableName: "GeneralSettings"))
+
+        HStack {
+          Text("AppendModeTimeWindow", tableName: "GeneralSettings")
+          TextField("", value: $appendModeTimeWindow, format: .number)
+            .frame(width: 60)
+          Text("seconds", tableName: "GeneralSettings")
+        }
+        .disabled(!Defaults[.appendModeEnabled])
       }
 
       Settings.Section(title: "") {

--- a/Maccy/Settings/en.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/en.lproj/GeneralSettings.strings
@@ -18,3 +18,7 @@
 "Regex" = "Regular expressions";
 "Mixed" = "Mixed";
 "NotificationsAndSounds" = "Notifications and sounds 􀱁";
+"AppendMode" = "Append Mode:";
+"EnableAppendMode" = "Enable append mode (CMD+C twice)";
+"EnableAppendModeTooltip" = "When enabled, pressing CMD+C twice within the time window will append the new content to the most recent clipboard item instead of creating a new one.";
+"AppendModeTimeWindow" = "Time window:";


### PR DESCRIPTION
Double-tapping ⌘C appends subsequent copies to the most recent clipboard item, allowing multiple non-contiguous selections to be pasted at once.

### Motivation
Many workflows involve collecting rather than replacing clipboard contents:
- copying multiple quotes from an article or PDF
- assembling code snippets from non-adjacent locations
- aggregating IDs, URLs, or log lines from different screens

### Behavior
- A double-tap ⌘C appends the newly copied content to the previous clipboard item
- Accumulated content is stored as a single clipboard entry
- A standard single ⌘C behaves exactly as before
- Order of copied items is preserved