### PR TITLE
Configurable popup size (width/height) in Appearance settings

### DIFF
--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -23,10 +23,10 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     self.onClose = onClose
 
     super.init(
-        contentRect: contentRect,
-        styleMask: [.nonactivatingPanel, .resizable, .closable, .fullSizeContentView],
-        backing: .buffered,
-        defer: false
+      contentRect: contentRect,
+      styleMask: [.nonactivatingPanel, .resizable, .closable, .fullSizeContentView],
+      backing: .buffered,
+      defer: false
     )
 
     self.statusBarButton = statusBarButton
@@ -55,10 +55,11 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
       rootView: view()
         // The safe area is ignored because the title bar still interferes with the geometry
         .ignoresSafeArea()
-        .gesture(DragGesture()
-          .onEnded { _ in
-            self.saveWindowPosition()
-        })
+        .gesture(
+          DragGesture()
+            .onEnded { _ in
+              self.saveWindowPosition()
+            })
     )
     contentView?.layer?.cornerRadius = Popup.cornerRadius + Popup.horizontalPadding
   }
@@ -73,7 +74,8 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
   func open(height: CGFloat, at popupPosition: PopupPosition = Defaults[.popupPosition]) {
     let size = Defaults[.windowSize]
-    setContentSize(NSSize(width: min(frame.width, size.width), height: min(height, size.height)))
+    AppState.shared.preview.contentWidth = size.width
+    setContentSize(NSSize(width: size.width, height: min(height, size.height)))
     setFrameOrigin(popupPosition.origin(size: frame.size, statusBarButton: statusBarButton))
     orderFrontRegardless()
     makeKey()
@@ -112,7 +114,8 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
       let anchorX = frame.minX + width / 2 - screenFrame.minX
       let anchorY = frame.maxY - screenFrame.minY
-      Defaults[.windowPosition] = NSPoint(x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
+      Defaults[.windowPosition] = NSPoint(
+        x: anchorX / screenFrame.width, y: anchorY / screenFrame.height)
     }
   }
 

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -15,6 +15,7 @@ struct AppearanceSettingsPane: View {
   @Default(.showSearch) private var showSearch
   @Default(.searchVisibility) private var searchVisibility
   @Default(.showFooter) private var showFooter
+  @Default(.windowSize) private var windowSize
   @Default(.windowPosition) private var windowPosition
   @Default(.showApplicationIcons) private var showApplicationIcons
 
@@ -47,6 +48,40 @@ struct AppearanceSettingsPane: View {
     formatter.maximum = 100_000
     return formatter
   }()
+
+  private let popupWidthFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.minimum = 300
+    formatter.maximum = 1600
+    return formatter
+  }()
+
+  private let popupHeightFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.minimum = 200
+    formatter.maximum = 2000
+    return formatter
+  }()
+
+  private var popupWidth: Binding<Double> {
+    Binding(get: {
+      Double(windowSize.width)
+    }, set: { newValue in
+      var size = windowSize
+      size.width = CGFloat(min(max(newValue, 300), 1600))
+      windowSize = size
+    })
+  }
+
+  private var popupHeight: Binding<Double> {
+    Binding(get: {
+      Double(windowSize.height)
+    }, set: { newValue in
+      var size = windowSize
+      size.height = CGFloat(min(max(newValue, 200), 2000))
+      windowSize = size
+    })
+  }
 
   var body: some View {
     Settings.Container(contentWidth: 650) {
@@ -108,6 +143,34 @@ struct AppearanceSettingsPane: View {
           Stepper("", value: $previewDelay, in: 200...100_000)
             .labelsHidden()
         }
+      }
+
+      Settings.Section(label: { Text("WindowSize", tableName: "AppearanceSettings") }) {
+        HStack {
+          Text("PopupWidth", tableName: "AppearanceSettings")
+          TextField("", value: popupWidth, formatter: popupWidthFormatter)
+            .frame(width: 80)
+          Stepper("", value: popupWidth, in: 300...1600, step: 10)
+            .labelsHidden()
+
+          Text("PopupHeight", tableName: "AppearanceSettings")
+            .padding(.leading, 8)
+          TextField("", value: popupHeight, formatter: popupHeightFormatter)
+            .frame(width: 80)
+          Stepper("", value: popupHeight, in: 200...2000, step: 10)
+            .labelsHidden()
+
+          Button {
+            _windowSize.reset()
+          } label: {
+            Image(systemName: "arrow.uturn.backward.circle.fill")
+              .imageScale(.large)
+          }
+          .buttonStyle(.borderless)
+          .help(Text("WindowSizeReset", tableName: "AppearanceSettings"))
+          .disabled(windowSize == _windowSize.defaultValue)
+        }
+        .help(Text("WindowSizeTooltip", tableName: "AppearanceSettings"))
       }
 
       Settings.Section(

--- a/Maccy/Settings/en.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/en.lproj/AppearanceSettings.strings
@@ -18,6 +18,11 @@
 "ImageHeightTooltip" = "Maximum image preview height.\nDefault: 40.\nHint: Set to 16 to look like text items.";
 "PreviewDelay" = "Preview delay:";
 "PreviewDelayTooltip" = "Delay in milliseconds until a preview popup is shown.\nDefault: 1500.";
+"WindowSize" = "Popup size:";
+"PopupWidth" = "Width";
+"PopupHeight" = "Height";
+"WindowSizeReset" = "Reset size";
+"WindowSizeTooltip" = "Change the maximum popup size. The popup may shrink if there are only a few items.";
 "HighlightMatches" = "Highlight matches:";
 "HighlightMatchColor" = "Color";
 "HighlightMatchBold" = "Bold";

--- a/Maccy/Settings/es.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/es.lproj/AppearanceSettings.strings
@@ -18,6 +18,11 @@
 "ImageHeightTooltip" = "Tamaño máximo de la previsualización de imágenes.\nPor defecto: 40.\nNota: Seleccionar 16 para igualar al tamaño del texto.";
 "PreviewDelay" = "Retraso de vista previa:";
 "PreviewDelayTooltip" = "Retraso en milisegundos hasta que se muestra una ventana emergente de vista previa.\nPor defecto: 1500.";
+"WindowSize" = "Tamaño de la ventana emergente:";
+"PopupWidth" = "Ancho";
+"PopupHeight" = "Alto";
+"WindowSizeReset" = "Restablecer tamaño";
+"WindowSizeTooltip" = "Cambia el tamaño máximo de la ventana emergente. Puede encogerse si hay pocos elementos.";
 "HighlightMatches" = "Partidos destacados:";
 "HighlightMatchColor" = "Color";
 "HighlightMatchBold" = "Negrita";


### PR DESCRIPTION
Hi! I’m a big fan of Maccy, I use it every day. Thanks for building and maintaining it.

This PR adds a preference to customize the popup window size (width + max height). My main pain point was that the popup could feel “full screen” on my setup, covering most of the screen and making it hard to keep seeing what 
I’m working on while browsing clipboard history.

What’s included:
- New Appearance preference: Popup size (Width / Height) with a Reset button
- Height continues to behave as a maximum (popup can shrink if there are only a few items)
- Width is respected on open (keeps content width in sync so it doesn’t snap back)

Why merge to master:
- Improves usability for users on smaller screens / large history lists / multi-monitor workflows
- Makes the UI feel less intrusive without changing defaults
- Low risk: uses existing windowSize preference plumbing and stays within reasonable bounds

Notes:
- No behavior change unless the user modifies the new setting
- Default remains the same as current behavior


Screenshots:

<img width="692" height="511" alt="image" src="https://github.com/user-attachments/assets/059a16e7-2fc6-43bb-a5ba-5eb684820aa5" />
