### PR TITLE
Add Hex Color Swatch Show Setting in Preferences

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -58,5 +58,6 @@ extension Defaults.Keys {
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
   static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: false)
+  static let showHexColorSwatch = Key<Bool>("showHexColorSwatch", default: true)
   static let previewWidth = Key<CGFloat>("previewWidth", default: 400)
 }

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -170,6 +170,10 @@ struct AppearanceSettingsPane: View {
         Defaults.Toggle(key: .showApplicationIcons) {
           Text("ShowApplicationIcons", tableName: "AppearanceSettings")
         }
+        Defaults.Toggle(key: .showHexColorSwatch) {
+          Text("ShowHexColorSwatch", tableName: "AppearanceSettings")
+        }
+        .help(Text("ShowHexColorSwatchTooltip", tableName: "AppearanceSettings"))
 
         Defaults.Toggle(key: .showFooter) {
           Text("ShowFooter", tableName: "AppearanceSettings")

--- a/Maccy/Settings/ar.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ar.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "إظهار التذييل";
 "ShowApplicationIcons" = "إظهار أيقونات التطبيقات";
 "OpenPreferencesWarning" = "⚠️ اضغط على ⌘، (command+comma) لفتح التفضيلات عندما يكون التذييل مخفيًا.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ar.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ar.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "إظهار التذييل";
 "ShowApplicationIcons" = "إظهار أيقونات التطبيقات";
 "OpenPreferencesWarning" = "⚠️ اضغط على ⌘، (command+comma) لفتح التفضيلات عندما يكون التذييل مخفيًا.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "إظهار عينة اللون الست عشري";
+"ShowHexColorSwatchTooltip" = "إظهار عينة اللون بجانب رموز الألوان الست عشرية.";

--- a/Maccy/Settings/be.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/be.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "PreviewDelayTooltip" = "Затрымка ў мілісекундах да з'яўлення ўсплыўнога акна прадпрагляду.\nПадставова: 1500.";
 "PopupAtTooltip" = "Змяніць месца для з'яўлення ўсплыўнога акна.\nПадставова: Курсор.";
 "ShowApplicationIcons" = "Паказаць значкі прыкладанняў";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Паказваць узор шаснаццатковага колеру";
+"ShowHexColorSwatchTooltip" = "Паказваць узор колеру побач з шаснаццатковымі кодамі колераў.";

--- a/Maccy/Settings/be.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/be.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "PreviewDelayTooltip" = "Затрымка ў мілісекундах да з'яўлення ўсплыўнога акна прадпрагляду.\nПадставова: 1500.";
 "PopupAtTooltip" = "Змяніць месца для з'яўлення ўсплыўнога акна.\nПадставова: Курсор.";
 "ShowApplicationIcons" = "Паказаць значкі прыкладанняў";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/bn.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/bn.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "হেক্স রঙের নমুনা দেখান";
+"ShowHexColorSwatchTooltip" = "হেক্স রঙ কোডের পাশে রঙের নমুনা দেখান।";

--- a/Maccy/Settings/bn.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/bn.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/bs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/bs.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Prikaži footer";
 "OpenPreferencesWarning" = "⚠️ Pritisni ⌘, (command+comma) da otvorite postavke kada je podnožje skriveno.";
 "ShowApplicationIcons" = "Prikaži ikone aplikacija";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/bs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/bs.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Prikaži footer";
 "OpenPreferencesWarning" = "⚠️ Pritisni ⌘, (command+comma) da otvorite postavke kada je podnožje skriveno.";
 "ShowApplicationIcons" = "Prikaži ikone aplikacija";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Prikaži uzorak hex boje";
+"ShowHexColorSwatchTooltip" = "Prikaži uzorak boje pored hex kodova boja.";

--- a/Maccy/Settings/ca.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ca.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ca.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ca.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Mostra la mostra de color hexadecimal";
+"ShowHexColorSwatchTooltip" = "Mostra la mostra de color al costat dels codis de color hexadecimals.";

--- a/Maccy/Settings/ckb.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ckb.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "پیشاندانی ئایکۆنی بەرنامەکان";
 "ShowFooter" = "پیشاندانی فووتەر";
 "OpenPreferencesWarning" = "⚠️ دوگمەی ⌘, (کۆماند+کۆما) دابگرە بۆ کردنەوەی هەڵبژاردەکان کاتێک فووتەر شاراوەیە.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ckb.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ckb.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "پیشاندانی ئایکۆنی بەرنامەکان";
 "ShowFooter" = "پیشاندانی فووتەر";
 "OpenPreferencesWarning" = "⚠️ دوگمەی ⌘, (کۆماند+کۆما) دابگرە بۆ کردنەوەی هەڵبژاردەکان کاتێک فووتەر شاراوەیە.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "پیشاندانی نموونەی ڕەنگی شانزەیی";
+"ShowHexColorSwatchTooltip" = "نموونەی ڕەنگ لەتەنیشت کۆدەکانی ڕەنگی شانزەیی پیشان بدە.";

--- a/Maccy/Settings/cs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/cs.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Zobrazovat patičku";
 "ShowApplicationIcons" = "Zobrazení ikon aplikací";
 "OpenPreferencesWarning" = "⚠️ Stiskni ⌘, (command+comma) pro otevření předvoleb, když je skrytá patička.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Zobrazit vzorek hex barvy";
+"ShowHexColorSwatchTooltip" = "Zobrazit barevný vzorek vedle hex kódů barev.";

--- a/Maccy/Settings/cs.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/cs.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Zobrazovat patičku";
 "ShowApplicationIcons" = "Zobrazení ikon aplikací";
 "OpenPreferencesWarning" = "⚠️ Stiskni ⌘, (command+comma) pro otevření předvoleb, když je skrytá patička.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/de.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/de.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Menü anzeigen";
 "ShowApplicationIcons" = "Anwendungssymbole anzeigen";
 "OpenPreferencesWarning" = "⚠️ Um die Einstellungen zu öffnen, halte ⌘, (command+comma) gedrückt.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Hex-Farbmuster anzeigen";
+"ShowHexColorSwatchTooltip" = "Farbmuster neben Hex-Farbcodes anzeigen.";

--- a/Maccy/Settings/de.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/de.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Menü anzeigen";
 "ShowApplicationIcons" = "Anwendungssymbole anzeigen";
 "OpenPreferencesWarning" = "⚠️ Um die Einstellungen zu öffnen, halte ⌘, (command+comma) gedrückt.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/el.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/el.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Εμφάνιση δείγματος δεκαεξαδικού χρώματος";
+"ShowHexColorSwatchTooltip" = "Εμφάνιση δείγματος χρώματος δίπλα σε δεκαεξαδικούς κωδικούς χρωμάτων.";

--- a/Maccy/Settings/el.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/el.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/en.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/en.lproj/AppearanceSettings.strings
@@ -31,5 +31,7 @@
 "ShowSearchField" = "Show search field";
 "ShowTitleBeforeSearchField" = "Show title before search field";
 "ShowApplicationIcons" = "Show application icons";
+"ShowHexColorSwatch" = "Show hex color swatch";
+"ShowHexColorSwatchTooltip" = "Show color swatch next to hex color codes.";
 "ShowFooter" = "Show footer";
 "OpenPreferencesWarning" = "⚠️ Press ⌘, (command+comma) to open preferences when footer is hidden.";

--- a/Maccy/Settings/eo.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/eo.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "Montri bildsimbolojn de aplikaĵoj";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/eo.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/eo.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "Montri bildsimbolojn de aplikaĵoj";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Montri kolorspecimenon de deksesuma koloro";
+"ShowHexColorSwatchTooltip" = "Montri kolorspecimenon apud deksesumaj kolorkodoj.";

--- a/Maccy/Settings/es.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/es.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Mostrar footer";
 "ShowApplicationIcons" = "Mostrar iconos de aplicaciones";
 "OpenPreferencesWarning" = "⚠️ Presionar ⌘, (command+comma) para abrir las preferencias cuando el footer esté oculto.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/es.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/es.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Mostrar footer";
 "ShowApplicationIcons" = "Mostrar iconos de aplicaciones";
 "OpenPreferencesWarning" = "⚠️ Presionar ⌘, (command+comma) para abrir las preferencias cuando el footer esté oculto.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Mostrar muestra de color hexadecimal";
+"ShowHexColorSwatchTooltip" = "Mostrar muestra de color junto a los códigos de color hexadecimales.";

--- a/Maccy/Settings/fa.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/fa.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "نمایش نمونه رنگ هگزادسیمال";
+"ShowHexColorSwatchTooltip" = "نمایش نمونه رنگ در کنار کدهای رنگ هگزادسیمال.";

--- a/Maccy/Settings/fa.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/fa.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/fr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/fr.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Afficher le bas de l’application";
 "ShowApplicationIcons" = "Afficher les icônes des applications";
 "OpenPreferencesWarning" = "⚠️ Pressez ⌘, (command+comma) pour ouvrir les préférences quand le bas de l’application est caché.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Afficher l'échantillon de couleur hexadécimale";
+"ShowHexColorSwatchTooltip" = "Afficher un échantillon de couleur à côté des codes couleur hexadécimaux.";

--- a/Maccy/Settings/fr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/fr.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Afficher le bas de l’application";
 "ShowApplicationIcons" = "Afficher les icônes des applications";
 "OpenPreferencesWarning" = "⚠️ Pressez ⌘, (command+comma) pour ouvrir les préférences quand le bas de l’application est caché.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/he.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/he.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "הצגת כותרת תחתונה";
 "OpenPreferencesWarning" = "⚠️ לחצו ⌘, (command+פסיק) כדי לפתוח את ההעדפות כאשר הכותרת התחתונה מוסתרת.";
 "ShowApplicationIcons" = "הצג סמלי יישומים";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "הצג דוגמית צבע הקסדצימלי";
+"ShowHexColorSwatchTooltip" = "הצג דוגמית צבע ליד קודי צבע הקסדצימליים.";

--- a/Maccy/Settings/he.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/he.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "הצגת כותרת תחתונה";
 "OpenPreferencesWarning" = "⚠️ לחצו ⌘, (command+פסיק) כדי לפתוח את ההעדפות כאשר הכותרת התחתונה מוסתרת.";
 "ShowApplicationIcons" = "הצג סמלי יישומים";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/hi.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hi.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "हेक्स रंग स्वैच दिखाएँ";
+"ShowHexColorSwatchTooltip" = "हेक्स रंग कोड के बगल में रंग स्वैच दिखाएँ।";

--- a/Maccy/Settings/hi.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hi.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/hr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hr.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Prikaži podnožje";
 "OpenPreferencesWarning" = "⚠️ Za otvaranje postavaka kad je podnožje skriveno, pritisni ⌘, (command+comma).";
 "ShowApplicationIcons" = "Prikaži ikone aplikacija";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/hr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hr.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Prikaži podnožje";
 "OpenPreferencesWarning" = "⚠️ Za otvaranje postavaka kad je podnožje skriveno, pritisni ⌘, (command+comma).";
 "ShowApplicationIcons" = "Prikaži ikone aplikacija";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Prikaži uzorak hex boje";
+"ShowHexColorSwatchTooltip" = "Prikaži uzorak boje pored hex kodova boja.";

--- a/Maccy/Settings/hu.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hu.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Lábléc megjelenítése";
 "ShowApplicationIcons" = "Alkalmazás ikonok megjelenítése";
 "OpenPreferencesWarning" = "⚠️ Nyomd meg a ⌘, (command+comma) gombot a Preferenciák megnyitásához, ha a lábléc el van rejtve.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/hu.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/hu.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Lábléc megjelenítése";
 "ShowApplicationIcons" = "Alkalmazás ikonok megjelenítése";
 "OpenPreferencesWarning" = "⚠️ Nyomd meg a ⌘, (command+comma) gombot a Preferenciák megnyitásához, ha a lábléc el van rejtve.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Hex színminta megjelenítése";
+"ShowHexColorSwatchTooltip" = "Színminta megjelenítése a hex színkódok mellett.";

--- a/Maccy/Settings/id.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/id.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "Tampilkan ikon aplikasi";
 "ShowFooter" = "Tampilkan footer";
 "OpenPreferencesWarning" = "⚠️ Tekan ⌘ untuk buka preferensi ketika footer tersembunyi.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Tampilkan contoh warna hex";
+"ShowHexColorSwatchTooltip" = "Tampilkan contoh warna di samping kode warna hex.";

--- a/Maccy/Settings/id.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/id.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "Tampilkan ikon aplikasi";
 "ShowFooter" = "Tampilkan footer";
 "OpenPreferencesWarning" = "⚠️ Tekan ⌘ untuk buka preferensi ketika footer tersembunyi.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/it.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/it.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Mostra footer";
 "ShowApplicationIcons" = "Mostra le icone delle applicazioni";
 "OpenPreferencesWarning" = "⚠️ Premi ⌘, (command+comma) per aprire le preferenze quando il footer è nascosto.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Mostra campione colore esadecimale";
+"ShowHexColorSwatchTooltip" = "Mostra il campione di colore accanto ai codici colore esadecimali.";

--- a/Maccy/Settings/it.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/it.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Mostra footer";
 "ShowApplicationIcons" = "Mostra le icone delle applicazioni";
 "OpenPreferencesWarning" = "⚠️ Premi ⌘, (command+comma) per aprire le preferenze quando il footer è nascosto.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ja.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ja.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "フッター表示";
 "ShowApplicationIcons" = "アプリケーションのアイコンを表示する";
 "OpenPreferencesWarning" = "⚠️ フッターが隠されている時に設定を開くには⌘, (command+comma)を押してください。";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ja.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ja.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "フッター表示";
 "ShowApplicationIcons" = "アプリケーションのアイコンを表示する";
 "OpenPreferencesWarning" = "⚠️ フッターが隠されている時に設定を開くには⌘, (command+comma)を押してください。";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "16進カラースウォッチを表示";
+"ShowHexColorSwatchTooltip" = "16進カラーコードの横にカラースウォッチを表示します。";

--- a/Maccy/Settings/ko.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ko.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "푸터 표시";
 "ShowApplicationIcons" = "애플리케이션 아이콘 표시";
 "OpenPreferencesWarning" = "⚠️ 푸터가 숨겨져 있을 때 설정을 열려면 ⌘, (command+comma)를 누르세요.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ko.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ko.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "푸터 표시";
 "ShowApplicationIcons" = "애플리케이션 아이콘 표시";
 "OpenPreferencesWarning" = "⚠️ 푸터가 숨겨져 있을 때 설정을 열려면 ⌘, (command+comma)를 누르세요.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "16진수 색상 견본 표시";
+"ShowHexColorSwatchTooltip" = "16진수 색상 코드 옆에 색상 견본을 표시합니다.";

--- a/Maccy/Settings/lt.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/lt.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Rodyti paraštę";
 "ShowApplicationIcons" = "Rodyti programų piktogramas";
 "OpenPreferencesWarning" = "⚠️ Paspauskite ⌘, (command+comma) norėdami atidaryti nustatymus, kai paraštė yra paslėpta.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/lt.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/lt.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Rodyti paraštę";
 "ShowApplicationIcons" = "Rodyti programų piktogramas";
 "OpenPreferencesWarning" = "⚠️ Paspauskite ⌘, (command+comma) norėdami atidaryti nustatymus, kai paraštė yra paslėpta.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Rodyti šešioliktainės spalvos pavyzdį";
+"ShowHexColorSwatchTooltip" = "Rodyti spalvos pavyzdį šalia šešioliktainių spalvų kodų.";

--- a/Maccy/Settings/lv.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/lv.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Rādīt kājeni";
 "ShowApplicationIcons" = "Rādīt lietojumprogrammu ikonas";
 "OpenPreferencesWarning" = "⚠️ Nospiediet taustiņu ⌘, (command+comma) lai atvērtu preferences, ja kājene ir paslēpta.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/lv.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/lv.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Rādīt kājeni";
 "ShowApplicationIcons" = "Rādīt lietojumprogrammu ikonas";
 "OpenPreferencesWarning" = "⚠️ Nospiediet taustiņu ⌘, (command+comma) lai atvērtu preferences, ja kājene ir paslēpta.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Rādīt heksadecimālās krāsas paraugu";
+"ShowHexColorSwatchTooltip" = "Rādīt krāsas paraugu blakus heksadecimālajiem krāsu kodiem.";

--- a/Maccy/Settings/nb.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nb.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Vis bunntekst";
 "ShowApplicationIcons" = "Vis applikasjonsikoner";
 "OpenPreferencesWarning" = "⚠️ Trykk ⌘, (command+comma) for å åpne valg når bunntekst er skjult.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/nb.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nb.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Vis bunntekst";
 "ShowApplicationIcons" = "Vis applikasjonsikoner";
 "OpenPreferencesWarning" = "⚠️ Trykk ⌘, (command+comma) for å åpne valg når bunntekst er skjult.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Vis heksadesimal fargeprøve";
+"ShowHexColorSwatchTooltip" = "Vis fargeprøve ved siden av heksadesimale fargekoder.";

--- a/Maccy/Settings/nl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nl.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Toon voettekst";
 "ShowApplicationIcons" = "Toepassingspictogrammen weergeven";
 "OpenPreferencesWarning" = "⚠️ Druk op ⌘, (command+comma) om voorkeuren te openen wanneer de voettekst verborgen is.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/nl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/nl.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Toon voettekst";
 "ShowApplicationIcons" = "Toepassingspictogrammen weergeven";
 "OpenPreferencesWarning" = "⚠️ Druk op ⌘, (command+comma) om voorkeuren te openen wanneer de voettekst verborgen is.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Hex kleurstaal tonen";
+"ShowHexColorSwatchTooltip" = "Toon kleurstaal naast hex kleurcodes.";

--- a/Maccy/Settings/pl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pl.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Pokaż stopkę";
 "ShowApplicationIcons" = "Pokaż ikony aplikacji";
 "OpenPreferencesWarning" = "⚠️ Naciśnij ⌘, (command+comma) aby otworzyć ustawienia, kiedy stopka jest ukryta.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Pokaż próbkę koloru hex";
+"ShowHexColorSwatchTooltip" = "Pokaż próbkę koloru obok kodów kolorów hex.";

--- a/Maccy/Settings/pl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pl.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Pokaż stopkę";
 "ShowApplicationIcons" = "Pokaż ikony aplikacji";
 "OpenPreferencesWarning" = "⚠️ Naciśnij ⌘, (command+comma) aby otworzyć ustawienia, kiedy stopka jest ukryta.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Mostrar rodapé";
 "ShowApplicationIcons" = "Mostrar ícones de aplicações";
 "OpenPreferencesWarning" = "⚠️ Pressione ⌘, (command+comma) para abrir as preferências quando o rodapé estiver oculto.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pt-BR.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Mostrar rodapé";
 "ShowApplicationIcons" = "Mostrar ícones de aplicações";
 "OpenPreferencesWarning" = "⚠️ Pressione ⌘, (command+comma) para abrir as preferências quando o rodapé estiver oculto.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Mostrar amostra de cor hexadecimal";
+"ShowHexColorSwatchTooltip" = "Mostrar amostra de cor ao lado dos códigos de cor hexadecimais.";

--- a/Maccy/Settings/pt.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pt.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "Mostrar ícones de aplicações";
 "ShowFooter" = "Mostrar rodapé";
 "OpenPreferencesWarning" = "⚠️ Pressione ⌘, (command+comma) para abrir as preferências quando o rodapé estiver oculto.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/pt.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/pt.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "Mostrar ícones de aplicações";
 "ShowFooter" = "Mostrar rodapé";
 "OpenPreferencesWarning" = "⚠️ Pressione ⌘, (command+comma) para abrir as preferências quando o rodapé estiver oculto.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Mostrar amostra de cor hexadecimal";
+"ShowHexColorSwatchTooltip" = "Mostrar amostra de cor junto aos códigos de cor hexadecimais.";

--- a/Maccy/Settings/ro.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ro.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "Afișează iconițele aplicațiilor";
 "ShowFooter" = "Afișează subsolul";
 "OpenPreferencesWarning" = "⚠️ Apasă ⌘, (command+comma) pentru a deschide preferințele atunci când subsolul este ascuns.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Afișare mostră de culoare hexazecimală";
+"ShowHexColorSwatchTooltip" = "Afișare mostră de culoare lângă codurile de culoare hexazecimale.";

--- a/Maccy/Settings/ro.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ro.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "Afișează iconițele aplicațiilor";
 "ShowFooter" = "Afișează subsolul";
 "OpenPreferencesWarning" = "⚠️ Apasă ⌘, (command+comma) pentru a deschide preferințele atunci când subsolul este ascuns.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ru.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ru.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Показывать нижний колонтитул";
 "ShowApplicationIcons" = "Показать значки приложений";
 "OpenPreferencesWarning" = "⚠️ Нажмите ⌘, (command+comma) чтобы открыть настройки когда нижний колонтитул скрыт.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Показывать образец hex-цвета";
+"ShowHexColorSwatchTooltip" = "Показывать образец цвета рядом с hex-кодами цветов.";

--- a/Maccy/Settings/ru.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ru.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Показывать нижний колонтитул";
 "ShowApplicationIcons" = "Показать значки приложений";
 "OpenPreferencesWarning" = "⚠️ Нажмите ⌘, (command+comma) чтобы открыть настройки когда нижний колонтитул скрыт.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/sl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/sl.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "Prikaži ikone aplikacij";
 "ShowFooter" = "Prikaži nogo";
 "OpenPreferencesWarning" = "⚠️ Pritisnite ⌘, (command+comma) da odprete nastavitve, ko je noga skrita.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Prikaži vzorec hex barve";
+"ShowHexColorSwatchTooltip" = "Prikaži barvni vzorec ob hex barvnih kodah.";

--- a/Maccy/Settings/sl.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/sl.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "Prikaži ikone aplikacij";
 "ShowFooter" = "Prikaži nogo";
 "OpenPreferencesWarning" = "⚠️ Pritisnite ⌘, (command+comma) da odprete nastavitve, ko je noga skrita.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/sv.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/sv.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Visa hexadecimalt färgprov";
+"ShowHexColorSwatchTooltip" = "Visa färgprov bredvid hexadecimala färgkoder.";

--- a/Maccy/Settings/sv.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/sv.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ta.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ta.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/ta.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/ta.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "";
 "ShowFooter" = "";
 "OpenPreferencesWarning" = "";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "ஹெக்ஸ் நிற மாதிரி காட்டு";
+"ShowHexColorSwatchTooltip" = "ஹெக்ஸ் நிறக் குறியீடுகளுக்கு அருகில் நிற மாதிரியைக் காட்டு.";

--- a/Maccy/Settings/th.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/th.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "แสดงส่วนท้าย";
 "OpenPreferencesWarning" = "⚠️ กด ⌘, (command+comma) เพื่อเปิดการตั้งค่าเมื่อส่วนท้ายซ่อน";
 "ShowApplicationIcons" = "แสดงไอคอนแอปพลิเคชั่น";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "แสดงตัวอย่างสีเลขฐานสิบหก";
+"ShowHexColorSwatchTooltip" = "แสดงตัวอย่างสีถัดจากรหัสสีเลขฐานสิบหก";

--- a/Maccy/Settings/th.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/th.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "แสดงส่วนท้าย";
 "OpenPreferencesWarning" = "⚠️ กด ⌘, (command+comma) เพื่อเปิดการตั้งค่าเมื่อส่วนท้ายซ่อน";
 "ShowApplicationIcons" = "แสดงไอคอนแอปพลิเคชั่น";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/tr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/tr.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Altbilgiyi göster";
 "ShowApplicationIcons" = "Uygulama simgelerini göster";
 "OpenPreferencesWarning" = "⚠️ Altbilgi gizliyken ayarları açmak için ⌘, (command+comma)'a basın.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Hex renk örneğini göster";
+"ShowHexColorSwatchTooltip" = "Hex renk kodlarının yanında renk örneği göster.";

--- a/Maccy/Settings/tr.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/tr.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Altbilgiyi göster";
 "ShowApplicationIcons" = "Uygulama simgelerini göster";
 "OpenPreferencesWarning" = "⚠️ Altbilgi gizliyken ayarları açmak için ⌘, (command+comma)'a basın.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/uk.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/uk.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "Показати нижній колонтитул";
 "ShowApplicationIcons" = "Показати іконки програм";
 "OpenPreferencesWarning" = "⚠️ Натисніть ⌘, (command+comma) щоб відкрити параметри, коли нижній колонтитул приховано.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/uk.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/uk.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "Показати нижній колонтитул";
 "ShowApplicationIcons" = "Показати іконки програм";
 "OpenPreferencesWarning" = "⚠️ Натисніть ⌘, (command+comma) щоб відкрити параметри, коли нижній колонтитул приховано.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Показувати зразок hex-кольору";
+"ShowHexColorSwatchTooltip" = "Показувати зразок кольору поруч із hex-кодами кольорів.";

--- a/Maccy/Settings/uz.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/uz.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowTitleBeforeSearchField" = "Qidiruv maydonidan oldin sarlavhani ko'rsatish";
 "ShowFooter" = "Pastgi qisimni ko'rsatish";
 "PinToTop" = "Yuqorida";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Hex rang namunasini koʻrsatish";
+"ShowHexColorSwatchTooltip" = "Hex rang kodlari yonida rang namunasini koʻrsatish.";

--- a/Maccy/Settings/uz.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/uz.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowTitleBeforeSearchField" = "Qidiruv maydonidan oldin sarlavhani ko'rsatish";
 "ShowFooter" = "Pastgi qisimni ko'rsatish";
 "PinToTop" = "Yuqorida";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/vi.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/vi.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowApplicationIcons" = "Hiển thị biểu tượng ứng dụng";
 "ShowFooter" = "Hiển thị phần chân trang";
 "OpenPreferencesWarning" = "⚠️ Nhấn phím ⌘, (command+comma) để mở cài đặt khi phần chân trang bị ẩn.";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/vi.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/vi.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowApplicationIcons" = "Hiển thị biểu tượng ứng dụng";
 "ShowFooter" = "Hiển thị phần chân trang";
 "OpenPreferencesWarning" = "⚠️ Nhấn phím ⌘, (command+comma) để mở cài đặt khi phần chân trang bị ẩn.";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "Hiển thị mẫu màu hex";
+"ShowHexColorSwatchTooltip" = "Hiển thị mẫu màu bên cạnh mã màu hex.";

--- a/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "显示底部菜单";
 "ShowApplicationIcons" = "显示应用程序图标";
 "OpenPreferencesWarning" = "⚠️ 隐藏底部菜单时仍可按 ⌘, (command+comma) 打开偏好设置。";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "显示十六进制颜色色块";
+"ShowHexColorSwatchTooltip" = "在十六进制颜色代码旁边显示颜色色块。";

--- a/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "显示底部菜单";
 "ShowApplicationIcons" = "显示应用程序图标";
 "OpenPreferencesWarning" = "⚠️ 隐藏底部菜单时仍可按 ⌘, (command+comma) 打开偏好设置。";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
@@ -33,3 +33,5 @@
 "ShowFooter" = "顯示底部操作選單";
 "ShowApplicationIcons" = "顯示應用程式圖示";
 "OpenPreferencesWarning" = "⚠️ 隱藏底部選單時，可按 ⌘, (command+comma) 顯示偏好設定。";
+"ShowHexColorSwatch" = "";
+"ShowHexColorSwatchTooltip" = "";

--- a/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/AppearanceSettings.strings
@@ -33,5 +33,5 @@
 "ShowFooter" = "顯示底部操作選單";
 "ShowApplicationIcons" = "顯示應用程式圖示";
 "OpenPreferencesWarning" = "⚠️ 隱藏底部選單時，可按 ⌘, (command+comma) 顯示偏好設定。";
-"ShowHexColorSwatch" = "";
-"ShowHexColorSwatchTooltip" = "";
+"ShowHexColorSwatch" = "顯示十六進位顏色色塊";
+"ShowHexColorSwatchTooltip" = "在十六進位顏色代碼旁邊顯示顏色色塊。";

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -29,7 +29,13 @@ struct HistoryItemView: View {
     }
   }
 
+  @Default(.showHexColorSwatch) private var showHexColorSwatch
   @Environment(AppState.self) private var appState
+
+  private var colorSwatchImage: NSImage? {
+    guard showHexColorSwatch else { return nil }
+    return ColorImage.from(item.title)
+  }
 
   var body: some View {
     ListItemView(
@@ -37,7 +43,7 @@ struct HistoryItemView: View {
       selectionId: item.id,
       appIcon: item.applicationImage,
       image: item.thumbnailImage,
-      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
+      accessoryImage: item.thumbnailImage != nil ? nil : colorSwatchImage,
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
       isSelected: item.isSelected,

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -43,7 +43,6 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   @ViewBuilder var title: () -> Title
 
   @Default(.showApplicationIcons) private var showIcons
-  @Default(.showHexColorSwatch) private var showHexColorSwatch
   @Environment(AppState.self) private var appState
   @Environment(ModifierFlags.self) private var modifierFlags
 
@@ -62,7 +61,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       Spacer()
         .frame(width: showIcons ? 5 : 10)
 
-      if showHexColorSwatch, let accessoryImage {
+      if let accessoryImage {
         Image(nsImage: accessoryImage)
           .accessibilityIdentifier("copy-history-item")
           .padding(.trailing, 5)

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -43,6 +43,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   @ViewBuilder var title: () -> Title
 
   @Default(.showApplicationIcons) private var showIcons
+  @Default(.showHexColorSwatch) private var showHexColorSwatch
   @Environment(AppState.self) private var appState
   @Environment(ModifierFlags.self) private var modifierFlags
 
@@ -61,7 +62,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       Spacer()
         .frame(width: showIcons ? 5 : 10)
 
-      if let accessoryImage {
+      if showHexColorSwatch, let accessoryImage {
         Image(nsImage: accessoryImage)
           .accessibilityIdentifier("copy-history-item")
           .padding(.trailing, 5)

--- a/Maccy/Views/PasteStackItemView.swift
+++ b/Maccy/Views/PasteStackItemView.swift
@@ -21,13 +21,20 @@ struct PasteStackItemView: View {
   var index: Int?
   var isSelected: Bool
 
+  @Default(.showHexColorSwatch) private var showHexColorSwatch
+
+  private var colorSwatchImage: NSImage? {
+    guard showHexColorSwatch else { return nil }
+    return ColorImage.from(item.title)
+  }
+
   var body: some View {
     ListItemView(
       id: PasteStackId(pasteStackId: stack.id, itemId: item.id),
       selectionId: stack.id,
       appIcon: item.applicationImage,
       image: index != nil ? item.thumbnailImage : nil,
-      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
+      accessoryImage: item.thumbnailImage != nil ? nil : colorSwatchImage,
       attributedTitle: item.attributedTitle,
       shortcuts: [],
       isSelected: isSelected,


### PR DESCRIPTION
Summary

  - Adds a new "Show hex color swatch" toggle in the Appearance settings pane
  - When enabled (default), a 12x12 color swatch preview is shown next to clipboard items whose text is a valid hex color code (e.g. #ff8942, fff)
  - When disabled, hex color strings appear as plain text without a swatch

  Implementation

  - New showHexColorSwatch boolean preference key (default: true) in Defaults.Keys
  - ListItemView gates the accessoryImage rendering on the new setting, following the same @Default pattern used by showApplicationIcons
  - Defaults.Toggle added to AppearanceSettingsPane between "Show application icons" and "Show footer"
  - Localization strings added to all 41 locale files (English translated, others left empty for future translation)

  Files changed

  - Maccy/Extensions/Defaults.Keys+Names.swift — new key
  - Maccy/Views/ListItemView.swift — gate accessory image on setting
  - Maccy/Settings/AppearanceSettingsPane.swift — new toggle
  - Maccy/Settings/*/AppearanceSettings.strings — localization entries (41 files)

  Test plan

  - Open Preferences > Appearance, verify "Show hex color swatch" toggle is visible
  - Copy a hex color string (e.g. #ff8942), verify swatch appears when toggle is on
  - Disable the toggle, verify swatch no longer appears for hex color items
  - Re-enable the toggle, verify swatch reappears