### PR TITLE
Cap search query length to prevent crash on huge paste (fixes #1147)

### DIFF
--- a/Maccy/Search.swift
+++ b/Maccy/Search.swift
@@ -35,11 +35,16 @@ class Search {
 
   private let fuse = Fuse(threshold: 0.7) // threshold found by trial-and-error
   private let fuzzySearchLimit = 5_000
+  private let queryLimit = 1_000
 
   func search(string: String, within: [Searchable]) -> [SearchResult] {
     guard !string.isEmpty else {
       return within.map { SearchResult(object: $0) }
     }
+
+    // Cap query length so an accidental cmd+v of huge clipboard contents
+    // into the search field can't blow up regex compilation or fuzzy matching.
+    let string = string.count > queryLimit ? String(string.prefix(queryLimit)) : string
 
     switch Defaults[.searchMode] {
     case .mixed:


### PR DESCRIPTION
## Summary
When a user accidentally pastes large clipboard contents into Maccy's search field (e.g. cmd+v while the popup is open), regex compilation and Fuse pattern construction can hang or crash the app. Caps the search query at 1,000 chars at the entry of `Search.search` so all search modes are protected.

## Repro
See [#1147 (comment)](https://github.com/p0deje/Maccy/issues/1147#issuecomment-4368372532) — `pbcopy < /usr/share/dict/words`, open Maccy, cmd+v in the search bar.

## Root cause
- `simpleSearch` with `.regularExpression` compiles the entire query as an `NSRegularExpression` pattern — very slow / can OOM on multi-MB input.
- `fuzzySearch` already caps the *target* string at `fuzzySearchLimit = 5_000`, but the *pattern* passed to `fuse.createPattern` is unbounded.

## Fix
One-line guard in `Search.search` that truncates the query to 1,000 chars before dispatching to any backend. No real user is searching clipboard history with a 1,000+ char pattern, so this is safe.

## Test plan
- [x] Built locally on Xcode 26.4.1, ran with a 1MB blob pasted into the search field — no crash, results render in <100ms.
- [x] Existing search behavior unchanged for queries under 1,000 chars.

Fixes #1147