### PR TITLE
perf: use in-memory cache instead of full DB fetch in findSimilarItem

### DIFF
--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -445,17 +445,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   @MainActor
   private func findSimilarItem(_ item: HistoryItem) -> HistoryItem? {
-    let descriptor = FetchDescriptor<HistoryItem>()
-    if let all = try? Storage.shared.context.fetch(descriptor) {
-      let duplicates = all.filter({ $0 == item || $0.supersedes(item) })
-      if duplicates.count > 1 {
-        return duplicates.first(where: { $0 != item })
-      } else {
-        return isModified(item)
-      }
+    if let duplicate = all.first(where: { $0.item.supersedes(item) }) {
+      return duplicate.item
     }
 
-    return item
+    return isModified(item)
   }
 
   private func isModified(_ item: HistoryItem) -> HistoryItem? {


### PR DESCRIPTION
## Problem

  Every clipboard change triggered a full SwiftData fetch of all history items with no predicate, causing synchronous disk I/O on the main thread. When large text was copied, this blocked the main thread for several seconds before the hotkey could respond.

## Root Cause

  `findSimilarItem` was fetching all records from SQLite on every call:

  ```swift
  let descriptor = FetchDescriptor<HistoryItem>()
  Storage.shared.context.fetch(descriptor)  // full table scan, no predicate
```

  History already maintains self.all as a complete in-memory list. There was no need to hit the database at all.


## Related Issues
https://github.com/p0deje/Maccy/issues/1080