### PR TITLE
fix: reload preview image when selecting another item

### DIFF
--- a/Maccy/Views/AsyncView.swift
+++ b/Maccy/Views/AsyncView.swift
@@ -7,6 +7,7 @@ enum AsyncViewState<T> {
 }
 
 struct AsyncView<Value, Content: View, Placeholder: View>: View {
+  let id: AnyHashable
   let operation: () async throws -> Value
   @ViewBuilder var content: (Value) -> Content
   @ViewBuilder var placeholder: () -> Placeholder
@@ -14,10 +15,12 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
   @State private var viewState = AsyncViewState<Value>.loading
 
   init(
+    id: AnyHashable,
     operation: @escaping () async throws -> Value,
     @ViewBuilder content: @escaping (Value) -> Content,
     @ViewBuilder placeholder: @escaping () -> Placeholder
   ) {
+    self.id = id
     self.operation = operation
     self.content = content
     self.placeholder = placeholder
@@ -31,7 +34,8 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
       case .loaded(let value):
         content(value)
       }
-    }.task {
+    }
+    .task(id: id) {
       do {
         viewState = .loading
         let result = try await operation()

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -14,9 +14,9 @@ struct PreviewItemView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       if item.hasImage {
-        AsyncView<NSImage?, _, _> {
+        AsyncView(id: item.id, operation: {
           return await item.asyncGetPreviewImage()
-        } content: { image in
+        }, content: { image in
           if let image = image {
             previewImage {
               Image(nsImage: image)


### PR DESCRIPTION
## Summary

Fixes #1344. `AsyncView` in the preview panel only loaded once, so switching between image history items kept showing the previous preview.

## Changes

- Add an `id` parameter to `AsyncView` and use `task(id:)` to restart loading when the id changes
- Pass `item.id` from `PreviewItemView`

## Test plan

- [ ] Copy two different images to the clipboard
- [ ] Open Maccy, open the preview slideout
- [ ] Hover/select the first image, then the second — preview should update to the second image