### PR TITLE
Fix popup rendering, bounds, pinned-paste crash, and search swallow

### DIFF
--- a/Maccy/Extensions/NSImage+Resized.swift
+++ b/Maccy/Extensions/NSImage+Resized.swift
@@ -15,13 +15,38 @@ extension NSImage {
       return self
     }
 
-    return NSImage(size: newSize, flipped: false) { destRect in
-      if let context = NSGraphicsContext.current {
-        context.imageInterpolation = .high
-        self.draw(in: destRect, from: NSRect.zero, operation: .copy, fraction: 1)
-      }
+    // HiDPI: bake at the highest active backing scale so the cached bitmap
+    // stays sharp on any display the popup is dragged to.
+    let scale = NSScreen.screens.map(\.backingScaleFactor).max() ?? 2.0
+    let pixelsWide = Int((newWidth * scale).rounded())
+    let pixelsHigh = Int((newHeight * scale).rounded())
 
-      return true
+    guard let rep = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: pixelsWide, pixelsHigh: pixelsHigh,
+      bitsPerSample: 8, samplesPerPixel: 4,
+      hasAlpha: true, isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0, bitsPerPixel: 0
+    ) else {
+      return self
     }
+    rep.size = newSize
+
+    guard let ctx = NSGraphicsContext(bitmapImageRep: rep) else {
+      return self
+    }
+    NSGraphicsContext.saveGraphicsState()
+    NSGraphicsContext.current = ctx
+    ctx.imageInterpolation = .high
+    draw(
+      in: NSRect(origin: .zero, size: newSize),
+      from: .zero, operation: .copy, fraction: 1
+    )
+    NSGraphicsContext.restoreGraphicsState()
+
+    let baked = NSImage(size: newSize)
+    baked.addRepresentation(rep)
+    return baked
   }
 }

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -75,6 +75,16 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     let size = Defaults[.windowSize]
     setContentSize(NSSize(width: min(frame.width, size.width), height: min(height, size.height)))
     setFrameOrigin(popupPosition.origin(size: frame.size, statusBarButton: statusBarButton))
+
+    // Ensure window stays within the visible screen bounds.
+    if let screenFrame = NSScreen.forPopup?.visibleFrame {
+      var origin = frame.origin
+      origin.y = max(origin.y, screenFrame.minY)
+      origin.x = max(origin.x, screenFrame.minX)
+      origin.x = min(origin.x, screenFrame.maxX - frame.width)
+      setFrameOrigin(origin)
+    }
+
     orderFrontRegardless()
     makeKey()
     isPresented = true

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -80,6 +80,7 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     if let screenFrame = NSScreen.forPopup?.visibleFrame {
       var origin = frame.origin
       origin.y = max(origin.y, screenFrame.minY)
+      origin.y = min(origin.y, screenFrame.maxY - frame.height)
       origin.x = max(origin.x, screenFrame.minX)
       origin.x = min(origin.x, screenFrame.maxX - frame.width)
       setFrameOrigin(origin)

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -86,7 +86,7 @@ class HistoryItem {
   }
 
   func generateTitle() -> String {
-    guard image == nil else {
+    guard imageData == nil else {
       Task {
         self.performTextRecognition()
       }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -176,9 +176,10 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     var itemDecorator: HistoryItemDecorator
     if let pin = item.pin {
       itemDecorator = HistoryItemDecorator(item, shortcuts: KeyShortcut.create(character: pin))
-      // Keep pins in the same place.
+      // Keep pins in the same place. `limitHistorySize` above may have mutated
+      // `all`, so clamp the captured index to the current bounds.
       if let removedItemIndex {
-        all.insert(itemDecorator, at: removedItemIndex)
+        all.insert(itemDecorator, at: min(removedItemIndex, all.count))
       }
     } else {
       itemDecorator = HistoryItemDecorator(item)

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -39,16 +39,54 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     return url.deletingPathExtension().lastPathComponent
   }
 
-  var hasImage: Bool { item.image != nil }
+  var hasImage: Bool { item.imageData != nil }
 
-  var previewImageGenerationTask: Task<(), Error>?
-  var thumbnailImageGenerationTask: Task<(), Error>?
+  var previewImageGenerationTask: Task<Void, Never>?
+  var thumbnailImageGenerationTask: Task<Void, Never>?
   var previewImage: NSImage?
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 
   // 10k characters seems to be more than enough on large displays
   var text: String { item.previewableText.shortened(to: 10_000) }
+
+  private var cachedPreviewText: String?
+
+  @MainActor
+  func asyncGetPreviewText() async -> String {
+    if let cached = cachedPreviewText { return cached }
+
+    // Extract raw data on main thread (SwiftData-safe)
+    let plainText = item.text
+    let rtfData = item.rtfData
+    let htmlData = item.htmlData
+    let fileURLs = item.fileURLs
+    let itemTitle = item.title
+
+    let result = await Task.detached {
+      if !fileURLs.isEmpty {
+        return fileURLs
+          .compactMap { $0.absoluteString.removingPercentEncoding }
+          .joined(separator: "\n")
+          .shortened(to: 10_000)
+      } else if let text = plainText, !text.isEmpty {
+        return text.shortened(to: 10_000)
+      } else if let data = rtfData,
+                let rtf = NSAttributedString(rtf: data, documentAttributes: nil),
+                !rtf.string.isEmpty {
+        return rtf.string.shortened(to: 10_000)
+      } else if let data = htmlData,
+                let html = NSAttributedString(html: data, documentAttributes: nil),
+                !html.string.isEmpty {
+        return html.string.shortened(to: 10_000)
+      } else {
+        return itemTitle.shortened(to: 10_000)
+      }
+    }.value
+
+    cachedPreviewText = result
+    return result
+  }
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }
@@ -74,7 +112,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   @MainActor
   func ensureThumbnailImage() {
-    guard item.image != nil else {
+    guard let data = item.imageData else {
       return
     }
     guard thumbnailImage == nil else {
@@ -83,14 +121,19 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     guard thumbnailImageGenerationTask == nil else {
       return
     }
-    thumbnailImageGenerationTask = Task { [weak self] in
-      self?.generateThumbnailImage()
+    let targetSize = HistoryItemDecorator.thumbnailImageSize
+    thumbnailImageGenerationTask = Task.detached { [weak self] in
+      guard let nsImage = NSImage(data: data) else { return }
+      let resized = nsImage.resized(to: targetSize)
+      await MainActor.run {
+        self?.thumbnailImage = resized
+      }
     }
   }
 
   @MainActor
   func ensurePreviewImage() {
-    guard item.image != nil else {
+    guard let data = item.imageData else {
       return
     }
     guard previewImage == nil else {
@@ -99,8 +142,13 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     guard previewImageGenerationTask == nil else {
       return
     }
-    previewImageGenerationTask = Task { [weak self] in
-      self?.generatePreviewImage()
+    let targetSize = HistoryItemDecorator.previewImageSize
+    previewImageGenerationTask = Task.detached { [weak self] in
+      guard let nsImage = NSImage(data: data) else { return }
+      let resized = nsImage.resized(to: targetSize)
+      await MainActor.run {
+        self?.previewImage = resized
+      }
     }
   }
 
@@ -110,7 +158,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
       return image
     }
     ensurePreviewImage()
-    _ = await previewImageGenerationTask?.result
+    await previewImageGenerationTask?.value
     return previewImage
   }
 
@@ -125,25 +173,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   }
 
   @MainActor
-  private func generateThumbnailImage() {
-    guard let image = item.image else {
-      return
-    }
-    thumbnailImage = image.resized(to: HistoryItemDecorator.thumbnailImageSize)
-  }
-
-  @MainActor
-  private func generatePreviewImage() {
-    guard let image = item.image else {
-      return
-    }
-    previewImage = image.resized(to: HistoryItemDecorator.previewImageSize)
-  }
-
-  @MainActor
   func sizeImages() {
-    generatePreviewImage()
-    generateThumbnailImage()
+    ensurePreviewImage()
+    ensureThumbnailImage()
   }
 
   func highlight(_ query: String, _ ranges: [Range<String.Index>]) {

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -50,30 +50,38 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   // 10k characters seems to be more than enough on large displays
   var text: String { item.previewableText.shortened(to: 10_000) }
 
-  private var cachedPreviewText: String?
+  @ObservationIgnored private var cachedPreviewText: String?
 
   @MainActor
   func asyncGetPreviewText() async -> String {
     if let cached = cachedPreviewText { return cached }
 
-    // Extract raw data on main thread (SwiftData-safe)
-    let plainText = item.text
+    // Fast paths: fileURLs and plain text don't need background parsing
+    let fileURLs = item.fileURLs
+    if !fileURLs.isEmpty {
+      let result = fileURLs
+        .compactMap { $0.absoluteString.removingPercentEncoding }
+        .joined(separator: "\n")
+        .shortened(to: 10_000)
+      cachedPreviewText = result
+      return result
+    }
+
+    if let plainText = item.text, !plainText.isEmpty {
+      let result = plainText.shortened(to: 10_000)
+      cachedPreviewText = result
+      return result
+    }
+
+    // Slow path: only read RTF/HTML data if needed, parse in background
     let rtfData = item.rtfData
     let htmlData = item.htmlData
-    let fileURLs = item.fileURLs
     let itemTitle = item.title
 
     let result = await Task.detached {
-      if !fileURLs.isEmpty {
-        return fileURLs
-          .compactMap { $0.absoluteString.removingPercentEncoding }
-          .joined(separator: "\n")
-          .shortened(to: 10_000)
-      } else if let text = plainText, !text.isEmpty {
-        return text.shortened(to: 10_000)
-      } else if let data = rtfData,
-                let rtf = NSAttributedString(rtf: data, documentAttributes: nil),
-                !rtf.string.isEmpty {
+      if let data = rtfData,
+         let rtf = NSAttributedString(rtf: data, documentAttributes: nil),
+         !rtf.string.isEmpty {
         return rtf.string.shortened(to: 10_000)
       } else if let data = htmlData,
                 let html = NSAttributedString(html: data, documentAttributes: nil),

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -63,8 +63,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
         .compactMap { $0.absoluteString.removingPercentEncoding }
         .joined(separator: "\n")
         .shortened(to: 10_000)
-      cachedPreviewText = result
-      return result
+      if !result.isEmpty {
+        cachedPreviewText = result
+        return result
+      }
     }
 
     if let plainText = item.text, !plainText.isEmpty {

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -143,6 +143,14 @@ class Popup {
         return nil
       }
 
+      // Treat this as the popup hotkey ONLY when modifiers also match.
+      // Without this guard, typing the hotkey letter alone in the search
+      // field (e.g. plain "v" when the popup hotkey is ⌘⇧V) is misclassified
+      // as the hotkey and routed to cycle/select, swallowing the character.
+      guard isHotKeyModifiers(event.modifierFlags) else {
+        return event
+      }
+
       if state == .opening {
         state = .cycle
         // Next 'if' will highlight next item and then return nil
@@ -153,7 +161,7 @@ class Popup {
         return nil
       }
 
-      if state == .toggle && isHotKeyModifiers(event.modifierFlags) {
+      if state == .toggle {
         close()
         return nil
       }

--- a/Maccy/Observables/SlideoutController.swift
+++ b/Maccy/Observables/SlideoutController.swift
@@ -189,6 +189,7 @@ class SlideoutController {
             newOrigin.x = max(newOrigin.x, screenFrame.minX)
             newOrigin.x = min(newOrigin.x, screenFrame.maxX - newSize.width)
             newOrigin.y = max(newOrigin.y, screenFrame.minY)
+            newOrigin.y = min(newOrigin.y, screenFrame.maxY - newSize.height)
           }
 
           context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)

--- a/Maccy/Observables/SlideoutController.swift
+++ b/Maccy/Observables/SlideoutController.swift
@@ -183,6 +183,14 @@ class SlideoutController {
             }
             // Otherwise the base is the desired position
           }
+
+          // Clamp to screen bounds so the slideout doesn't go off-screen.
+          if let screenFrame = window.screen?.visibleFrame {
+            newOrigin.x = max(newOrigin.x, screenFrame.minX)
+            newOrigin.x = min(newOrigin.x, screenFrame.maxX - newSize.width)
+            newOrigin.y = max(newOrigin.y, screenFrame.minY)
+          }
+
           context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
           context.completionHandler = {
             if self.state == expectedAnimationState {

--- a/Maccy/Views/AsyncView.swift
+++ b/Maccy/Views/AsyncView.swift
@@ -7,6 +7,7 @@ enum AsyncViewState<T> {
 }
 
 struct AsyncView<Value, Content: View, Placeholder: View>: View {
+  let taskId: AnyHashable
   let operation: () async throws -> Value
   @ViewBuilder var content: (Value) -> Content
   @ViewBuilder var placeholder: () -> Placeholder
@@ -14,10 +15,23 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
   @State private var viewState = AsyncViewState<Value>.loading
 
   init(
+    id: some Hashable,
     operation: @escaping () async throws -> Value,
     @ViewBuilder content: @escaping (Value) -> Content,
     @ViewBuilder placeholder: @escaping () -> Placeholder
   ) {
+    self.taskId = AnyHashable(id)
+    self.operation = operation
+    self.content = content
+    self.placeholder = placeholder
+  }
+
+  init(
+    operation: @escaping () async throws -> Value,
+    @ViewBuilder content: @escaping (Value) -> Content,
+    @ViewBuilder placeholder: @escaping () -> Placeholder
+  ) {
+    self.taskId = AnyHashable(0)
     self.operation = operation
     self.content = content
     self.placeholder = placeholder
@@ -31,13 +45,14 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
       case .loaded(let value):
         content(value)
       }
-    }.task {
+    }.task(id: taskId) {
       do {
-        viewState = .loading
         let result = try await operation()
         viewState = .loaded(result)
       } catch {
-        viewState = .failed
+        if case .loading = viewState {
+          viewState = .failed
+        }
       }
     }
   }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -61,18 +61,18 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       Spacer()
         .frame(width: showIcons ? 5 : 10)
 
-      if let accessoryImage {
-        Image(nsImage: accessoryImage)
-          .accessibilityIdentifier("copy-history-item")
-          .padding(.trailing, 5)
-          .padding(.vertical, 5)
-      }
-
-      if let image {
-        Image(nsImage: image)
-          .accessibilityIdentifier("copy-history-item")
-          .padding(.trailing, 5)
-          .padding(.vertical, 5)
+      if image != nil || accessoryImage != nil {
+        Group {
+          if let image {
+            Image(nsImage: image)
+          } else if let accessoryImage {
+            Image(nsImage: accessoryImage)
+          }
+        }
+        .accessibilityIdentifier("copy-history-item")
+        .frame(maxWidth: 340, maxHeight: CGFloat(Defaults[.imageMaxHeight]))
+        .padding(.trailing, 5)
+        .padding(.vertical, 5)
       } else {
         ListItemTitleView(attributedTitle: attributedTitle, title: title)
           .padding(.trailing, 5)

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -50,9 +50,16 @@ struct PreviewItemView: View {
           }
         }
       } else {
-        ScrollView {
-          Text(item.text)
-            .font(.body)
+        AsyncView<String, _, _> {
+          return await item.asyncGetPreviewText()
+        } content: { text in
+          ScrollView {
+            Text(text)
+              .font(.body)
+          }
+        } placeholder: {
+          ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
       }
 

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -14,7 +14,7 @@ struct PreviewItemView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       if item.hasImage {
-        AsyncView<NSImage?, _, _> {
+        AsyncView<NSImage?, _, _>(id: item.id) {
           return await item.asyncGetPreviewImage()
         } content: { image in
           if let image = image {
@@ -50,7 +50,7 @@ struct PreviewItemView: View {
           }
         }
       } else {
-        AsyncView<String, _, _> {
+        AsyncView<String, _, _>(id: item.id) {
           return await item.asyncGetPreviewText()
         } content: { text in
           ScrollView {

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -59,21 +59,48 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertNil(itemDecorator.thumbnailImage)
   }
 
-  func testImage() {
+  func testImage() async {
     let image = NSImage(named: "StatusBarMenuImage")!
     let itemDecorator = historyItemDecorator(image)
     itemDecorator.sizeImages()
+    await itemDecorator.previewImageGenerationTask?.value
+    await itemDecorator.thumbnailImageGenerationTask?.value
     XCTAssertEqual(itemDecorator.title, "")
     XCTAssertEqual(itemDecorator.previewImage!.size, image.size)
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, image.size)
   }
 
   // We also need to add test for image with width bigger than max width.
-  func testImageWithHeightBiggerThanMaxHeight() {
+  func testImageWithHeightBiggerThanMaxHeight() async {
     let image = NSImage(named: "NSApplicationIcon")!
     let itemDecorator = historyItemDecorator(image)
     itemDecorator.sizeImages()
+    await itemDecorator.thumbnailImageGenerationTask?.value
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, NSSize(width: 40, height: 40))
+  }
+
+  func testHasImage() {
+    let image = NSImage(named: "StatusBarMenuImage")!
+    let itemDecorator = historyItemDecorator(image)
+    XCTAssertTrue(itemDecorator.hasImage)
+  }
+
+  func testHasNoImage() {
+    let itemDecorator = historyItemDecorator("plain text")
+    XCTAssertFalse(itemDecorator.hasImage)
+  }
+
+  func testAsyncGetPreviewTextWithHTML() async {
+    let html = "<a href='#'>foo</a>".data(using: .utf8)
+    let itemDecorator = historyItemDecorator(html, .html)
+    let text = await itemDecorator.asyncGetPreviewText()
+    XCTAssertEqual(text, "foo")
+  }
+
+  func testAsyncGetPreviewTextWithPlainText() async {
+    let itemDecorator = historyItemDecorator("bar")
+    let text = await itemDecorator.asyncGetPreviewText()
+    XCTAssertEqual(text, "bar")
   }
 
   func testFile() {

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -233,6 +233,30 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.items, [bar])
   }
 
+  // Regression test: re-adding a duplicate of a pinned item while the
+  // unpinned history is at capacity used to trap on out-of-range insert
+  // because `limitHistorySize` mutated `all` between capturing the
+  // removed item's index and re-inserting the decorator at that index.
+  func testRepinningAtCapacityDoesNotCrash() {
+    let savedPinTo = Defaults[.pinTo]
+    Defaults[.pinTo] = .bottom
+    Defaults[.size] = 3
+    defer { Defaults[.pinTo] = savedPinTo }
+
+    let pinned = history.add(historyItem("pinned"))
+    pinned.togglePin()
+
+    _ = history.add(historyItem("a"))
+    _ = history.add(historyItem("b"))
+    _ = history.add(historyItem("c"))
+
+    // Re-add a duplicate of the pinned item. Before the fix this
+    // trapped in Array.insert(_:at:) with "index out of range".
+    _ = history.add(historyItem("pinned"))
+
+    XCTAssertTrue(history.all.contains(where: { $0.item.pin != nil }))
+  }
+
   private func historyItem(_ value: String) -> HistoryItem {
     let contents = [
       HistoryItemContent(


### PR DESCRIPTION
## Summary

Fixes the "Not Responding" freeze that occurs when hovering over clipboard items with the preview panel, a separate list-scrolling freeze on rows that contain large image thumbnails, two positioning bugs where the popup could extend beyond the visible screen, a crash when re-pasting a pinned clipboard item while the unpinned history is at capacity, and a regression where the search field would swallow keystrokes matching the popup hotkey's letter.

The hover freeze is reproducible by scrolling through the history list and rapidly moving the mouse up and down across items — the main thread blocks hard enough that macOS's watchdog will eventually kill the process. The list-scrolling freeze reproduces independently by scrolling to a clipboard row that holds a large composite screenshot — the row's first appearance pegs the main thread at 100% CPU for 12+ seconds. The pinned-paste crash reproduces by filling the unpinned history to `Defaults[.size]` and then re-pasting a pinned item — `History.add` traps in `Array.insert(_:at:)` with "index out of range" (three production `.ips` reports captured this signature on May 2-3). The search-swallow bug reproduces by opening the popup with the default `⌘⇧V` hotkey, releasing modifiers, and typing "v" in the search field — the keystroke moves the selection down instead of inserting "v" into the query, making it impossible to search for any term containing the letter V.

## Root causes

Six separate main-thread / event-handling issues:

1. **`hasImage` allocated a full `NSImage`** just to check existence. `item.image != nil` decodes the entire image blob; `item.imageData != nil` is a cheap content-type lookup.

2. **Image decode and resize ran on `@MainActor`.** The `Task { }` wrapper inherited the actor context from its `@MainActor` caller, so `NSImage(data:)` and `.resized(to:)` still executed on the main thread. Replaced with `Task.detached` + raw `Data` capture.

3. **`NSAttributedString(html:)` parsed synchronously in the view body.** HTML clipboard content (from browsers) invokes WebKit internally, which blocks rendering for hundreds of milliseconds. Moved behind an async `AsyncView` operation.

4. **`LazyVStack` row-layout cycling on rows with image thumbnails.** Separate from the hover path. The history row rendered `Image(nsImage:)` without an explicit frame and switched between `image` / `accessoryImage` / `title-fallback` branches depending on whether the async thumbnail had completed. The view-tree shape changed when thumbnails finished loading, forcing `LazyVStack` to re-measure and invalidating its row-height cache for everything below. Compounding this, `NSImage+Resized.resized(to:)` returned an `NSImage(size:flipped:drawingHandler:)` whose intrinsic size varied subtly per redraw, defeating the lazy cache. The combined effect was a runaway SwiftUI transaction loop — captured by macOS's CPU resource diagnostic showing time spent in `LazySubviewPlacements.placeSubviews` → `LazyStack.place` → `LazyLayoutViewCache.commitPlacedSubviews` → `Array.sortForDisplayLarge`, with no time in image decoding (decoding is already off-thread after fix #2).

5. **`History.add` trapped on stale index after `limitHistorySize` mutation.** When a pinned clipboard item was re-pasted, the function captured `removedItemIndex` for the existing pinned row, removed it, then called `limitHistorySize` which can mutate `all` further by deleting unpinned rows. The captured index then becomes stale, and the subsequent `Array.insert(_:at:)` traps with "index out of range" if the new array length is smaller than the captured index. Hits when the unpinned history is at capacity.

6. **`Popup.handleKeyDown` matched the popup hotkey by keyCode only.** The local `NSEvent` monitor's gate `if isHotKeyCode(Int(event.keyCode))` compared only `event.keyCode` against the popup shortcut's key, ignoring modifier flags. With the default `⌘⇧V` popup hotkey, plain "v" with no modifiers still satisfied this check; combined with a `keyDown`-vs-`flagsChanged` event-ordering race that could leave `state == .opening` or `state == .cycle`, the keystroke routed to the cycle/`highlightNext` branch and `return nil` swallowed it before the search field's `onKeyPress` ever ran. Once stuck in `.cycle` (and modifiers were already empty so no further `flagsChanged` would fire), every subsequent "v" repeated the cycle behavior.

A seventh issue emerged during the preview fixes: with the preview open, `AsyncView`'s `.task { }` fires only on appear, so navigating between items showed stale content. An initial attempt using `.id(item.id)` on `PreviewItemView` caused full view teardown/recreation on every hover — this itself froze the app under rapid mouse movement. The final fix adds a `taskId` parameter to `AsyncView` that uses `.task(id:)`, which cancels and restarts the async operation on id change without destroying the view.

## Changes

- `HistoryItemDecorator`: `hasImage` uses `imageData`, image generation uses `Task.detached`, new `asyncGetPreviewText()` with lazy content reading and `@ObservationIgnored` cache.
- `HistoryItem`: `generateTitle()` uses `imageData == nil` instead of `image == nil`.
- `AsyncView`: Added `id` init parameter that switches to `.task(id:)` internally. Prior init without `id` is preserved for backwards compat.
- `PreviewItemView`: Text branch wrapped in `AsyncView`; both image and text `AsyncView`s pass `item.id`.
- `FloatingPanel.open()` and `SlideoutController.togglePreview()`: Clamp window origin to the visible screen frame on both axes so the popup/slideout can't extend off-screen.
- `ListItemView`: `image` / `accessoryImage` branches wrapped in a single `Group` with `.frame(maxWidth: 340, maxHeight: imageMaxHeight)`, so the row's view shape stays stable across async thumbnail completion.
- `NSImage+Resized.resized(to:)`: replaces the deferred-draw `NSImage(size:flipped:drawingHandler:)` with an eager `NSBitmapImageRep` bake at the highest active screen's `backingScaleFactor` (so cached bitmaps stay sharp on multi-display setups). Falls back to `self` if either the bitmap or graphics context can't be allocated.
- `History.add(_:)`: `all.insert(itemDecorator, at: removedItemIndex)` becomes `all.insert(itemDecorator, at: min(removedItemIndex, all.count))`. `Array.insert(at:)` accepts `0...count`, so clamping to `count` is always valid; when the original slot was trimmed, the re-pinned item lands at the end of `all` instead of crashing.
- `Popup.handleKeyDown`: adds a `guard isHotKeyModifiers(event.modifierFlags) else { return event }` after the `pressedShortcutItem` block so non-hotkey-letter keystrokes fall through to the search field. The redundant `&& isHotKeyModifiers(...)` is dropped from the `state == .toggle` branch (the new guard already enforces it). The cycle-paste workflow (`⌘⇧V` held → `highlightNext`) is unchanged because both keyCode and modifiers match in that case.
- `HistoryDecoratorTests`: Image tests made `async` to await the detached generation; added tests for `hasImage` and `asyncGetPreviewText`.
- `HistoryTests.testRepinningAtCapacityDoesNotCrash`: regression test that fills unpinned history to capacity and re-adds a duplicate of a pinned item with `pinTo = .bottom` — reliably reproduced the crash on the pre-fix code path.

## Verification

Tested by copying a mix of content types (plain text, HTML from browsers, large images, file URLs) and:
- Hovering over individual items — preview loads without freeze.
- Scrolling to mid-list, rapidly moving mouse up/down across items — no freeze, content updates smoothly.
- Scrolling through history that contains large composite screenshots — no freeze; thumbnail dimensions match prior behavior.
- Positioning the popup near all four edges of the screen — no clipping.
- Dragging the popup between a Retina built-in display and a 1× external monitor with image rows visible — thumbnails stay crisp on both.
- With `Defaults[.size] = 3`, pinning an item, filling the unpinned slots with three copies, and re-pasting the pinned item — pre-fix this crashed with "index out of range"; post-fix the pin survives and remains in the popup.
- Opening the popup with `⌘⇧V`, releasing the modifiers, and typing "valley" / "vivid" / "vvvvv" in the search field — pre-fix the V keystrokes were swallowed and the selection cycled down; post-fix the characters insert into the query and history filters correctly. Holding `⌘⇧V` (the intended cycle gesture) still cycles the selection as before; pressing `⌘⇧V` while the popup is in `.toggle` state still closes it.

Unit tests pass.

## Notes for reviewers

- Commits tell the debugging story (each issue surfaced after fixing the previous one). Happy to squash to a single commit if preferred.
- SwiftData model access stays on the main actor — only raw `Data` bytes and value types cross into `Task.detached`.
- Trade-off worth flagging on the new `NSImage+Resized` path: the bake target is `colorSpaceName: .deviceRGB`, which converts P3-tagged source screenshots to deviceRGB at thumbnail size. Visually imperceptible at ≤340pt but a real change vs. the prior deferred-draw path, which preserved the source colorspace until composite time.
- `.resizable().scaledToFit()` is intentionally omitted on the SwiftUI `Image` in `ListItemView` — `Popup.itemHeight = 24` would otherwise become the row floor and shrink the thumbnail into a 24pt cell. The eager bake gives the NSImage a correct intrinsic point size, and the explicit frame is the only sizing control needed.
- Minor list-row behavior note: `ListItemView` previously rendered the `accessoryImage` and the main `image` as two stacked positions inside the row when both were non-nil. The `Group { if let image … else if let accessoryImage … }` wrapper picks one. In practice only one of the two is ever set on a given row, so this should be invisible in normal usage; calling it out for transparency.
- On the search-swallow fix in `Popup.handleKeyDown`: the existing call ordering is preserved on purpose. `pressedShortcutItem` runs before the new modifier guard so list-item shortcuts (⌘1, ⌘2, …) still resolve through their own `HistoryItemAction(modifierFlags)` validation. The pre-existing requirement that `pressedShortcutItem` is only consulted when the keyCode equals the popup hotkey's keyCode is left as-is — behaviour-preserving and out of scope for a one-line bugfix.
- The pinned-paste crash and the V-key search swallow are bundled with the rendering fixes because all four are surgical correctness fixes touching unrelated code paths in the popup surface, and a single PR keeps reviewer overhead low. Happy to split if preferred.
- Pre-existing items not addressed in this PR (orthogonal, predate this change): NSAttributedString HTML/RTF parser input size limits, file URL canonicalization, Vision framework text recognition callback thread safety.