### PR TITLE
Auto-paste first item on quick shortcut tap  

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		DA3BCB922C3EEC3C00B01BC1 /* History.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3BCB912C3EEC3C00B01BC1 /* History.swift */; };
 		DA3BCB942C3EECBB00B01BC1 /* HistoryItemDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3BCB932C3EECBB00B01BC1 /* HistoryItemDecorator.swift */; };
 		DA3CE8001E44A62500B3AA98 /* ClipboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3CE7FF1E44A62500B3AA98 /* ClipboardTests.swift */; };
+		DA3CE8012E44A62500B3AA99 /* PopupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3CE8022E44A62500B3AA99 /* PopupTests.swift */; };
 		DA3EAE0C2AE30F7500F39108 /* NSApplication+Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3EAE0B2AE30F7500F39108 /* NSApplication+Windows.swift */; };
 		DA3F1B452C90084600267632 /* Sauce+KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3F1B442C90083800267632 /* Sauce+KeyboardShortcuts.swift */; };
 		DA44C5E42C1C858400819834 /* StorageSettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA44C5E32C1C858400819834 /* StorageSettingsPane.swift */; };
@@ -204,7 +205,6 @@
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
-		2FFF8BCF2CE2116600235A78 /* Data+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Encoding.swift"; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -297,6 +297,7 @@
 		DA3BCB912C3EEC3C00B01BC1 /* History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = History.swift; sourceTree = "<group>"; };
 		DA3BCB932C3EECBB00B01BC1 /* HistoryItemDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemDecorator.swift; sourceTree = "<group>"; };
 		DA3CE7FF1E44A62500B3AA98 /* ClipboardTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClipboardTests.swift; sourceTree = "<group>"; };
+		DA3CE8022E44A62500B3AA99 /* PopupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopupTests.swift; sourceTree = "<group>"; };
 		DA3EAE0B2AE30F7500F39108 /* NSApplication+Windows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApplication+Windows.swift"; sourceTree = "<group>"; };
 		DA3F1B442C90083800267632 /* Sauce+KeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sauce+KeyboardShortcuts.swift"; sourceTree = "<group>"; };
 		DA44C5E32C1C858400819834 /* StorageSettingsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageSettingsPane.swift; sourceTree = "<group>"; };
@@ -718,6 +719,7 @@
 				DA48AE852A5F0077006D4894 /* Fixtures */,
 				DA3CE7FF1E44A62500B3AA98 /* ClipboardTests.swift */,
 				DAE2850123225BD90080E394 /* ColorImageTests.swift */,
+				DA3CE8022E44A62500B3AA99 /* PopupTests.swift */,
 				DA360DB21E3DF137005C6F6B /* HistoryTests.swift */,
 				DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */,
 				DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */,
@@ -1059,6 +1061,7 @@
 			files = (
 				DAFE2DE9268A9B1B00990986 /* HistoryItemTests.swift in Sources */,
 				DA3CE8001E44A62500B3AA98 /* ClipboardTests.swift in Sources */,
+				DA3CE8012E44A62500B3AA99 /* PopupTests.swift in Sources */,
 				DA1EDE432045B35300479723 /* HistoryDecoratorTests.swift in Sources */,
 				DAE2850223225BD90080E394 /* ColorImageTests.swift in Sources */,
 				DA384E86232746D800603999 /* SearchTests.swift in Sources */,

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -165,19 +165,32 @@ class Popup {
   private func handleFlagsChanged(_ event: NSEvent) -> NSEvent? {
     // If we are in cycle mode, releasing modifiers triggers a selection
     if state == .cycle && allModifiersReleased(event) {
-      DispatchQueue.main.async {
+      Task { @MainActor in
         AppState.shared.select()
       }
       return nil
     }
 
-    // Otherwise if in opening mode, enter toggle mode
     if state == .opening && allModifiersReleased(event) {
+      // Trigger selection of the first item when the user quickly taps the shortcut
+      // (press and release modifiers without cycling). This only applies when
+      // "Paste by Default" is enabled and the search field is hidden.
+      if shouldSelectFirstRecordOnOpen {
+        Task { @MainActor in
+          AppState.shared.select()
+        }
+        return nil
+      }
+
       state = .toggle
       return event
     }
 
     return event
+  }
+
+  var shouldSelectFirstRecordOnOpen: Bool {
+    Defaults[.pasteByDefault] && !Defaults[.showSearch]
   }
 
   private func isHotKeyCode(_ keyCode: Int) -> Bool {

--- a/MaccyTests/PopupTests.swift
+++ b/MaccyTests/PopupTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import Defaults
+@testable import Maccy
+
+class PopupTests: XCTestCase {
+  let savedPasteByDefault = Defaults[.pasteByDefault]
+  let savedShowSearch = Defaults[.showSearch]
+
+  var popup: Popup!
+
+  override func setUp() {
+    super.setUp()
+    popup = Popup()
+  }
+
+  override func tearDown() {
+    super.tearDown()
+    popup.deinitEventsMonitor()
+    Defaults[.pasteByDefault] = savedPasteByDefault
+    Defaults[.showSearch] = savedShowSearch
+  }
+
+  func testShouldAutoPasteWhenPasteByDefaultEnabledAndSearchHidden() {
+    Defaults[.pasteByDefault] = true
+    Defaults[.showSearch] = false
+    XCTAssertTrue(popup.shouldSelectFirstRecordOnOpen)
+  }
+
+  func testShouldNotAutoPasteWhenPasteByDefaultDisabled() {
+    Defaults[.pasteByDefault] = false
+    Defaults[.showSearch] = false
+    XCTAssertFalse(popup.shouldSelectFirstRecordOnOpen)
+  }
+
+  func testShouldNotAutoPasteWhenSearchVisible() {
+    Defaults[.pasteByDefault] = true
+    Defaults[.showSearch] = true
+    XCTAssertFalse(popup.shouldSelectFirstRecordOnOpen)
+  }
+
+  func testShouldNotAutoPasteWhenBothDisabledAndSearchVisible() {
+    Defaults[.pasteByDefault] = false
+    Defaults[.showSearch] = true
+    XCTAssertFalse(popup.shouldSelectFirstRecordOnOpen)
+  }
+}


### PR DESCRIPTION
When "Paste by Default" is enabled and the search field is hidden, quickly tapping the popup shortcut (press and release modifiers without cycling) automatically selects and pastes the  first history item instead of leaving the popup open in toggle mode.
                                                                                                                                                                                                                                                                                         
How to test:                                                                                                                                                                                   
- Enable "Paste by Default" and disable "Show Search", tap the shortcut quickly — first item should be pasted automatically                                                                  
