### PR TITLE
This PR adds a new ignore rule for clipboard entries based on plain-text length, introduces related settings UI, and completes Chinese localization for the new feature. It also fixes a UI truncation issue in the Ignore settings tab when localized labels are longer.

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		DA9C3C5E2C20E1190056795D /* IgnoreApplicationsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9C3C5D2C20E1190056795D /* IgnoreApplicationsSettingsView.swift */; };
 		DA9C3C602C20E1890056795D /* IgnorePasteboardTypesSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9C3C5F2C20E1890056795D /* IgnorePasteboardTypesSettingsView.swift */; };
 		DA9C3C622C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9C3C612C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift */; };
+		2F8A4EAD2F4F100100ABC001 /* IgnoreTextLengthSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A4EAC2F4F100100ABC001 /* IgnoreTextLengthSettingsView.swift */; };
 		DA9C3C652C211B5F0056795D /* AdvancedSettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9C3C642C211B5F0056795D /* AdvancedSettingsPane.swift */; };
 		DAA072D12C4089D3006DDFD2 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA072D02C4089D3006DDFD2 /* VisualEffectView.swift */; };
 		DAA072D32C40A961006DDFD2 /* Color+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA072D22C40A961006DDFD2 /* Color+Random.swift */; };
@@ -451,6 +452,7 @@
 		DA9C3C5D2C20E1190056795D /* IgnoreApplicationsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreApplicationsSettingsView.swift; sourceTree = "<group>"; };
 		DA9C3C5F2C20E1890056795D /* IgnorePasteboardTypesSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnorePasteboardTypesSettingsView.swift; sourceTree = "<group>"; };
 		DA9C3C612C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreRegexpsSettingsView.swift; sourceTree = "<group>"; };
+		2F8A4EAC2F4F100100ABC001 /* IgnoreTextLengthSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreTextLengthSettingsView.swift; sourceTree = "<group>"; };
 		DA9C3C642C211B5F0056795D /* AdvancedSettingsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsPane.swift; sourceTree = "<group>"; };
 		DAA072D02C4089D3006DDFD2 /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		DAA072D22C40A961006DDFD2 /* Color+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Random.swift"; sourceTree = "<group>"; };
@@ -771,6 +773,7 @@
 				DA9C3C5D2C20E1190056795D /* IgnoreApplicationsSettingsView.swift */,
 				DA9C3C5F2C20E1890056795D /* IgnorePasteboardTypesSettingsView.swift */,
 				DA9C3C612C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift */,
+				2F8A4EAC2F4F100100ABC001 /* IgnoreTextLengthSettingsView.swift */,
 			);
 			path = IgnoreSettingsPane;
 			sourceTree = "<group>";
@@ -1083,6 +1086,7 @@
 				2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */,
 				DA1969102C3F0AAC00258481 /* KeyShortcut.swift in Sources */,
 				DA9C3C622C20E1BF0056795D /* IgnoreRegexpsSettingsView.swift in Sources */,
+				2F8A4EAD2F4F100100ABC001 /* IgnoreTextLengthSettingsView.swift in Sources */,
 				DA243D142C2F66DD0012A27F /* Storage.swift in Sources */,
 				2F0EC7812E773F1D003E2EA9 /* PasteStack.swift in Sources */,
 				DA5078992CF2676B00215488 /* MouseMovedViewModifer.swift in Sources */,

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -246,19 +246,37 @@ class Clipboard {
   }
 
   private func shouldIgnore(_ item: NSPasteboardItem) -> Bool {
+    let string = item.string(forType: .string)
+
+    if shouldIgnore(string) {
+      return true
+    }
+
+    guard let string else {
+      return false
+    }
+
     for regexp in Defaults[.ignoreRegexp] {
-      if let string = item.string(forType: .string) {
-        do {
-          let regex = try NSRegularExpression(pattern: regexp)
-          if regex.numberOfMatches(in: string, range: NSRange(string.startIndex..., in: string)) > 0 {
-            return true
-          }
-        } catch {
-          return false
+      do {
+        let regex = try NSRegularExpression(pattern: regexp)
+        if regex.numberOfMatches(in: string, range: NSRange(string.startIndex..., in: string)) > 0 {
+          return true
         }
+      } catch {
+        return false
       }
     }
     return false
+  }
+
+  private func shouldIgnore(_ string: String?) -> Bool {
+    guard let maxTextLengthToRemember = Defaults[.maxTextLengthToRemember],
+          maxTextLengthToRemember > 0,
+          let string else {
+      return false
+    }
+
+    return string.count > maxTextLengthToRemember
   }
 
   private func isEmptyString(_ item: NSPasteboardItem) -> Bool {

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -20,6 +20,7 @@ extension Defaults.Keys {
   static let highlightMatch = Key<HighlightMatch>("highlightMatch", default: .bold)
   static let ignoreAllAppsExceptListed = Key<Bool>("ignoreAllAppsExceptListed", default: false)
   static let ignoreEvents = Key<Bool>("ignoreEvents", default: false)
+  static let maxTextLengthToRemember = Key<Int?>("maxTextLengthToRemember", default: nil)
   static let ignoreOnlyNextEvent = Key<Bool>("ignoreOnlyNextEvent", default: false)
   static let ignoreRegexp = Key<[String]>("ignoreRegexp", default: [])
   static let ignoredApps = Key<[String]>("ignoredApps", default: [])

--- a/Maccy/Settings/IgnoreSettingsPane.swift
+++ b/Maccy/Settings/IgnoreSettingsPane.swift
@@ -15,6 +15,10 @@ struct IgnoreSettingsPane: View {
         .tabItem {
           Text("RegexpTab", tableName: "IgnoreSettings")
         }
+      IgnoreTextLengthSettingsView()
+        .tabItem {
+          Text("TextLengthTab", tableName: "IgnoreSettings")
+        }
     }
     .frame(maxWidth: 500, minHeight: 400)
     .padding()

--- a/Maccy/Settings/IgnoreSettingsPane.swift
+++ b/Maccy/Settings/IgnoreSettingsPane.swift
@@ -20,7 +20,7 @@ struct IgnoreSettingsPane: View {
           Text("TextLengthTab", tableName: "IgnoreSettings")
         }
     }
-    .frame(maxWidth: 500, minHeight: 400)
+    .frame(minWidth: 560, maxWidth: 700, minHeight: 400)
     .padding()
   }
 }

--- a/Maccy/Settings/IgnoreSettingsPane/IgnoreTextLengthSettingsView.swift
+++ b/Maccy/Settings/IgnoreSettingsPane/IgnoreTextLengthSettingsView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import Defaults
+
+struct IgnoreTextLengthSettingsView: View {
+  @Default(.maxTextLengthToRemember) private var maxTextLengthToRemember
+
+  @State private var enabled = false
+  @State private var maxTextLength = 10_000
+
+  private let maxTextLengthFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.minimum = 1
+    formatter.maximum = 1_000_000
+    return formatter
+  }()
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Toggle(isOn: $enabled) {
+        Text("IgnoreByTextLengthEnabled", tableName: "IgnoreSettings")
+      }
+      .onChange(of: enabled) { _, isEnabled in
+        if isEnabled {
+          let value = max(maxTextLengthToRemember ?? maxTextLength, 1)
+          maxTextLength = value
+          maxTextLengthToRemember = value
+        } else {
+          maxTextLengthToRemember = nil
+        }
+      }
+
+      HStack {
+        Text("IgnoreByTextLengthLimitLabel", tableName: "IgnoreSettings")
+
+        TextField("", value: $maxTextLength, formatter: maxTextLengthFormatter)
+          .frame(width: 120)
+
+        Stepper("", value: $maxTextLength, in: 1...1_000_000)
+          .labelsHidden()
+      }
+      .disabled(!enabled)
+      .onChange(of: maxTextLength) { _, value in
+        guard enabled else {
+          return
+        }
+
+        let correctedValue = max(value, 1)
+        if value != correctedValue {
+          maxTextLength = correctedValue
+        }
+        maxTextLengthToRemember = correctedValue
+      }
+
+      Text("IgnoreByTextLengthDescription", tableName: "IgnoreSettings")
+        .fixedSize(horizontal: false, vertical: true)
+        .foregroundStyle(.gray)
+        .controlSize(.small)
+    }
+    .onAppear {
+      if let limit = maxTextLengthToRemember, limit > 0 {
+        enabled = true
+        maxTextLength = limit
+      } else {
+        enabled = false
+      }
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  IgnoreTextLengthSettingsView()
+    .environment(\.locale, .init(identifier: "en"))
+}

--- a/Maccy/Settings/en.lproj/IgnoreSettings.strings
+++ b/Maccy/Settings/en.lproj/IgnoreSettings.strings
@@ -7,3 +7,7 @@
 "IgnoredPasteboardTypesReset" = "Reset";
 "RegexpTab" = "Regular expressions";
 "IgnoredRegexpsDescription" = "It's possible to ignore certain copies from remembering based on defined regular expressions.";
+"TextLengthTab" = "Text length";
+"IgnoreByTextLengthEnabled" = "Ignore long copied text";
+"IgnoreByTextLengthLimitLabel" = "Maximum length:";
+"IgnoreByTextLengthDescription" = "Ignore copied plain text entries longer than the configured number of characters. This does not apply to non-text clipboard types.";

--- a/Maccy/Settings/zh-Hans.lproj/IgnoreSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/IgnoreSettings.strings
@@ -7,3 +7,7 @@
 "IgnoredPasteboardTypesReset" = "重置";
 "RegexpTab" = "正则表达式";
 "IgnoredRegexpsDescription" = "可以根据定义的正则表达式忽略某些副本。";
+"TextLengthTab" = "文本长度";
+"IgnoreByTextLengthEnabled" = "忽略过长的复制文本";
+"IgnoreByTextLengthLimitLabel" = "最大长度：";
+"IgnoreByTextLengthDescription" = "当复制的纯文本长度超过设置的字符数时将被忽略。此规则不适用于非文本剪贴板类型。";

--- a/Maccy/Settings/zh-Hant.lproj/IgnoreSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/IgnoreSettings.strings
@@ -7,3 +7,7 @@
 "IgnoredPasteboardTypesReset" = "重設";
 "RegexpTab" = "正規表示式";
 "IgnoredRegexpsDescription" = "可以根據所設的正規表示式來忽略特定的拷貝。";
+"TextLengthTab" = "文字長度";
+"IgnoreByTextLengthEnabled" = "忽略過長的複製文字";
+"IgnoreByTextLengthLimitLabel" = "最大長度：";
+"IgnoreByTextLengthDescription" = "當複製的純文字長度超過設定的字元數時將被忽略。此規則不適用於非文字剪貼簿類型。";

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -25,6 +25,7 @@ class ClipboardTests: XCTestCase {
   let savedIgnoreAllAppsExceptListed = Defaults[.ignoreAllAppsExceptListed]
   let savedIgnoredApps = Defaults[.ignoredApps]
   let savedIgnoredPasteboardTypes = Defaults[.ignoredPasteboardTypes]
+  let savedMaxTextLengthToRemember = Defaults[.maxTextLengthToRemember]
 
   override func setUp() {
     super.setUp()
@@ -40,6 +41,7 @@ class ClipboardTests: XCTestCase {
     Defaults[.ignoreAllAppsExceptListed] = savedIgnoreAllAppsExceptListed
     Defaults[.ignoredApps] = savedIgnoredApps
     Defaults[.ignoredPasteboardTypes] = savedIgnoredPasteboardTypes
+    Defaults[.maxTextLengthToRemember] = savedMaxTextLengthToRemember
     clipboard.clearHooks()
   }
 
@@ -78,6 +80,46 @@ class ClipboardTests: XCTestCase {
     waitForExpectations(timeout: 2)
   }
 
+  func testIgnoreStringLongerThanConfiguredMaxLength() {
+    Defaults[.maxTextLengthToRemember] = 5
+
+    let hookExpectation = expectation(description: "Hook is called")
+    hookExpectation.isInverted = true
+    clipboard.onNewCopy({ (_: HistoryItem) in
+      hookExpectation.fulfill()
+    })
+    clipboard.start()
+    pasteboard.declareTypes([.string], owner: nil)
+    pasteboard.setString("123456", forType: .string)
+    waitForExpectations(timeout: 2)
+  }
+
+  func testDoesNotIgnoreStringWhenLengthEqualsConfiguredMaxLength() {
+    Defaults[.maxTextLengthToRemember] = 6
+
+    let hookExpectation = expectation(description: "Hook is called")
+    clipboard.onNewCopy({ (_: HistoryItem) in
+      hookExpectation.fulfill()
+    })
+    clipboard.start()
+    pasteboard.declareTypes([.string], owner: nil)
+    pasteboard.setString("123456", forType: .string)
+    waitForExpectations(timeout: 2)
+  }
+
+  func testDoesNotIgnoreStringWhenMaxLengthIsNotConfigured() {
+    Defaults[.maxTextLengthToRemember] = nil
+
+    let hookExpectation = expectation(description: "Hook is called")
+    clipboard.onNewCopy({ (_: HistoryItem) in
+      hookExpectation.fulfill()
+    })
+    clipboard.start()
+    pasteboard.declareTypes([.string], owner: nil)
+    pasteboard.setString(String(repeating: "a", count: 20_000), forType: .string)
+    waitForExpectations(timeout: 2)
+  }
+
   func testDoesNotIgnoreRTF() {
     let hookExpectation = expectation(description: "Hook is called")
     clipboard.onNewCopy({ (_: HistoryItem) in
@@ -94,6 +136,19 @@ class ClipboardTests: XCTestCase {
   }
 
   func testDoesNotIgnoreHTML() {
+    let hookExpectation = expectation(description: "Hook is called")
+    clipboard.onNewCopy({ (_: HistoryItem) in
+      hookExpectation.fulfill()
+    })
+    clipboard.start()
+    pasteboard.declareTypes([.html], owner: nil)
+    pasteboard.setString("foo", forType: .html)
+    waitForExpectations(timeout: 2)
+  }
+
+  func testDoesNotApplyMaxLengthLimitToHTML() {
+    Defaults[.maxTextLengthToRemember] = 1
+
     let hookExpectation = expectation(description: "Hook is called")
     clipboard.onNewCopy({ (_: HistoryItem) in
       hookExpectation.fulfill()


### PR DESCRIPTION
## Summary / 摘要

### EN
This PR adds a new ignore rule for clipboard entries based on plain-text length, introduces related settings UI, and completes Chinese localization for the new feature. It also fixes a UI truncation issue in the Ignore settings tab when localized labels are longer.

### 中文
这个 PR 新增了“按纯文本长度忽略剪贴板内容”的规则，并提供了对应的设置页面；同时补齐了该功能的中文本地化文案。另修复了 Ignore 设置页在中文等较长文案下标签被截断的界面问题。

---

## Motivation / 背景与动机

### EN
The goal is to prevent extremely long copied text from entering clipboard history.  
We initially tried to solve this via the existing regex ignore rules, but in practice regex filtering became unreliable for very large payloads (observed around 501,997+ characters).  
Because of that limitation, we implemented a dedicated length-based ignore feature for predictable behavior.  
This direction is also aligned with similar product behavior seen in CleanClip.

### 中文
目标是避免超长文本进入剪贴板历史。  
一开始尝试通过现有的正则忽略规则实现，但在实际使用中，当文本长度非常大（实测约 501,997 字符以上）时，正则过滤会出现失效或不稳定。  
基于这个限制，我们决定直接实现一个“按长度忽略”的专用能力，以获得更可预测、稳定的行为。  
这个方案也参考了 CleanClip 的相关设计思路。

---

## Changes / 变更内容

### EN
- Added a new optional setting key:
  - `maxTextLengthToRemember` (default: `nil`, disabled by default)
- Clipboard behavior update:
  - Ignore copied plain text when `string.count > maxTextLengthToRemember`
  - Rule only applies to `.string` content
- Settings UI:
  - Added a new Ignore tab: **Text length**
  - Added toggle + numeric input (`TextField` + `Stepper`) for length threshold
- Localization:
  - Added English strings for the new tab/labels/descriptions
  - Added Simplified Chinese (`zh-Hans`) and Traditional Chinese (`zh-Hant`) strings
- UI compatibility:
  - Updated `onChange` usage to modern closure signature to avoid deprecation warnings on macOS 14+
- UI fix:
  - Set a minimum width for `IgnoreSettingsPane` to prevent tab label truncation in localized UI

### 中文
- 新增可选配置项：
  - `maxTextLengthToRemember`（默认 `nil`，即默认不启用）
- 剪贴板行为更新：
  - 当复制的纯文本满足 `string.count > maxTextLengthToRemember` 时忽略该条记录
  - 规则仅对 `.string` 内容生效
- 设置界面：
  - 在 Ignore 中新增 **Text length** 标签页
  - 新增阈值开关与数值输入（`TextField` + `Stepper`）
- 国际化：
  - 新增英文文案（tab/标签/说明）
  - 新增简体中文（`zh-Hans`）与繁体中文（`zh-Hant`）文案
- 兼容性处理：
  - 将 `onChange` 改为新版闭包签名，避免 macOS 14+ 废弃警告
- 界面修复：
  - 为 `IgnoreSettingsPane` 增加最小宽度，避免本地化文案较长时标签页被截断

---

## Testing / 测试

### EN
Targeted tests (new feature related) were run successfully:
- `ClipboardTests/testIgnoreStringLongerThanConfiguredMaxLength`
- `ClipboardTests/testDoesNotIgnoreStringWhenLengthEqualsConfiguredMaxLength`
- `ClipboardTests/testDoesNotIgnoreStringWhenMaxLengthIsNotConfigured`
- `ClipboardTests/testDoesNotApplyMaxLengthLimitToHTML`

Build verified successfully with:
- `xcodebuild ... CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO ...`

### 中文
已通过与新功能相关的定向测试：
- `ClipboardTests/testIgnoreStringLongerThanConfiguredMaxLength`
- `ClipboardTests/testDoesNotIgnoreStringWhenLengthEqualsConfiguredMaxLength`
- `ClipboardTests/testDoesNotIgnoreStringWhenMaxLengthIsNotConfigured`
- `ClipboardTests/testDoesNotApplyMaxLengthLimitToHTML`

并通过 `xcodebuild`（禁用签名参数）验证构建成功。

---

## Notes / 备注

### EN
This branch also includes the Ignore settings width fix because the truncation issue was discovered during manual verification of this feature in localized UI.

### 中文
该分支同时包含了 Ignore 设置页宽度修复，因为该问题是在本功能本地化验证过程中发现的。
