### PR TITLE
Add option to keep selection when clearing search

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -43,6 +43,7 @@ extension Defaults.Keys {
   static let popupPosition = Key<PopupPosition>("popupPosition", default: .cursor)
   static let popupScreen = Key<Int>("popupScreen", default: 0)
   static let previewDelay = Key<Int>("previewDelay", default: 1500)
+  static let preserveSelectionAfterSearch = Key<Bool>("preserveSelectionAfterSearch", default: false)
   static let removeFormattingByDefault = Key<Bool>("removeFormattingByDefault", default: false)
   static let searchMode = Key<Search.Mode>("searchMode", default: .exact)
   static let showFooter = Key<Bool>("showFooter", default: true)

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -22,10 +22,17 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   var searchQuery: String = "" {
     didSet {
       throttler.throttle { [self] in
+        let previousSelectionID = AppState.shared.navigator.leadHistoryItem?.id
         updateItems(search.search(string: searchQuery, within: all))
 
         if searchQuery.isEmpty {
-          AppState.shared.navigator.select(item: unpinnedItems.first)
+          if Defaults[.preserveSelectionAfterSearch],
+             let previousSelectionID,
+             let previousSelection = items.first(where: { $0.id == previousSelectionID && $0.isVisible }) {
+            AppState.shared.navigator.select(item: previousSelection)
+          } else {
+            AppState.shared.navigator.select(item: unpinnedItems.first)
+          }
         } else {
           AppState.shared.navigator.highlightFirst()
         }

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -10,6 +10,7 @@ struct GeneralSettingsPane: View {
   )
 
   @Default(.searchMode) private var searchMode
+  @Default(.preserveSelectionAfterSearch) private var preserveSelectionAfterSearch
 
   @State private var copyModifier = HistoryItemAction.copy.modifierFlags.description
   @State private var pasteModifier = HistoryItemAction.paste.modifierFlags.description
@@ -73,6 +74,12 @@ struct GeneralSettingsPane: View {
         }
         .labelsHidden()
         .frame(width: 180, alignment: .leading)
+
+        Toggle(isOn: $preserveSelectionAfterSearch) {
+          Text("PreserveSelectionAfterSearch", tableName: "GeneralSettings")
+        }
+        .help(Text("PreserveSelectionAfterSearchTooltip", tableName: "GeneralSettings"))
+        .fixedSize()
       }
 
       Settings.Section(

--- a/Maccy/Settings/en.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/en.lproj/GeneralSettings.strings
@@ -19,4 +19,6 @@
 "Fuzzy" = "Fuzzy";
 "Regex" = "Regular expressions";
 "Mixed" = "Mixed";
+"PreserveSelectionAfterSearch" = "Keep selected item when clearing search";
+"PreserveSelectionAfterSearchTooltip" = "When enabled, clearing search keeps focus on the previously selected history item instead of jumping to the top.";
 "NotificationsAndSounds" = "Notifications and sounds 􀱁";

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -6,6 +6,7 @@ import Defaults
 class HistoryTests: XCTestCase {
   let savedSize = Defaults[.size]
   let savedSortBy = Defaults[.sortBy]
+  let savedPreserveSelectionAfterSearch = Defaults[.preserveSelectionAfterSearch]
   let history = History.shared
 
   override func setUp() {
@@ -13,12 +14,14 @@ class HistoryTests: XCTestCase {
     history.clearAll()
     Defaults[.size] = 10
     Defaults[.sortBy] = .firstCopiedAt
+    Defaults[.preserveSelectionAfterSearch] = false
   }
 
   override func tearDown() {
     super.tearDown()
     Defaults[.size] = savedSize
     Defaults[.sortBy] = savedSortBy
+    Defaults[.preserveSelectionAfterSearch] = savedPreserveSelectionAfterSearch
   }
 
   func testDefaultIsEmpty() {
@@ -231,6 +234,44 @@ class HistoryTests: XCTestCase {
     let bar = history.add(historyItem("bar"))
     history.delete(foo)
     XCTAssertEqual(history.items, [bar])
+  }
+
+  func testClearingSearchSelectsFirstUnpinnedItemByDefault() {
+    Defaults[.preserveSelectionAfterSearch] = false
+
+    let target = history.add(historyItem("apple marker"))
+    let topItem = history.add(historyItem("recent item"))
+
+    history.searchQuery = "apple"
+    waitForSearchUpdate()
+    XCTAssertEqual(AppState.shared.navigator.leadHistoryItem, target)
+
+    history.searchQuery = ""
+    waitForSearchUpdate()
+    XCTAssertEqual(AppState.shared.navigator.leadHistoryItem, topItem)
+  }
+
+  func testClearingSearchKeepsSelectionWhenEnabled() {
+    Defaults[.preserveSelectionAfterSearch] = true
+
+    let target = history.add(historyItem("apple marker"))
+    _ = history.add(historyItem("recent item"))
+
+    history.searchQuery = "apple"
+    waitForSearchUpdate()
+    XCTAssertEqual(AppState.shared.navigator.leadHistoryItem, target)
+
+    history.searchQuery = ""
+    waitForSearchUpdate()
+    XCTAssertEqual(AppState.shared.navigator.leadHistoryItem, target)
+  }
+
+  private func waitForSearchUpdate() {
+    let expectation = XCTestExpectation(description: "Wait for throttled search")
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 1.0)
   }
 
   private func historyItem(_ value: String) -> HistoryItem {


### PR DESCRIPTION
## Summary

Add option to keep selection when clearing search

Today, when search is cleared, Maccy always jumps selection back to the first unpinned item.
With this change, users can enable a setting to keep the previously selected item instead.

<img width="622" height="699" alt="image" src="https://github.com/user-attachments/assets/25a974e3-9850-4ef7-91be-2904f74de338" />


## Problem

My common workflow is:

1. I copy two items. A and B
2. I forget what is item B but I still remember what is A.
3. I Search for item A hoping that I find B
4. I search for A in clipboard. I find it.
5. Clear search to continue around that same position and find nearby item B.

**Current behavior resets selection to the top.**

## Changes

- Added new default key:
- `preserveSelectionAfterSearch` (default: `false`)
- Added new setting in **General → Search**:
- **Keep selected item when clearing search**
- Updated search-clear behavior in `History.searchQuery.didSet`:
- If enabled and previous selection is still visible, keep that selection.
- Otherwise fallback to existing behavior (select first unpinned item).
- Added tests in `HistoryTests` for:
- default behavior (jump to top)
- enabled behavior (preserve selection)

## Backward compatibility

- Default value is `false`, so existing behavior is unchanged unless users enable it.

## Testing

- Build passes with:
- `xcodebuild build -project Maccy.xcodeproj -scheme Maccy -configuration Release -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Added unit tests in `HistoryTests` for new behavior.

I couldn't find a way to know how to run the changes locally. I came up with these
```shell
  cd /Maccy

  # Build Release (unsigned)
  xcodebuild build \
    -project Maccy.xcodeproj \
    -scheme Maccy \
    -configuration Release \
    -destination 'platform=macOS' \
    CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO

  # Find built app
  APP_PATH="$(find ~/Library/Developer/Xcode/DerivedData -path '*Maccy*/Build/Products/Release/Maccy.app' | tail -n 1)"
  echo "$APP_PATH"

  # Replace installed app
  pkill Maccy || true
  rm -rf /Applications/Maccy.app
  cp -R "$APP_PATH" /Applications/Maccy.app

  # Remove quarantine + launch
  xattr -dr com.apple.quarantine /Applications/Maccy.app
  open /Applications/Maccy.app
```

## Notes

- Only English settings strings were added in this PR for the new option label/tooltip.



