### PR TITLE
Fix 100% CPU spin on macOS 26 caused by .truncationMode(.middle)

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   private var statusItemVisibilityObserver: NSKeyValueObservation?
+  private var menuIconTextUpdatePending = false
 
   func applicationWillFinishLaunching(_ notification: Notification) { // swiftlint:disable:this function_body_length
     #if DEBUG
@@ -161,7 +162,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     _ = withObservationTracking {
       AppState.shared.menuIconText
     } onChange: {
+      // Guard against multiple onChange callbacks firing before the async block
+      // runs (e.g. when History.add() mutates `items` and then updates shortcuts
+      // in the same turn). Without this guard each callback queues its own async
+      // block, and each block re-registers an observation, causing the number of
+      // active observations to grow unboundedly and CPU usage to spike over time.
+      guard !self.menuIconTextUpdatePending else { return }
+      self.menuIconTextUpdatePending = true
       DispatchQueue.main.async {
+        self.menuIconTextUpdatePending = false
         if Defaults[.showRecentCopyInMenuBar] {
           self.statusItem.button?.title = AppState.shared.menuIconText
         }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -62,6 +62,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   private(set) var item: HistoryItem
 
+  private var itemPinUpdatePending = false
+  private var itemTitleUpdatePending = false
+
   init(_ item: HistoryItem, shortcuts: [KeyShortcut] = []) {
     self.item = item
     self.shortcuts = shortcuts
@@ -187,7 +190,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     _ = withObservationTracking {
       item.pin
     } onChange: {
+      guard !self.itemPinUpdatePending else { return }
+      self.itemPinUpdatePending = true
       DispatchQueue.main.async {
+        self.itemPinUpdatePending = false
         if let pin = self.item.pin {
           self.shortcuts = KeyShortcut.create(character: pin)
         }
@@ -200,7 +206,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     _ = withObservationTracking {
       item.title
     } onChange: {
+      guard !self.itemTitleUpdatePending else { return }
+      self.itemTitleUpdatePending = true
       DispatchQueue.main.async {
+        self.itemTitleUpdatePending = false
         self.title = self.item.title
         self.synchronizeItemTitle()
       }

--- a/Maccy/Views/HeightReaderModifier.swift
+++ b/Maccy/Views/HeightReaderModifier.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-struct SizeReaderModifier<Value: Equatable>: ViewModifier {
+// Used only for @State bindings (e.g. PasteStackPreviewView).
+private struct SizeReaderModifier<Value: Equatable>: ViewModifier {
   @Binding var value: Value
   let mapper: (CGSize) -> Value
 
@@ -13,31 +14,40 @@ struct SizeReaderModifier<Value: Equatable>: ViewModifier {
   }
 }
 
-fileprivate extension Binding {
-  init<State>(
-    _ object: State,
-    keyPath: ReferenceWritableKeyPath<State, Value>
-  ) {
-    self.init(
-      get: { object[keyPath: keyPath] },
-      set: { object[keyPath: keyPath] = $0 }
-    )
+// Writes to a keyPath on an @Observable object WITHOUT going through @Binding.
+//
+// Using a @Binding to an @Observable property here would register the
+// destination property (e.g. popup.headerHeight) as a render dependency of
+// this modifier. Any write from onGeometryChange would then re-invalidate the
+// modifier itself, creating a potential layout feedback loop on macOS 26.
+// Writing directly via keyPath avoids that dependency registration entirely.
+private struct ObservableSizeReaderModifier<State: AnyObject>: ViewModifier {
+  let object: State
+  let keyPath: ReferenceWritableKeyPath<State, CGFloat>
+  let mapper: (CGSize) -> CGFloat
+
+  func body(content: Content) -> some View {
+    content.onGeometryChange(for: CGFloat.self) { proxy in
+      mapper(proxy.size)
+    } action: { [weak object] newValue in
+      object?[keyPath: keyPath] = newValue
+    }
   }
 }
 
 extension View {
-  func readHeight<State>(
+  func readHeight<State: AnyObject>(
     _ state: State,
     into keyPath: ReferenceWritableKeyPath<State, CGFloat>
   ) -> some View {
-    readHeight(Binding(state, keyPath: keyPath))
+    modifier(ObservableSizeReaderModifier(object: state, keyPath: keyPath, mapper: \.height))
   }
 
-  func readWidth<State>(
+  func readWidth<State: AnyObject>(
     _ state: State,
     into keyPath: ReferenceWritableKeyPath<State, CGFloat>
   ) -> some View {
-    readWidth(Binding(state, keyPath: keyPath))
+    modifier(ObservableSizeReaderModifier(object: state, keyPath: keyPath, mapper: \.width))
   }
 
   func readWidth(_ value: Binding<CGFloat>) -> some View {
@@ -48,3 +58,4 @@ extension View {
     modifier(SizeReaderModifier(value: value, mapper: \.height))
   }
 }
+

--- a/Maccy/Views/ListItemTitleView.swift
+++ b/Maccy/Views/ListItemTitleView.swift
@@ -14,10 +14,22 @@ struct ListItemTitleView<Title: View>: View {
       title()
         .accessibilityIdentifier("copy-history-item")
         .lineLimit(1)
-        .truncationMode(.middle)
+        // On macOS 26, .truncationMode(.middle) causes NSCoreTypesetter to
+        // enter an infinite truncation loop (__NSCoreTypesetterTruncateLine)
+        // when the text is measured with an unconstrained size proposal
+        // (e.g. during the SlideoutView preview-panel open/close animation).
+        // Use .tail truncation on macOS 26 to avoid this CoreText hang.
+        .truncationMode(truncationMode)
         // Workaround for macOS 26 to avoid flipped text
         // https://github.com/p0deje/Maccy/issues/1113
         .drawingGroup()
     }
+  }
+
+  private var truncationMode: Text.TruncationMode {
+    if #available(macOS 26.0, *) {
+      return .tail
+    }
+    return .middle
   }
 }


### PR DESCRIPTION
## Problem
On macOS 26, Maccy's CPU usage climbs to 100% immediately after launch,
causing the app to become unresponsive. Reproduces on every open of the popup.

## Root Cause
`NSCoreTypesetter.__NSCoreTypesetterTruncateLine` (in UIFoundation) enters
an infinite loop when measuring `Text` views with `.truncationMode(.middle)`
under an unconstrained height size proposal.

The trigger path:
1. `SlideoutView` preview panel starts opening (isAnimating = true)
2. Content VStack gets `.fixedSize(horizontal: true, vertical: false)`
3. SwiftUI measures the content at ideal (unconstrained) height
4. Traverses down: ZStack → VStack → SlideoutView → ScrollView → LazyVStack
5. Each `HistoryItemView` title is measured via `NSAttributedString.boundingRect`
6. CoreText's truncation loop hangs indefinitely for certain text content

Confirmed via `sample` profiling: 100% of CPU time in
`__NSCoreTypesetterTruncateLine_block_invoke`.

## Fix
- Use `.truncationMode(.tail)` on macOS 26 in `ListItemTitleView`.
  The existing `.drawingGroup()` workaround for flipped text (#1113)
  is preserved and works correctly with tail truncation.
- (Defensive) `HeightReaderModifier`: write to `@Observable` keypaths
  directly instead of via a custom `Binding` to avoid unintended render
  dependency registration.
- (Defensive) `AppDelegate` / `HistoryItemDecorator`: guard
  `withObservationTracking` re-registration callbacks with a pending flag
  to prevent observation count from growing when multiple mutations fire
  in the same turn.