### PR TITLE
fix: apply preview delay when hovering another item

### DIFF
--- a/Maccy/Observables/SlideoutController.swift
+++ b/Maccy/Observables/SlideoutController.swift
@@ -144,7 +144,10 @@ class SlideoutController {
     return newSize
   }
 
-  func togglePreview(trigger: SlideoutToggleTrigger = .manual) {
+  func togglePreview(
+    trigger: SlideoutToggleTrigger = .manual,
+    cancelPendingAutoOpen: Bool = true
+  ) {
     if !state.isOpen {
       let navigator = AppState.shared.navigator
       guard navigator.leadHistoryItem != nil || navigator.pasteStackSelected else { return }
@@ -158,7 +161,9 @@ class SlideoutController {
       }
     }
 
-    cancelAutoOpen()
+    if cancelPendingAutoOpen {
+      cancelAutoOpen()
+    }
     withAnimation(.easeInOut(duration: Self.animationDuration), completionCriteria: .removed) {
       if let window = nswindow {
         togglePreviewStateWithAnimation(windowFrame: window.frame)
@@ -225,14 +230,21 @@ class SlideoutController {
 
     guard autoOpenEnabled else { return }
     guard !autoOpenSuppressed else { return }
-    guard !state.isOpen else { return }
+
+    let navigator = AppState.shared.navigator
+    guard navigator.leadHistoryItem != nil || navigator.pasteStackSelected else { return }
 
     autoOpenTask = Task { @MainActor in
+      if state.isOpen {
+        togglePreview(trigger: .autoOpen, cancelPendingAutoOpen: false)
+      }
+
       try? await Task.sleep(for: .milliseconds(Defaults[.previewDelay]))
       guard !Task.isCancelled else { return }
+      guard !autoOpenSuppressed else { return }
 
       if !state.isOpen {
-        togglePreview(trigger: .autoOpen)
+        togglePreview(trigger: .autoOpen, cancelPendingAutoOpen: false)
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #1365. When the preview slideout was already open, `startAutoOpen()` returned immediately because of `guard !state.isOpen`, so `previewDelay` only applied on the first hover in a popup session.

Now, changing the hovered/selected item while the preview is open closes the slideout, waits for `previewDelay`, then reopens for the new selection. Rapid hovers still cancel the previous timer via `cancelAutoOpen()`.

## Test plan

- [ ] Set preview delay to 2000ms in Appearance settings
- [ ] Open Maccy, hover item A — preview opens after delay
- [ ] Hover item B without closing popup — preview closes, waits ~2s, reopens with B's content
- [ ] Rapidly hover several items — only the last item's preview opens after delay
- [ ] Manually close preview with shortcut — auto-open stays suppressed until popup reopens