### PR TITLE
fix: show red border for invalid history size input

### DIFF
--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -62,9 +62,14 @@ struct StorageSettingsPane: View {
   @State private var viewModel = ViewModel()
   @State private var storageSize = Storage.shared.size
   @State private var sizeText = ""
-  @State private var isSizeValid = true
 
   private static let sizeRange = 1...999
+
+  private func isValidSize() -> Bool {
+    if sizeText.isEmpty { return true }
+    guard let value = Int(sizeText) else { return false }
+    return Self.sizeRange.contains(value)
+  }
 
   var body: some View {
     Settings.Container(contentWidth: 450) {
@@ -94,29 +99,24 @@ struct StorageSettingsPane: View {
           TextField("", text: $sizeText)
             .frame(width: 80)
             .help(Text("SizeTooltip", tableName: "StorageSettings"))
-            .border(isSizeValid ? Color.clear : Color.red)
+            .border(isValidSize() ? Color.clear : Color.red)
             .onAppear { sizeText = "\(size)" }
             .onChange(of: sizeText) {
-              if let value = Int(sizeText), Self.sizeRange.contains(value) {
-                isSizeValid = true
+              if isValidSize(), let value = Int(sizeText) {
                 size = value
-              } else {
-                isSizeValid = sizeText.isEmpty ? true : false
               }
             }
             .onSubmit {
-              if let value = Int(sizeText), Self.sizeRange.contains(value) {
+              if isValidSize(), let value = Int(sizeText) {
                 size = value
               } else {
                 sizeText = "\(size)"
-                isSizeValid = true
               }
             }
           Stepper("", value: $size, in: Self.sizeRange)
             .labelsHidden()
             .onChange(of: size) {
               sizeText = "\(size)"
-              isSizeValid = true
             }
           Text(storageSize)
             .controlSize(.small)

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -61,13 +61,10 @@ struct StorageSettingsPane: View {
 
   @State private var viewModel = ViewModel()
   @State private var storageSize = Storage.shared.size
+  @State private var sizeText = ""
+  @State private var isSizeValid = true
 
-  private let sizeFormatter: NumberFormatter = {
-    let formatter = NumberFormatter()
-    formatter.minimum = 1
-    formatter.maximum = 999
-    return formatter
-  }()
+  private static let sizeRange = 1...999
 
   var body: some View {
     Settings.Container(contentWidth: 450) {
@@ -94,11 +91,33 @@ struct StorageSettingsPane: View {
 
       Settings.Section(label: { Text("Size", tableName: "StorageSettings") }) {
         HStack {
-          TextField("", value: $size, formatter: sizeFormatter)
+          TextField("", text: $sizeText)
             .frame(width: 80)
             .help(Text("SizeTooltip", tableName: "StorageSettings"))
-          Stepper("", value: $size, in: 1...999)
+            .border(isSizeValid ? Color.clear : Color.red)
+            .onAppear { sizeText = "\(size)" }
+            .onChange(of: sizeText) {
+              if let value = Int(sizeText), Self.sizeRange.contains(value) {
+                isSizeValid = true
+                size = value
+              } else {
+                isSizeValid = sizeText.isEmpty ? true : false
+              }
+            }
+            .onSubmit {
+              if let value = Int(sizeText), Self.sizeRange.contains(value) {
+                size = value
+              } else {
+                sizeText = "\(size)"
+                isSizeValid = true
+              }
+            }
+          Stepper("", value: $size, in: Self.sizeRange)
             .labelsHidden()
+            .onChange(of: size) {
+              sizeText = "\(size)"
+              isSizeValid = true
+            }
           Text(storageSize)
             .controlSize(.small)
             .foregroundStyle(.gray)


### PR DESCRIPTION
## Summary

- Replaces the `NumberFormatter`-based TextField with a text-based TextField that validates input in real-time
- Shows a red border when the entered value is outside the valid range (1–999) or non-numeric
- On submit (Return key), invalid values revert to the last valid value
- Stepper updates sync back to the text field

This addresses the silent failure where typing a value above 999 appeared to be accepted but was actually ignored.

Fixes #1292

## Test plan

- [ ] Type a value above 999 → red border appears
- [ ] Type a non-numeric value → red border appears  
- [ ] Type a valid value (1–999) → no red border, value is saved
- [ ] Use stepper → text field updates correctly
- [ ] Press Return with invalid value → reverts to last valid value
- [ ] Close and reopen settings → value persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)