### PR TITLE
README : Title divider glitch over Maccy logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<img width="128px" src="https://maccy.app/img/maccy/Logo.png" alt="Logo" align="left" />
+<img width="128px" src="https://maccy.app/img/maccy/Logo.png" alt="Logo" />
 
 # [Maccy](https://maccy.app)
 


### PR DESCRIPTION
## Actual
<img width="382" height="134" alt="image" src="https://github.com/user-attachments/assets/6180a6e3-5652-459d-b308-c7682b7c4f7a" />

## Proposal
<img width="236" height="260" alt="image" src="https://github.com/user-attachments/assets/81944e84-57b7-4470-8890-0505a21cf39d" />
