### PR TITLE
fix: prevent unicode corruption from thread-unsafe OCR mutation

### DIFF
--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -238,6 +238,9 @@ class HistoryItem {
       return observation.topCandidates(1).first?.string
     }
 
-    self.title = recognizedStrings.joined(separator: "\n")
+    let text = recognizedStrings.joined(separator: "\n")
+    Task { @MainActor in
+      self.title = text
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes a thread safety violation where `VNRecognizeTextRequest`'s completion handler mutated a SwiftData `@Model` property from a background thread, gradually corrupting the `ModelContext`'s internal state and causing random unicode corruption across all clipboard items.

## Root Cause

In `HistoryItem.generateTitle()` (Maccy/Models/HistoryItem.swift:88-94), when the copied item is an image, a `Task` fires `performTextRecognition()`. Since `generateTitle()` is not `@MainActor`, this Task runs on the default global concurrent executor.

`VNImageRequestHandler.perform()` is synchronous (Maccy/Models/HistoryItem.swift:226) — the `recognizeTextHandler` completion handler executes on the same background thread. It directly set `self.title` on a SwiftData `@Model` object (line 241), which is only safe on the `@MainActor`.

This thread safety violation corrupts the shared `ModelContext`'s internal snapshot and change tracking state. Over days of use, the corruption spreads to all loaded objects — not just images — manifesting as random unicode characters in clipboard text.

Quitting the app clears the in-memory context, which is why it temporarily 'fixes' itself on relaunch.

## Fix

Capture the recognized text on the background thread (safe), then dispatch the SwiftData model mutation to `@MainActor`:

```swift
let text = recognizedStrings.joined(separator: "\n")
Task { @MainActor in
    self.title = text
}
```

## Testing

- Existing HistoryItemTests continue to pass
- The OCR path is exercised whenever an image item's title is generated

Closes #1374