### PR TITLE
Fix: Additional unicode characters getting added to pinned items

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -29,6 +29,11 @@ class Clipboard {
     .concealed,
     .transient
   ]
+  private let metadataTypes: Set<NSPasteboard.PasteboardType> = [
+    .fromMaccy, .source, .linkPresentationMetadata,
+    .customWebKitPasteboardData, .customChromiumWebData,
+    .chromiumSourceUrl, .chromiumSourceToken, .notesRichText
+  ]
 
   private var enabledTypes: Set<NSPasteboard.PasteboardType> { Defaults[.enabledPasteboardTypes] }
   private var disabledTypes: Set<NSPasteboard.PasteboardType> { supportedTypes.subtracting(enabledTypes) }
@@ -197,6 +202,7 @@ class Clipboard {
 
       types = types
         .subtracting(disabledTypes)
+        .subtracting(metadataTypes)
         .filter { !$0.rawValue.starts(with: dynamicTypePrefix) }
         .filter { !$0.rawValue.starts(with: microsoftSourcePrefix) }
 

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -146,7 +146,9 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     var removedItemIndex: Int?
     if let existingHistoryItem = findSimilarItem(item) {
       if isModified(item) == nil {
-        item.contents = existingHistoryItem.contents
+        item.contents = existingHistoryItem.contents.map {
+          HistoryItemContent(type: $0.type, value: $0.value)
+        }
       }
       item.firstCopiedAt = existingHistoryItem.firstCopiedAt
       item.numberOfCopies += existingHistoryItem.numberOfCopies


### PR DESCRIPTION
Fix unicode/garbled text on paste from browsers and Notes
                                                                                                                                                                                                                           
  Two fixes:
                                                                                                                                                                                                                           
  1. Clipboard.swift — strips metadata-only pasteboard types (Chrome's customWebKitPasteboardData, chromiumSourceToken, Notes' notesRichText, etc.) before storing. These tags travel alongside the real content but       
  confuse paste targets, producing garbled or extra characters.
  2. History.swift — deep-copies HistoryItemContent objects when merging a duplicate item, instead of sharing the reference. The old item is deleted from Core Data immediately after, which was silently invalidating the 
  shared content objects and leaving the new item with blank/corrupted data. 