### PR TITLE
Show relative copy age in the history list

### DIFF
--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -12,6 +12,22 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   static var previewImageSize: NSSize { NSScreen.forPopup?.visibleFrame.size ?? NSSize(width: 2048, height: 1536) }
   static var thumbnailImageSize: NSSize { NSSize(width: 340, height: Defaults[.imageMaxHeight]) }
+  private static func relativeCopyTimeFormatter(locale: Locale) -> RelativeDateTimeFormatter {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.locale = locale
+    formatter.unitsStyle = .abbreviated
+    formatter.dateTimeStyle = .named
+    return formatter
+  }
+
+  static func formatRelativeCopyTime(
+    for date: Date,
+    relativeTo referenceDate: Date = .now,
+    locale: Locale = .autoupdatingCurrent
+  ) -> String {
+    return relativeCopyTimeFormatter(locale: locale)
+      .localizedString(for: date, relativeTo: referenceDate)
+  }
 
   let id = UUID()
 
@@ -49,6 +65,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   // 10k characters seems to be more than enough on large displays
   var text: String { item.previewableText.shortened(to: 10_000) }
+  var relativeLastCopiedAt: String { Self.formatRelativeCopyTime(for: item.lastCopiedAt) }
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -40,6 +40,7 @@ struct HistoryItemView: View {
       accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
+      detailText: item.relativeLastCopiedAt,
       isSelected: item.isSelected,
       selectionIndex: visualIndex,
       selectionAppearance: selectionAppearance

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -36,6 +36,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   var accessoryImage: NSImage?
   var attributedTitle: AttributedString?
   var shortcuts: [KeyShortcut]
+  var detailText: String? = nil
   var isSelected: Bool
   var selectionIndex: Int?
   var help: LocalizedStringKey?
@@ -81,6 +82,15 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       Spacer()
 
       HStack(spacing: 5) {
+        if let detailText, !detailText.isEmpty {
+          Text(detailText)
+            .font(.caption2)
+            .monospacedDigit()
+            .foregroundStyle(isSelected ? Color.white.opacity(0.8) : .secondary)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+        }
+
         if let index = selectionIndex {
           Text("\(index + 1)")
             .font(.caption)

--- a/Maccy/Views/PasteStackItemView.swift
+++ b/Maccy/Views/PasteStackItemView.swift
@@ -30,6 +30,7 @@ struct PasteStackItemView: View {
       accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
       attributedTitle: item.attributedTitle,
       shortcuts: [],
+      detailText: item.relativeLastCopiedAt,
       isSelected: isSelected,
       selectionIndex: index,
       selectionAppearance: .none

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -134,6 +134,19 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.attributedTitle, nil)
   }
 
+  func testRelativeCopyTimeFormatting() {
+    let date = Date(timeIntervalSince1970: -3 * 60 * 60)
+    let referenceDate = Date(timeIntervalSince1970: 0)
+
+    let relative = HistoryItemDecorator.formatRelativeCopyTime(
+      for: date,
+      relativeTo: referenceDate,
+      locale: Locale(identifier: "en_US")
+    )
+
+    XCTAssertEqual(relative, "3h ago")
+  }
+
   private func historyItemDecorator(
     _ value: String?,
     application: String? = "com.apple.finder"


### PR DESCRIPTION
## Summary
- show a compact relative age label for each copied item in the main history list
- reuse the same relative age label in paste stack rows for consistency
- add a focused unit test for the relative time formatter helper

## Testing
- xcodebuild test -project Maccy.xcodeproj -scheme Maccy -destination "platform=macOS" -only-testing:MaccyTests/HistoryItemDecoratorTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=