### PR TITLE
Show image dimensions in preview

### DIFF
--- a/Maccy/Extensions/NSImage+Resized.swift
+++ b/Maccy/Extensions/NSImage+Resized.swift
@@ -2,6 +2,15 @@ import AppKit.NSImage
 
 // Based on https://stackoverflow.com/questions/73062803/resizing-nsimage-keeping-aspect-ratio-reducing-the-image-size-while-trying-to-sc.
 extension NSImage {
+  /// Returns the pixel dimensions of the image.
+  /// On Retina displays, this differs from `size` which returns logical points.
+  var pixelSize: NSSize {
+    if let bitmapRep = representations.first(where: { $0 is NSBitmapImageRep }) as? NSBitmapImageRep {
+      return NSSize(width: CGFloat(bitmapRep.pixelsWide), height: CGFloat(bitmapRep.pixelsHigh))
+    }
+    // Fallback to logical size if no bitmap representation is available
+    return size
+  }
   func resized(to newSize: NSSize) -> NSImage {
     let ratioX = newSize.width / size.width
     let ratioY = newSize.height / size.height

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -72,6 +72,13 @@ struct PreviewItemView: View {
         }
       }
 
+      if item.hasImage, let image = item.item.image {
+        HStack(spacing: 3) {
+          Text("Dimensions", tableName: "PreviewItemView")
+          Text("\(Int(image.pixelSize.width))×\(Int(image.pixelSize.height))")
+        }
+      }
+
       HStack(spacing: 3) {
         Text("FirstCopyTime", tableName: "PreviewItemView")
         Text(item.item.firstCopiedAt, style: .date)
@@ -87,13 +94,6 @@ struct PreviewItemView: View {
       HStack(spacing: 3) {
         Text("NumberOfCopies", tableName: "PreviewItemView")
         Text(String(item.item.numberOfCopies))
-      }
-
-      if item.hasImage, let image = item.item.image {
-        HStack(spacing: 3) {
-          Text("Dimensions", tableName: "PreviewItemView")
-          Text("\(Int(image.size.width))×\(Int(image.size.height))")
-        }
       }
     }
     .controlSize(.small)

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -88,6 +88,13 @@ struct PreviewItemView: View {
         Text("NumberOfCopies", tableName: "PreviewItemView")
         Text(String(item.item.numberOfCopies))
       }
+
+      if item.hasImage, let image = item.item.image {
+        HStack(spacing: 3) {
+          Text("Dimensions", tableName: "PreviewItemView")
+          Text("\(Int(image.size.width))×\(Int(image.size.height))")
+        }
+      }
     }
     .controlSize(.small)
   }

--- a/Maccy/Views/ar.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ar.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "اضغط على {pinKey} للتثبيت أو إلغاء التثبيت.";
 "DeleteKey" = "اضغط على {deleteKey} للحذف.";
 "PreviewKey" = "اضغط على {previewKey} لتبديل المعاينة.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "الأبعاد:";

--- a/Maccy/Views/ar.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ar.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "اضغط على {pinKey} للتثبيت أو إلغاء التثبيت.";
 "DeleteKey" = "اضغط على {deleteKey} للحذف.";
 "PreviewKey" = "اضغط على {previewKey} لتبديل المعاينة.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/be.lproj/PreviewItemView.strings
+++ b/Maccy/Views/be.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Націсніце {pinKey}, каб адмацаваць.";
 "DeleteKey" = "Націсніце {deleteKey}, каб выдаліць.";
 "PreviewKey" = "Націсніце {previewKey} для пераключэння перадпрагляду.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Памеры:";

--- a/Maccy/Views/be.lproj/PreviewItemView.strings
+++ b/Maccy/Views/be.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Націсніце {pinKey}, каб адмацаваць.";
 "DeleteKey" = "Націсніце {deleteKey}, каб выдаліць.";
 "PreviewKey" = "Націсніце {previewKey} для пераключэння перадпрагляду.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/bn.lproj/PreviewItemView.strings
+++ b/Maccy/Views/bn.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/bn.lproj/PreviewItemView.strings
+++ b/Maccy/Views/bn.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "মাত্রা:";

--- a/Maccy/Views/bs.lproj/PreviewItemView.strings
+++ b/Maccy/Views/bs.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Pritisni {pinKey} Zakačiš.";
 "DeleteKey" = "Pritisni {deleteKey} za brisanje.";
 "PreviewKey" = "Pritisni {previewKey} da uključite/isključite pregled.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimenzije:";

--- a/Maccy/Views/bs.lproj/PreviewItemView.strings
+++ b/Maccy/Views/bs.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Pritisni {pinKey} Zakačiš.";
 "DeleteKey" = "Pritisni {deleteKey} za brisanje.";
 "PreviewKey" = "Pritisni {previewKey} da uključite/isključite pregled.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ca.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ca.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ckb.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ckb.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "دوگمەی {pinKey} دابگرە بۆ لابردنی چەسپاندن.";
 "DeleteKey" = "دوگمەی {deleteKey} دابگرە بۆ سڕینەوە.";
 "PreviewKey" = "{previewKey} دابگرە بۆ گۆڕینی پێشبینین.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "قەبارە:";

--- a/Maccy/Views/ckb.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ckb.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "دوگمەی {pinKey} دابگرە بۆ لابردنی چەسپاندن.";
 "DeleteKey" = "دوگمەی {deleteKey} دابگرە بۆ سڕینەوە.";
 "PreviewKey" = "{previewKey} دابگرە بۆ گۆڕینی پێشبینین.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/cs.lproj/PreviewItemView.strings
+++ b/Maccy/Views/cs.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Stiskni {pinKey} pro odepnutí.";
 "DeleteKey" = "Stiskni {deleteKey} pro smazání.";
 "PreviewKey" = "Stiskni {previewKey} pro přepnutí náhledu.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/cs.lproj/PreviewItemView.strings
+++ b/Maccy/Views/cs.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Stiskni {pinKey} pro odepnutí.";
 "DeleteKey" = "Stiskni {deleteKey} pro smazání.";
 "PreviewKey" = "Stiskni {previewKey} pro přepnutí náhledu.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Rozměry:";

--- a/Maccy/Views/de.lproj/PreviewItemView.strings
+++ b/Maccy/Views/de.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Drücke {pinKey} zum Lösen.";
 "DeleteKey" = "Drücke {deleteKey} zum Löschen.";
 "PreviewKey" = "Drücke {previewKey} um Vorschau umzuschalten.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Abmessungen:";

--- a/Maccy/Views/de.lproj/PreviewItemView.strings
+++ b/Maccy/Views/de.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Drücke {pinKey} zum Lösen.";
 "DeleteKey" = "Drücke {deleteKey} zum Löschen.";
 "PreviewKey" = "Drücke {previewKey} um Vorschau umzuschalten.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/el.lproj/PreviewItemView.strings
+++ b/Maccy/Views/el.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/el.lproj/PreviewItemView.strings
+++ b/Maccy/Views/el.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Διαστάσεις:";

--- a/Maccy/Views/en.lproj/PreviewItemView.strings
+++ b/Maccy/Views/en.lproj/PreviewItemView.strings
@@ -2,6 +2,7 @@
 "FirstCopyTime" = "First copy time:";
 "LastCopyTime" = "Last copy time:";
 "NumberOfCopies" = "Number of copies:";
+"Dimensions" = "Dimensions:";
 "PinKey" = "Press {pinKey} to pin.";
 "UnpinKey" = "Press {pinKey} to unpin.";
 "DeleteKey" = "Press {deleteKey} to delete.";

--- a/Maccy/Views/eo.lproj/PreviewItemView.strings
+++ b/Maccy/Views/eo.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "Premu {deleteKey} por forigi.";
 "UnpinKey" = "Premu {pinKey} por malfiksi.";
 "PreviewKey" = "";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/eo.lproj/PreviewItemView.strings
+++ b/Maccy/Views/eo.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "Premu {deleteKey} por forigi.";
 "UnpinKey" = "Premu {pinKey} por malfiksi.";
 "PreviewKey" = "";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensioj:";

--- a/Maccy/Views/es.lproj/PreviewItemView.strings
+++ b/Maccy/Views/es.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Presiona {pinKey} para desanclar.";
 "DeleteKey" = "Presiona {deleteKey} para borrar.";
 "PreviewKey" = "Presiona {previewKey} para alternar la vista previa.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/es.lproj/PreviewItemView.strings
+++ b/Maccy/Views/es.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Presiona {pinKey} para desanclar.";
 "DeleteKey" = "Presiona {deleteKey} para borrar.";
 "PreviewKey" = "Presiona {previewKey} para alternar la vista previa.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensiones:";

--- a/Maccy/Views/fa.lproj/PreviewItemView.strings
+++ b/Maccy/Views/fa.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "برای حذف، کلید {deleteKey} را فشار دهید.";
 "UnpinKey" = "برای برداشتن سنجاق، کلید {pinKey} را فشار دهید.";
 "PreviewKey" = "{previewKey} را فشار دهید تا پیش‌نمایش تغییر کند.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "ابعاد:";

--- a/Maccy/Views/fa.lproj/PreviewItemView.strings
+++ b/Maccy/Views/fa.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "برای حذف، کلید {deleteKey} را فشار دهید.";
 "UnpinKey" = "برای برداشتن سنجاق، کلید {pinKey} را فشار دهید.";
 "PreviewKey" = "{previewKey} را فشار دهید تا پیش‌نمایش تغییر کند.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/fr.lproj/PreviewItemView.strings
+++ b/Maccy/Views/fr.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Appuyez sur {pinKey} pour épingler.";
 "DeleteKey" = "Appuyez sur {deleteKey} pour supprimer.";
 "PreviewKey" = "Appuyez sur {previewKey} pour basculer l'aperçu.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/fr.lproj/PreviewItemView.strings
+++ b/Maccy/Views/fr.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Appuyez sur {pinKey} pour épingler.";
 "DeleteKey" = "Appuyez sur {deleteKey} pour supprimer.";
 "PreviewKey" = "Appuyez sur {previewKey} pour basculer l'aperçu.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensions :";

--- a/Maccy/Views/he.lproj/PreviewItemView.strings
+++ b/Maccy/Views/he.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "יש ללחוץ על {pinKey} כדי לנעוץ / לשחרר.";
 "DeleteKey" = "יש ללחוץ על {deleteKey} כדי למחוק.";
 "PreviewKey" = "לחץ על {previewKey} כדי להחליף תצוגה מקדימה.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "ממדים:";

--- a/Maccy/Views/he.lproj/PreviewItemView.strings
+++ b/Maccy/Views/he.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "יש ללחוץ על {pinKey} כדי לנעוץ / לשחרר.";
 "DeleteKey" = "יש ללחוץ על {deleteKey} כדי למחוק.";
 "PreviewKey" = "לחץ על {previewKey} כדי להחליף תצוגה מקדימה.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/hi.lproj/PreviewItemView.strings
+++ b/Maccy/Views/hi.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/hi.lproj/PreviewItemView.strings
+++ b/Maccy/Views/hi.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "";
 "UnpinKey" = "";
 "PreviewKey" = "";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "आयाम:";

--- a/Maccy/Views/hr.lproj/PreviewItemView.strings
+++ b/Maccy/Views/hr.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Pritisnite {pinKey} za otkvačivanje.";
 "DeleteKey" = "Pritisnite {deleteKey} za brisanje.";
 "PreviewKey" = "Pritisnite {previewKey} za uključivanje/isključivanje pregleda.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimenzije:";

--- a/Maccy/Views/hr.lproj/PreviewItemView.strings
+++ b/Maccy/Views/hr.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Pritisnite {pinKey} za otkvačivanje.";
 "DeleteKey" = "Pritisnite {deleteKey} za brisanje.";
 "PreviewKey" = "Pritisnite {previewKey} za uključivanje/isključivanje pregleda.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/hu.lproj/PreviewItemView.strings
+++ b/Maccy/Views/hu.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Nyomd meg a {pinKey} gombokat a kitűzés levételéhez.";
 "DeleteKey" = "Nyomd meg a {deleteKey} gombokat a törléshez.";
 "PreviewKey" = "Nyomja meg a {previewKey} gombot az előnézet váltásához.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/hu.lproj/PreviewItemView.strings
+++ b/Maccy/Views/hu.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Nyomd meg a {pinKey} gombokat a kitűzés levételéhez.";
 "DeleteKey" = "Nyomd meg a {deleteKey} gombokat a törléshez.";
 "PreviewKey" = "Nyomja meg a {previewKey} gombot az előnézet váltásához.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Méretek:";

--- a/Maccy/Views/id.lproj/PreviewItemView.strings
+++ b/Maccy/Views/id.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "Tekan tombol {deleteKey} untuk menghapus.";
 "UnpinKey" = "Tekan tombol {pinKey} untuk melepas pin.";
 "PreviewKey" = "Tekan tombol {previewKey} untuk beralih pratinjau.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensi:";

--- a/Maccy/Views/id.lproj/PreviewItemView.strings
+++ b/Maccy/Views/id.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "Tekan tombol {deleteKey} untuk menghapus.";
 "UnpinKey" = "Tekan tombol {pinKey} untuk melepas pin.";
 "PreviewKey" = "Tekan tombol {previewKey} untuk beralih pratinjau.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/it.lproj/PreviewItemView.strings
+++ b/Maccy/Views/it.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Premi {pinKey} per sbloccare.";
 "DeleteKey" = "Premi {deleteKey} per cancellare.";
 "PreviewKey" = "Premi {previewKey} per attivare/disattivare l'anteprima.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/it.lproj/PreviewItemView.strings
+++ b/Maccy/Views/it.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Premi {pinKey} per sbloccare.";
 "DeleteKey" = "Premi {deleteKey} per cancellare.";
 "PreviewKey" = "Premi {previewKey} per attivare/disattivare l'anteprima.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensioni:";

--- a/Maccy/Views/ja.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ja.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "{deleteKey}で削除します。";
 "UnpinKey" = "{pinKey}でピン留めを外します。";
 "PreviewKey" = "{previewKey}でプレビューを切り替えます。";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "サイズ:";

--- a/Maccy/Views/ja.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ja.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "{deleteKey}で削除します。";
 "UnpinKey" = "{pinKey}でピン留めを外します。";
 "PreviewKey" = "{previewKey}でプレビューを切り替えます。";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ko.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ko.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "{pinKey}를 눌러 고정(해제)합니다.";
 "DeleteKey" = "{deleteKey}를 눌러 제거합니다.";
 "PreviewKey" = "{previewKey}를 눌러 미리보기를 전환합니다.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "크기:";

--- a/Maccy/Views/ko.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ko.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "{pinKey}를 눌러 고정(해제)합니다.";
 "DeleteKey" = "{deleteKey}를 눌러 제거합니다.";
 "PreviewKey" = "{previewKey}를 눌러 미리보기를 전환합니다.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/lt.lproj/PreviewItemView.strings
+++ b/Maccy/Views/lt.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "PinKey" = "Paspauskite {pinKey}, kad prisegtumėte.";
 "UnpinKey" = "Paspauskite {pinKey}, kad neprisegtumėte.";
 "PreviewKey" = "Paspauskite {previewKey} peržiūrai perjungti.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/lt.lproj/PreviewItemView.strings
+++ b/Maccy/Views/lt.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "PinKey" = "Paspauskite {pinKey}, kad prisegtumėte.";
 "UnpinKey" = "Paspauskite {pinKey}, kad neprisegtumėte.";
 "PreviewKey" = "Paspauskite {previewKey} peržiūrai perjungti.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Matmenys:";

--- a/Maccy/Views/lv.lproj/PreviewItemView.strings
+++ b/Maccy/Views/lv.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Nospiediet {pinKey}, lai atspraust.";
 "DeleteKey" = "Nospiediet {deleteKey}, lai dzēstu.";
 "PreviewKey" = "Nospiediet {previewKey}, lai pārslēgtu priekšskatījumu.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/lv.lproj/PreviewItemView.strings
+++ b/Maccy/Views/lv.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Nospiediet {pinKey}, lai atspraust.";
 "DeleteKey" = "Nospiediet {deleteKey}, lai dzēstu.";
 "PreviewKey" = "Nospiediet {previewKey}, lai pārslēgtu priekšskatījumu.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Izmēri:";

--- a/Maccy/Views/nb.lproj/PreviewItemView.strings
+++ b/Maccy/Views/nb.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Trykk {pinKey} for å avmerke.";
 "DeleteKey" = "Trykk {deleteKey} for å slette.";
 "PreviewKey" = "Trykk {previewKey} for å veksle forhåndsvisning.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/nb.lproj/PreviewItemView.strings
+++ b/Maccy/Views/nb.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Trykk {pinKey} for å avmerke.";
 "DeleteKey" = "Trykk {deleteKey} for å slette.";
 "PreviewKey" = "Trykk {previewKey} for å veksle forhåndsvisning.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensjoner:";

--- a/Maccy/Views/nl.lproj/PreviewItemView.strings
+++ b/Maccy/Views/nl.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Druk op {pinKey} om te ontpinnen.";
 "DeleteKey" = "Druk op {deleteKey} om te verwijderen.";
 "PreviewKey" = "Druk op {previewKey} om voorbeeld te schakelen.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/nl.lproj/PreviewItemView.strings
+++ b/Maccy/Views/nl.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Druk op {pinKey} om te ontpinnen.";
 "DeleteKey" = "Druk op {deleteKey} om te verwijderen.";
 "PreviewKey" = "Druk op {previewKey} om voorbeeld te schakelen.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Afmetingen:";

--- a/Maccy/Views/pl.lproj/PreviewItemView.strings
+++ b/Maccy/Views/pl.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Naciśnij {pinKey} aby odpiąć wpis.";
 "DeleteKey" = "Naciśnij {deleteKey} aby usunąć wpis.";
 "PreviewKey" = "Naciśnij {previewKey}, aby przełączyć podgląd.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/pl.lproj/PreviewItemView.strings
+++ b/Maccy/Views/pl.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Naciśnij {pinKey} aby odpiąć wpis.";
 "DeleteKey" = "Naciśnij {deleteKey} aby usunąć wpis.";
 "PreviewKey" = "Naciśnij {previewKey}, aby przełączyć podgląd.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Wymiary:";

--- a/Maccy/Views/pt-BR.lproj/PreviewItemView.strings
+++ b/Maccy/Views/pt-BR.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Pressione {pinKey} para desafixar.";
 "DeleteKey" = "Pressione {deleteKey} para excluir.";
 "PreviewKey" = "Pressione {previewKey} para alternar a pré-visualização.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/pt-BR.lproj/PreviewItemView.strings
+++ b/Maccy/Views/pt-BR.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Pressione {pinKey} para desafixar.";
 "DeleteKey" = "Pressione {deleteKey} para excluir.";
 "PreviewKey" = "Pressione {previewKey} para alternar a pré-visualização.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensões:";

--- a/Maccy/Views/pt.lproj/PreviewItemView.strings
+++ b/Maccy/Views/pt.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "NumberOfCopies" = "Quantidade de cópias:";
 "UnpinKey" = "Pressione {pinKey} para desafixar.";
 "PreviewKey" = "Pressione {previewKey} para alternar a pré-visualização.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensões:";

--- a/Maccy/Views/pt.lproj/PreviewItemView.strings
+++ b/Maccy/Views/pt.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "NumberOfCopies" = "Quantidade de cópias:";
 "UnpinKey" = "Pressione {pinKey} para desafixar.";
 "PreviewKey" = "Pressione {previewKey} para alternar a pré-visualização.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ro.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ro.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Apasă {pinKey} pentru a detașa.";
 "DeleteKey" = "Apasă {deleteKey} pentru a șterge.";
 "PreviewKey" = "Apasă {previewKey} pentru a comuta previzualizarea.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ro.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ro.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Apasă {pinKey} pentru a detașa.";
 "DeleteKey" = "Apasă {deleteKey} pentru a șterge.";
 "PreviewKey" = "Apasă {previewKey} pentru a comuta previzualizarea.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimensiuni:";

--- a/Maccy/Views/ru.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ru.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Нажмите {pinKey}, чтобы открепить.";
 "DeleteKey" = "Нажмите {deleteKey}, чтобы удалить.";
 "PreviewKey" = "Нажмите {previewKey} для переключения предпросмотра.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ru.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ru.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Нажмите {pinKey}, чтобы открепить.";
 "DeleteKey" = "Нажмите {deleteKey}, чтобы удалить.";
 "PreviewKey" = "Нажмите {previewKey} для переключения предпросмотра.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Размеры:";

--- a/Maccy/Views/sl.lproj/PreviewItemView.strings
+++ b/Maccy/Views/sl.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "PinKey" = "Pritisnite {pinKey} za zapenjanje.";
 "UnpinKey" = "Pritisnite {pinKey} za odzapenjanje.";
 "PreviewKey" = "Pritisnite {previewKey} za preklop predogleda.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/sl.lproj/PreviewItemView.strings
+++ b/Maccy/Views/sl.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "PinKey" = "Pritisnite {pinKey} za zapenjanje.";
 "UnpinKey" = "Pritisnite {pinKey} za odzapenjanje.";
 "PreviewKey" = "Pritisnite {previewKey} za preklop predogleda.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Dimenzije:";

--- a/Maccy/Views/sv.lproj/PreviewItemView.strings
+++ b/Maccy/Views/sv.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "";
 "DeleteKey" = "";
 "PreviewKey" = "";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Mått:";

--- a/Maccy/Views/sv.lproj/PreviewItemView.strings
+++ b/Maccy/Views/sv.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "";
 "DeleteKey" = "";
 "PreviewKey" = "";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ta.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ta.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "DeleteKey" = "நீக்க {deleteKey} ஐ அழுத்தவும்.";
 "UnpinKey" = "முள்ளை அகற்ற {pinKey} ஐ அழுத்தவும்.";
 "PreviewKey" = "முன்னோட்டத்தை மாற்ற {previewKey} அழுத்தவும்.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/ta.lproj/PreviewItemView.strings
+++ b/Maccy/Views/ta.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "DeleteKey" = "நீக்க {deleteKey} ஐ அழுத்தவும்.";
 "UnpinKey" = "முள்ளை அகற்ற {pinKey} ஐ அழுத்தவும்.";
 "PreviewKey" = "முன்னோட்டத்தை மாற்ற {previewKey} அழுத்தவும்.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "பரிமாணங்கள்:";

--- a/Maccy/Views/th.lproj/PreviewItemView.strings
+++ b/Maccy/Views/th.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "กด {pinKy} เพื่อลบเข็มกลัด";
 "DeleteKey" = "กด {deleteKey} เพื่อลบ";
 "PreviewKey" = "กด {previewKey} เพื่อสลับตัวอย่าง";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/th.lproj/PreviewItemView.strings
+++ b/Maccy/Views/th.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "กด {pinKy} เพื่อลบเข็มกลัด";
 "DeleteKey" = "กด {deleteKey} เพื่อลบ";
 "PreviewKey" = "กด {previewKey} เพื่อสลับตัวอย่าง";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "ขนาด:";

--- a/Maccy/Views/tr.lproj/PreviewItemView.strings
+++ b/Maccy/Views/tr.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Kaldırmak için {pinKey}'a basın.";
 "DeleteKey" = "Silmek için {deleteKey}'a basın.";
 "PreviewKey" = "Önizlemeyi değiştirmek için {previewKey} tuşuna basın.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Boyutlar:";

--- a/Maccy/Views/tr.lproj/PreviewItemView.strings
+++ b/Maccy/Views/tr.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Kaldırmak için {pinKey}'a basın.";
 "DeleteKey" = "Silmek için {deleteKey}'a basın.";
 "PreviewKey" = "Önizlemeyi değiştirmek için {previewKey} tuşuna basın.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/uk.lproj/PreviewItemView.strings
+++ b/Maccy/Views/uk.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Натисніть {pinKey}, щоб відкріпити.";
 "DeleteKey" = "Натисніть {deleteKey}, щоб видалити.";
 "PreviewKey" = "Натисніть {previewKey} для перемикання попереднього перегляду.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Розміри:";

--- a/Maccy/Views/uk.lproj/PreviewItemView.strings
+++ b/Maccy/Views/uk.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Натисніть {pinKey}, щоб відкріпити.";
 "DeleteKey" = "Натисніть {deleteKey}, щоб видалити.";
 "PreviewKey" = "Натисніть {previewKey} для перемикання попереднього перегляду.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/uz.lproj/PreviewItemView.strings
+++ b/Maccy/Views/uz.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Biriktirishni o‘chirish uchun {pinKey} tugmasini bosing.";
 "DeleteKey" = "O‘chirish uchun {deleteKey} tugmasini bosing.";
 "PreviewKey" = "Oldindan ko'rishni yoqish/o'chirish uchun {previewKey} tugmasini bosing.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/uz.lproj/PreviewItemView.strings
+++ b/Maccy/Views/uz.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Biriktirishni o‘chirish uchun {pinKey} tugmasini bosing.";
 "DeleteKey" = "O‘chirish uchun {deleteKey} tugmasini bosing.";
 "PreviewKey" = "Oldindan ko'rishni yoqish/o'chirish uchun {previewKey} tugmasini bosing.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "O'lchamlar:";

--- a/Maccy/Views/vi.lproj/PreviewItemView.strings
+++ b/Maccy/Views/vi.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "Nhấn {pinKey} để bỏ ghim.";
 "DeleteKey" = "Nhấn {deleteKey} để xóa.";
 "PreviewKey" = "Nhấn {previewKey} để chuyển đổi xem trước.";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "Kích thước:";

--- a/Maccy/Views/vi.lproj/PreviewItemView.strings
+++ b/Maccy/Views/vi.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "Nhấn {pinKey} để bỏ ghim.";
 "DeleteKey" = "Nhấn {deleteKey} để xóa.";
 "PreviewKey" = "Nhấn {previewKey} để chuyển đổi xem trước.";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/zh-Hans.lproj/PreviewItemView.strings
+++ b/Maccy/Views/zh-Hans.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "按 {pinKey} (取消)固定。";
 "DeleteKey" = "按 {deleteKey} 删除。";
 "PreviewKey" = "按 {previewKey} 切换预览。";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "尺寸:";

--- a/Maccy/Views/zh-Hans.lproj/PreviewItemView.strings
+++ b/Maccy/Views/zh-Hans.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "按 {pinKey} (取消)固定。";
 "DeleteKey" = "按 {deleteKey} 删除。";
 "PreviewKey" = "按 {previewKey} 切换预览。";
+"Dimensions" = "Dimensions:";

--- a/Maccy/Views/zh-Hant.lproj/PreviewItemView.strings
+++ b/Maccy/Views/zh-Hant.lproj/PreviewItemView.strings
@@ -6,4 +6,4 @@
 "UnpinKey" = "按 {pinKey} (取消)固定。";
 "DeleteKey" = "按 {deleteKey} 刪除。";
 "PreviewKey" = "按 {previewKey} 切換預覽。";
-"Dimensions" = "Dimensions:";
+"Dimensions" = "尺寸:";

--- a/Maccy/Views/zh-Hant.lproj/PreviewItemView.strings
+++ b/Maccy/Views/zh-Hant.lproj/PreviewItemView.strings
@@ -6,3 +6,4 @@
 "UnpinKey" = "按 {pinKey} (取消)固定。";
 "DeleteKey" = "按 {deleteKey} 刪除。";
 "PreviewKey" = "按 {previewKey} 切換預覽。";
+"Dimensions" = "Dimensions:";


### PR DESCRIPTION
Fixes #1139.

Displays pixel dimensions (e.g. "500×300") in the preview panel when hovering over an image clipboard entry. The dimensions line only appears for image items.

Changes:
- Added a "Dimensions" row to `PreviewItemView` that reads the image size from the clipboard data
- Added the "Dimensions" localization key to all `.lproj/PreviewItemView.strings` files (non-English files use English as placeholder for Weblate to translate)