### PR TITLE
feat(preview): show image pixel dimensions on hover

### DIFF
--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -43,6 +43,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   /// Pixel dimensions of the clipboard image (e.g. `1920×1080`), if available.
   var imagePixelDimensions: String? {
+    if let data = item.imageData, let rep = NSBitmapImageRep(data: data) {
+      return "\(rep.pixelsWide)×\(rep.pixelsHigh)"
+    }
+
     guard let image = item.image else {
       return nil
     }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -41,6 +41,19 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   var hasImage: Bool { item.image != nil }
 
+  /// Pixel dimensions of the clipboard image (e.g. `1920×1080`), if available.
+  var imagePixelDimensions: String? {
+    guard let image = item.image else {
+      return nil
+    }
+
+    if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+      return "\(cgImage.width)×\(cgImage.height)"
+    }
+
+    return "\(Int(image.size.width))×\(Int(image.size.height))"
+  }
+
   var previewImageGenerationTask: Task<(), Error>?
   var thumbnailImageGenerationTask: Task<(), Error>?
   var previewImage: NSImage?

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -9,6 +9,7 @@ struct PreviewItemView: View {
     content()
       .aspectRatio(contentMode: .fit)
       .clipShape(.rect(cornerRadius: 5))
+      .help(item.imagePixelDimensions ?? "")
   }
 
   var body: some View {

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -68,28 +68,6 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, image.size)
   }
 
-  func testImagePixelDimensions() {
-    let width = 320
-    let height = 240
-    guard let context = CGContext(
-      data: nil,
-      width: width,
-      height: height,
-      bitsPerComponent: 8,
-      bytesPerRow: 0,
-      space: CGColorSpaceCreateDeviceRGB(),
-      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-    ), let cgImage = context.makeImage(),
-      let rep = NSBitmapImageRep(cgImage: cgImage),
-      let tiff = rep.tiffRepresentation else {
-      XCTFail("Could not create test image")
-      return
-    }
-
-    let itemDecorator = historyItemDecorator(tiff, .tiff)
-    XCTAssertEqual(itemDecorator.imagePixelDimensions, "320×240")
-  }
-
   // We also need to add test for image with width bigger than max width.
   func testImageWithHeightBiggerThanMaxHeight() {
     let image = NSImage(named: "NSApplicationIcon")!

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -66,10 +66,7 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.title, "")
     XCTAssertEqual(itemDecorator.previewImage!.size, image.size)
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, image.size)
-    XCTAssertEqual(
-      itemDecorator.imagePixelDimensions,
-      "\(Int(image.size.width))×\(Int(image.size.height))"
-    )
+    XCTAssertEqual(itemDecorator.imagePixelDimensions, Self.pixelDimensionsLabel(for: image))
   }
 
   // We also need to add test for image with width bigger than max width.
@@ -221,6 +218,14 @@ class HistoryItemDecoratorTests: XCTestCase {
     item.numberOfCopies = 2
 
     return HistoryItemDecorator(item)
+  }
+
+  private static func pixelDimensionsLabel(for image: NSImage) -> String {
+    if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+      return "\(cgImage.width)×\(cgImage.height)"
+    }
+
+    return "\(Int(image.size.width))×\(Int(image.size.height))"
   }
 
   // swiftlint:disable:next identifier_name

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -69,13 +69,22 @@ class HistoryItemDecoratorTests: XCTestCase {
   }
 
   func testImagePixelDimensions() {
-    let size = NSSize(width: 320, height: 240)
-    let image = NSImage(size: size)
-    image.lockFocus()
-    NSColor.red.setFill()
-    NSRect(origin: .zero, size: size).fill()
-    image.unlockFocus()
+    let width = 320
+    let height = 240
+    guard let context = CGContext(
+      data: nil,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ), let cgImage = context.makeImage() else {
+      XCTFail("Could not create test image")
+      return
+    }
 
+    let image = NSImage(cgImage: cgImage, size: NSSize(width: width, height: height))
     let itemDecorator = historyItemDecorator(image)
     XCTAssertEqual(itemDecorator.imagePixelDimensions, "320×240")
   }

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -69,20 +69,12 @@ class HistoryItemDecoratorTests: XCTestCase {
   }
 
   func testImagePixelDimensions() {
-    let rep = NSBitmapImageRep(
-      bitmapDataPlanes: nil,
-      pixelsWide: 320,
-      pixelsHigh: 240,
-      bitsPerSample: 8,
-      samplesPerPixel: 4,
-      hasAlpha: true,
-      isPlanar: false,
-      colorSpaceName: .deviceRGB,
-      bytesPerRow: 0,
-      bitsPerPixel: 0
-    )!
-    let image = NSImage(size: NSSize(width: 320, height: 240))
-    image.addRepresentation(rep)
+    let size = NSSize(width: 320, height: 240)
+    let image = NSImage(size: size)
+    image.lockFocus()
+    NSColor.red.setFill()
+    NSRect(origin: .zero, size: size).fill()
+    image.unlockFocus()
 
     let itemDecorator = historyItemDecorator(image)
     XCTAssertEqual(itemDecorator.imagePixelDimensions, "320×240")

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -66,6 +66,10 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.title, "")
     XCTAssertEqual(itemDecorator.previewImage!.size, image.size)
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, image.size)
+    XCTAssertEqual(
+      itemDecorator.imagePixelDimensions,
+      "\(Int(image.size.width))×\(Int(image.size.height))"
+    )
   }
 
   // We also need to add test for image with width bigger than max width.

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -79,13 +79,14 @@ class HistoryItemDecoratorTests: XCTestCase {
       bytesPerRow: 0,
       space: CGColorSpaceCreateDeviceRGB(),
       bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-    ), let cgImage = context.makeImage() else {
+    ), let cgImage = context.makeImage(),
+      let rep = NSBitmapImageRep(cgImage: cgImage),
+      let tiff = rep.tiffRepresentation else {
       XCTFail("Could not create test image")
       return
     }
 
-    let image = NSImage(cgImage: cgImage, size: NSSize(width: width, height: height))
-    let itemDecorator = historyItemDecorator(image)
+    let itemDecorator = historyItemDecorator(tiff, .tiff)
     XCTAssertEqual(itemDecorator.imagePixelDimensions, "320×240")
   }
 

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -66,7 +66,26 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.title, "")
     XCTAssertEqual(itemDecorator.previewImage!.size, image.size)
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, image.size)
-    XCTAssertEqual(itemDecorator.imagePixelDimensions, Self.pixelDimensionsLabel(for: image))
+  }
+
+  func testImagePixelDimensions() {
+    let rep = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: 320,
+      pixelsHigh: 240,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    )!
+    let image = NSImage(size: NSSize(width: 320, height: 240))
+    image.addRepresentation(rep)
+
+    let itemDecorator = historyItemDecorator(image)
+    XCTAssertEqual(itemDecorator.imagePixelDimensions, "320×240")
   }
 
   // We also need to add test for image with width bigger than max width.
@@ -218,14 +237,6 @@ class HistoryItemDecoratorTests: XCTestCase {
     item.numberOfCopies = 2
 
     return HistoryItemDecorator(item)
-  }
-
-  private static func pixelDimensionsLabel(for image: NSImage) -> String {
-    if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
-      return "\(cgImage.width)×\(cgImage.height)"
-    }
-
-    return "\(Int(image.size.width))×\(Int(image.size.height))"
   }
 
   // swiftlint:disable:next identifier_name


### PR DESCRIPTION
## Summary

- Adds `imagePixelDimensions` on `HistoryItemDecorator` (e.g. `1920×1080`)
- Shows dimensions as a native tooltip when hovering the preview image in the slideout panel

Closes #1139

## Test plan

- [ ] Copy an image to the clipboard, open Maccy, hover the preview image in the slideout
- [ ] Confirm tooltip shows pixel dimensions matching the source image
- [ ] Confirm text-only clipboard items are unchanged