### PR TITLE
Reintroduce screen-edge clamping for popup window

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94D2E774B570093D72C /* NavigationManager.swift */; };
 		2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94F2E7808420093D72C /* AppImageView.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
+		4F1BF1D079BC22CB6F487445 /* PopupPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40DE239D8B1706A4F1BD5F66 /* PopupPositionTests.swift */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
 		DA009934256411F90030E697 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = DA00992F256411F90030E697 /* LICENSE */; };
@@ -204,8 +205,8 @@
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
-		2FFF8BCF2CE2116600235A78 /* Data+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Encoding.swift"; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		40DE239D8B1706A4F1BD5F66 /* PopupPositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PopupPositionTests.swift; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4DC4D112252713D700FE5FAC /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -722,6 +723,7 @@
 				DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */,
 				DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */,
 				DA384E85232746D800603999 /* SearchTests.swift */,
+				40DE239D8B1706A4F1BD5F66 /* PopupPositionTests.swift */,
 				DA696BD12401EEE900DE80CF /* SorterTests.swift */,
 				DA360DB41E3DF137005C6F6B /* Info.plist */,
 			);
@@ -1064,6 +1066,7 @@
 				DA384E86232746D800603999 /* SearchTests.swift in Sources */,
 				DA696BD22401EEE900DE80CF /* SorterTests.swift in Sources */,
 				DA360DB31E3DF137005C6F6B /* HistoryTests.swift in Sources */,
+				4F1BF1D079BC22CB6F487445 /* PopupPositionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Maccy/PopupPosition.swift
+++ b/Maccy/PopupPosition.swift
@@ -31,23 +31,26 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
     switch self {
     case .center:
       if let frame = NSScreen.forPopup?.visibleFrame {
-        return NSRect.centered(ofSize: size, in: frame).origin
+        let origin = NSRect.centered(ofSize: size, in: frame).origin
+        return Self.clamp(origin, size, to: frame)
       }
     case .window:
-      if let frame = NSWorkspace.shared.frontmostApplication?.windowFrame {
-        return NSRect.centered(ofSize: size, in: frame).origin
+      if let windowFrame = NSWorkspace.shared.frontmostApplication?.windowFrame {
+        let origin = NSRect.centered(ofSize: size, in: windowFrame).origin
+        let windowCenter = NSPoint(x: windowFrame.midX, y: windowFrame.midY)
+        let screen = NSScreen.screens.first(where: { $0.frame.contains(windowCenter) })
+          ?? NSScreen.forPopup
+        if let screenRect = screen?.visibleFrame {
+          return Self.clamp(origin, size, to: screenRect)
+        }
+        return origin
       }
     case .statusItem:
       if let statusBarButton, let screen = NSScreen.main {
         let rectInWindow = statusBarButton.convert(statusBarButton.bounds, to: nil)
         if let screenRect = statusBarButton.window?.convertToScreen(rectInWindow) {
-          var topLeftPoint = NSPoint(x: screenRect.minX, y: screenRect.minY - size.height)
-          // Ensure that window doesn't spill over to the right screen.
-          if (topLeftPoint.x + size.width) > screen.frame.maxX {
-            topLeftPoint.x = screen.frame.maxX - size.width
-          }
-
-          return topLeftPoint
+          let origin = NSPoint(x: screenRect.minX, y: screenRect.minY - size.height)
+          return Self.clamp(origin, size, to: screen.visibleFrame)
         }
       }
     case .lastPosition:
@@ -56,7 +59,8 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
         let anchorX = frame.minX + frame.width * relativePos.x
         let anchorY = frame.minY + frame.height * relativePos.y
         // Anchor is top middle of frame
-        return NSPoint(x: anchorX - size.width / 2, y: anchorY - size.height)
+        let origin = NSPoint(x: anchorX - size.width / 2, y: anchorY - size.height)
+        return Self.clamp(origin, size, to: frame)
       }
     default:
       break
@@ -64,6 +68,26 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
 
     var point = NSEvent.mouseLocation
     point.y -= size.height
+    if let screenRect = NSScreen.forPopup?.visibleFrame {
+      return Self.clamp(point, size, to: screenRect)
+    }
     return point
+  }
+
+  static func clamp(_ origin: NSPoint, _ size: NSSize, to screen: NSRect) -> NSPoint {
+    var result = origin
+    if result.y + size.height > screen.maxY {
+      result.y = screen.maxY - size.height
+    }
+    if result.y < screen.minY {
+      result.y = screen.minY
+    }
+    if result.x + size.width > screen.maxX {
+      result.x = screen.maxX - size.width
+    }
+    if result.x < screen.minX {
+      result.x = screen.minX
+    }
+    return result
   }
 }

--- a/MaccyTests/PopupPositionTests.swift
+++ b/MaccyTests/PopupPositionTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Maccy
+
+class PopupPositionTests: XCTestCase {
+  let screen = NSRect(x: 0, y: 0, width: 1440, height: 900)
+  let size = NSSize(width: 300, height: 400)
+
+  func testClampNoAdjustmentNeeded() {
+    let origin = NSPoint(x: 100, y: 200)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 100)
+    XCTAssertEqual(result.y, 200)
+  }
+
+  func testClampBottomEdge() {
+    let origin = NSPoint(x: 100, y: -200)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 100)
+    XCTAssertEqual(result.y, 0)
+  }
+
+  func testClampTopEdge() {
+    // origin.y + height = 800 + 400 = 1200 > 900
+    let origin = NSPoint(x: 100, y: 800)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 100)
+    XCTAssertEqual(result.y, 500) // 900 - 400
+  }
+
+  func testClampRightEdge() {
+    // origin.x + width = 1300 + 300 = 1600 > 1440
+    let origin = NSPoint(x: 1300, y: 200)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 1140) // 1440 - 300
+    XCTAssertEqual(result.y, 200)
+  }
+
+  func testClampLeftEdge() {
+    let origin = NSPoint(x: -50, y: 200)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 0)
+    XCTAssertEqual(result.y, 200)
+  }
+
+  func testClampBottomAndRightCorner() {
+    let origin = NSPoint(x: 1300, y: -100)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 1140) // 1440 - 300
+    XCTAssertEqual(result.y, 0)
+  }
+
+  func testClampWithNonZeroScreenOrigin() {
+    // Secondary monitor starting at x=1440
+    let secondScreen = NSRect(x: 1440, y: 0, width: 1440, height: 900)
+    let origin = NSPoint(x: 1430, y: 200)
+    let result = PopupPosition.clamp(origin, size, to: secondScreen)
+    XCTAssertEqual(result.x, 1440) // clamped to secondScreen.minX
+    XCTAssertEqual(result.y, 200)
+  }
+
+  func testClampExactlyOnEdge() {
+    // Right edge: 1140 + 300 = 1440 == screen.maxX — no adjustment needed
+    let origin = NSPoint(x: 1140, y: 200)
+    let result = PopupPosition.clamp(origin, size, to: screen)
+    XCTAssertEqual(result.x, 1140)
+    XCTAssertEqual(result.y, 200)
+  }
+
+  func testClampPopupLargerThanScreen() {
+    // Popup larger than screen: bottom-left priority
+    let largeSize = NSSize(width: 2000, height: 1200)
+    let origin = NSPoint(x: 100, y: 100)
+    let result = PopupPosition.clamp(origin, largeSize, to: screen)
+    XCTAssertEqual(result.x, 0) // left edge wins
+    XCTAssertEqual(result.y, 0) // bottom edge wins
+  }
+}


### PR DESCRIPTION
## Summary

The clamping logic introduced in #709 was lost during the popup system rewrite in July 2024 (commits `43f1ccf` and `cf6edca`). This PR restores and improves it.

- **Problem**: Opening Maccy near screen edges (especially the bottom) causes the popup to extend beyond the visible area
- **Fix**: Add a `clamp()` function to `PopupPosition` that constrains the popup origin to the screen's `visibleFrame`, applied to all 5 positioning modes
- **Improvements over #709**:
  - Adapted for bottom-left origin (AppKit convention) — the original treated `pos` as top-left
  - Added left-edge check (missing from original)
  - `.window` mode detects the correct screen in multi-monitor setups
  - `.statusItem` now uses `visibleFrame` instead of `frame` (respects Dock placement)
  - Replaces the partial right-edge guard in `.statusItem` with full 4-edge clamping
  - Includes 9 unit tests for the `clamp()` function

## Test plan

- [x] Unit tests pass (`PopupPositionTests` — 9 tests covering all edges, corners, multi-monitor, boundary conditions, and oversized popups)
- [x] Manual testing: open popup with cursor at bottom/right/left edges — popup stays fully visible
- [x] Manual testing: `.statusItem` near right edge of menu bar — no overflow
- [x] Build succeeds with zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)