### PR TITLE
fix: prevent HistoryItemContent orphaning during duplicate resolution

### DIFF
--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -146,7 +146,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     var removedItemIndex: Int?
     if let existingHistoryItem = findSimilarItem(item) {
       if isModified(item) == nil {
+        for content in item.contents {
+          Storage.shared.context.delete(content)
+        }
         item.contents = existingHistoryItem.contents
+        existingHistoryItem.contents = []
       }
       item.firstCopiedAt = existingHistoryItem.firstCopiedAt
       item.numberOfCopies += existingHistoryItem.numberOfCopies

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Defaults
+import SwiftData
 @testable import Maccy
 
 @MainActor
@@ -121,6 +122,23 @@ class HistoryTests: XCTestCase {
 
     XCTAssertEqual(history.items, [second])
     XCTAssertEqual(Set(history.items[0].item.contents), Set(firstContents))
+  }
+
+  func testDuplicateDoesNotOrphanContents() {
+    let item = historyItem("foo")
+    history.add(item)
+
+    let descriptor1 = FetchDescriptor<HistoryItemContent>()
+    let contents1 = try? Storage.shared.context.fetch(descriptor1)
+    XCTAssertEqual(contents1?.count, 1)
+
+    let duplicate = historyItem("foo")
+    history.add(duplicate)
+
+    let descriptor2 = FetchDescriptor<HistoryItemContent>()
+    let contents2 = try? Storage.shared.context.fetch(descriptor2)
+    XCTAssertEqual(contents2?.count, 1)
+    XCTAssertNotNil(contents2?.first?.item)
   }
 
   func testAddingItemFromMaccy() {


### PR DESCRIPTION
## Summary

Fixes a bug where adding a duplicate clipboard item could leave orphaned `HistoryItemContent` rows in the SwiftData store with `item == nil`, and cascade deletion of the existing item could delete content objects shared with the replacement item.

## Root Cause

In `History.add(_:)` (Maccy/Observables/History.swift:147-163), when a duplicate was detected:

1. The incoming item was already persisted to SwiftData (line 140)
2. Its contents were replaced with the existing item's contents (line 149)
3. The original contents were left orphaned in the store
4. The existing item was cascade-deleted, which could wipe content objects now referenced by the replacement

## Fix

- Delete the incoming item's contents from the store before replacing them (prevents orphaning)
- Detach the existing item's contents (`existingHistoryItem.contents = []`) before cascade deletion (prevents shared content from being wiped)
- Both operations are gated behind `if isModified(item) == nil`, so they only run when contents are actually transferred

## Testing

Added `testDuplicateDoesNotOrphanContents` which verifies:
- Exactly 1 `HistoryItemContent` row exists after duplicate merge
- The surviving content has a valid `item` reference

Closes #1368