### PR TITLE
feat: Remove clipboard items older than set time

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -9,6 +9,7 @@ class Clipboard {
 
   private var onNewCopyHooks: [OnNewCopyHook] = []
   var changeCount: Int
+  var lastCleanup: Date
 
   private let pasteboard = NSPasteboard.general
 
@@ -37,6 +38,7 @@ class Clipboard {
 
   init() {
     changeCount = pasteboard.changeCount
+    lastCleanup = Date()
   }
 
   func onNewCopy(_ hook: @escaping OnNewCopyHook) {
@@ -148,6 +150,15 @@ class Clipboard {
   @objc
   @MainActor
   func checkForChangesInPasteboard() { // swiftlint:disable:this cyclomatic_complexity
+
+    let cleanUpInterval = (Defaults[.time] * 3600) / 2
+    
+    if (Date().timeIntervalSince(lastCleanup) > cleanUpInterval) {
+      // Remove items older than time limit in background
+      History.shared.removeOldestItem(to: Defaults[.time])
+      lastCleanup = Date()
+    }
+    
     guard pasteboard.changeCount != changeCount else {
       return
     }

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -53,6 +53,7 @@ extension Defaults.Keys {
   static let showSpecialSymbols = Key<Bool>("showSpecialSymbols", default: true)
   static let showTitle = Key<Bool>("showTitle", default: true)
   static let size = Key<Int>("historySize", default: 200)
+  static let time = Key<Double>("timeLimit", default: 8)
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -107,13 +107,33 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     let results = try Storage.shared.context.fetch(descriptor)
     all = sorter.sort(results).map { HistoryItemDecorator($0) }
     items = all
-
+    
+    // check and remove older items
+    removeOldestItem(to: Defaults[.time])
+    
     limitHistorySize(to: Defaults[.size])
 
     updateShortcuts()
     // Ensure that panel size is proper *after* loading all items.
     Task {
       AppState.shared.popup.needsResize = true
+    }
+  }
+    
+  @MainActor
+  func removeOldestItem(to timeInHours: Double) {
+    if (timeInHours == 0) {
+      return
+    }
+    if (all.isEmpty) {
+      return
+    }
+    let timeInSeconds = timeInHours * 3600
+    let oldest = all.filter{
+      $0.isUnpinned && (Date().timeIntervalSince($0.item.lastCopiedAt) > timeInSeconds)
+    };
+    if oldest.count != 0 {
+      oldest.forEach(delete)
     }
   }
 
@@ -170,7 +190,9 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     // Remove exceeding items. Do this after the item is added to avoid removing something
     // if a duplicate was found as then the size already stayed the same.
     limitHistorySize(to: Defaults[.size] - 1)
-
+      
+    removeOldestItem(to: Defaults[.time])
+    
     sessionLog[Clipboard.shared.changeCount] = item
 
     var itemDecorator: HistoryItemDecorator
@@ -473,7 +495,6 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
       return item
     }
-
     updateUnpinnedShortcuts()
   }
 
@@ -483,7 +504,6 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         item.shortcuts = KeyShortcut.create(character: pin)
       }
     }
-
     updateUnpinnedShortcuts()
   }
 

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -57,6 +57,7 @@ struct StorageSettingsPane: View {
   }
 
   @Default(.size) private var size
+  @Default(.time) private var time
   @Default(.sortBy) private var sortBy
 
   @State private var viewModel = ViewModel()
@@ -106,6 +107,20 @@ struct StorageSettingsPane: View {
             .onAppear {
               storageSize = Storage.shared.size
             }
+        }
+      }
+      
+      Settings.Section(label: { Text("Time", tableName: "StorageSettings") }) {
+        HStack {
+          TextField("", value: $time, formatter: sizeFormatter)
+            .frame(width: 80)
+            .help(Text("TimeToolTip", tableName: "StorageSettings"))
+          Stepper("", value: $time, in: 0...48)
+            .labelsHidden()
+          Text(time != 1 ? "hours" : "hour")
+            .controlSize(.small)
+            .foregroundStyle(.gray)
+            .help(Text("TimeToolTip", tableName: "StorageSettings"))
         }
       }
 

--- a/Maccy/Settings/en.lproj/StorageSettings.strings
+++ b/Maccy/Settings/en.lproj/StorageSettings.strings
@@ -7,6 +7,8 @@
 "Size" = "Size:";
 "SizeTooltip" = "Number of history items to keep.\nDefault: 200.";
 "CurrentSizeTooltip" = "Current size on disk.";
+"Time" = "Keep for:";
+"TimeToolTip" = "How long to keep items in history.\nDefault: 8 hours.";
 "SortBy" = "Sort by:";
 "LastCopiedAt" = "Time of last copy";
 "FirstCopiedAt" = "Time of first copy";


### PR DESCRIPTION
This PR adds a function to remove items older than set time in settings under Storage options. Function is called when program is loaded or a new item is added to it. This function wont clear pinned items and to avoid unnecessary cycles function will exit early if clipboard is empty or user sets time to 0.

Function can also run in the background without being triggered by add or load using "checkForChangesInPasteboard" function. However, this will run it twice a second from my testing so, I added "lastChange" variable to store last time it cleared the old items. I chose half of set time in hours as condition if it's larger then it older items will be cleared and sets "lastChange" to now.

Time setting default is 8 and accepts values from 0 to 48, setting it to 0 will disable it.

Added:
    Background cleanup
        Cleanup interval (Time set / 2) to avoid unnecessary cpu cycles
    Settings entry.
    removeOldestItem() function