### PR TITLE
Fix OpenPreferencesWarning text overflow on long localizations

### DIFF
--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -175,6 +175,7 @@ struct AppearanceSettingsPane: View {
           Text("ShowFooter", tableName: "AppearanceSettings")
         }
         Text("OpenPreferencesWarning", tableName: "AppearanceSettings")
+          .fixedSize(horizontal: false, vertical: true)
           .opacity(showFooter ? 0 : 1)
           .controlSize(.small)
           .foregroundStyle(.gray)


### PR DESCRIPTION
## Summary
- Adds `.fixedSize(horizontal: false, vertical: true)` to the `OpenPreferencesWarning` text so it wraps instead of overflowing the settings pane on longer localizations (e.g. French, Romanian, Portuguese)

## Test plan
- [ ] Set system language to French (or another long localization)
- [ ] Open Appearance settings, disable "Show footer"
- [ ] Verify the warning text wraps within the pane instead of overflowing

Fixes #1327

🤖 Generated with [Claude Code](https://claude.com/claude-code)