### PR TITLE
Add storage cleanup action

### DIFF
--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -212,26 +212,17 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @MainActor
   func clear() {
     withLogging("Clearing history") {
-      all.forEach { item in
-        if item.isUnpinned {
-          cleanup(item)
-        }
-      }
+      let itemsToDelete = all.filter(\.isUnpinned)
+      itemsToDelete.forEach(cleanup)
       all.removeAll(where: \.isUnpinned)
       sessionLog.removeValues { $0.pin == nil }
       items = all
 
-      try? Storage.shared.context.transaction {
-        try? Storage.shared.context.delete(
-          model: HistoryItem.self,
-          where: #Predicate { $0.pin == nil }
-        )
-        try? Storage.shared.context.delete(
-          model: HistoryItemContent.self,
-          where: #Predicate { $0.item?.pin == nil }
-        )
+      itemsToDelete.forEach { item in
+        Storage.shared.context.delete(item.item)
       }
       Storage.shared.context.processPendingChanges()
+      Storage.shared.removeOrphanedContents()
       try? Storage.shared.context.save()
     }
 
@@ -245,15 +236,17 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @MainActor
   func clearAll() {
     withLogging("Clearing all history") {
-      all.forEach { item in
-        cleanup(item)
-      }
+      let itemsToDelete = all
+      itemsToDelete.forEach(cleanup)
       all.removeAll()
       sessionLog.removeAll()
       items = all
 
-      try? Storage.shared.context.delete(model: HistoryItem.self)
+      itemsToDelete.forEach { item in
+        Storage.shared.context.delete(item.item)
+      }
       Storage.shared.context.processPendingChanges()
+      Storage.shared.removeOrphanedContents()
       try? Storage.shared.context.save()
     }
 
@@ -272,6 +265,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     withLogging("Removing history item") {
       Storage.shared.context.delete(item.item)
       Storage.shared.context.processPendingChanges()
+      Storage.shared.removeOrphanedContents()
       try? Storage.shared.context.save()
     }
 

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -3,6 +3,11 @@ import Defaults
 import Settings
 
 struct StorageSettingsPane: View {
+  struct CompactStorageError: Identifiable {
+    let id = UUID()
+    let message: String
+  }
+
   @Observable
   class ViewModel {
     var saveFiles = false {
@@ -61,6 +66,8 @@ struct StorageSettingsPane: View {
 
   @State private var viewModel = ViewModel()
   @State private var storageSize = Storage.shared.size
+  @State private var isCompacting = false
+  @State private var compactError: CompactStorageError?
 
   private let sizeFormatter: NumberFormatter = {
     let formatter = NumberFormatter()
@@ -106,6 +113,18 @@ struct StorageSettingsPane: View {
             .onAppear {
               storageSize = Storage.shared.size
             }
+          Button {
+            compactStorage()
+          } label: {
+            Text("CompactStorage", tableName: "StorageSettings")
+          }
+          .controlSize(.small)
+          .disabled(isCompacting || !Storage.shared.hasDatabase)
+          .help(Text("CompactStorageTooltip", tableName: "StorageSettings"))
+          if isCompacting {
+            ProgressView()
+              .controlSize(.small)
+          }
         }
       }
 
@@ -119,6 +138,34 @@ struct StorageSettingsPane: View {
         .frame(width: 160, alignment: .leading)
         .help(Text("SortByTooltip", tableName: "StorageSettings"))
       }
+    }
+    .alert(
+      Text("CompactStorageErrorTitle", tableName: "StorageSettings"),
+      isPresented: Binding(
+        get: { compactError != nil },
+        set: { if !$0 { compactError = nil } }
+      ),
+      presenting: compactError
+    ) { _ in
+      Button(role: .cancel) {} label: {
+        Text("CompactStorageErrorDismiss", tableName: "StorageSettings")
+      }
+    } message: { error in
+      Text(error.message)
+    }
+  }
+
+  private func compactStorage() {
+    isCompacting = true
+
+    Task { @MainActor in
+      do {
+        storageSize = try await Storage.shared.reclaimDiskSpace()
+      } catch {
+        compactError = CompactStorageError(message: error.localizedDescription)
+      }
+
+      isCompacting = false
     }
   }
 }

--- a/Maccy/Settings/ar.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ar.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "وقت النسخة الأولى";
 "NumberOfCopies" = "عدد النسخ";
 "SortByTooltip" = "الافتراضي: وقت النسخة الأخيرة.";
+"CompactStorage" = "تحرير مساحة";
+"CompactStorageTooltip" = "يزيل بيانات الحافظة المحذوفة ويقلّص قاعدة بيانات التخزين.";
+"CompactStorageErrorTitle" = "تعذّر تحرير مساحة.";
+"CompactStorageErrorDismiss" = "حسنًا";

--- a/Maccy/Settings/be.lproj/StorageSettings.strings
+++ b/Maccy/Settings/be.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "SizeTooltip" = "Колькасць элементаў, якія будуць захоўвацца.\nПадставова: 200.";
 "SortBy" = "Сартаваць па:";
 "CurrentSizeTooltip" = "Бягучы памер на дыску.";
+"CompactStorage" = "Вызваліць месца";
+"CompactStorageTooltip" = "Выдаляе выдаленыя даныя буфера абмену і сціскае базу даных сховішча.";
+"CompactStorageErrorTitle" = "Не ўдалося вызваліць месца.";
+"CompactStorageErrorDismiss" = "Добра";

--- a/Maccy/Settings/bn.lproj/StorageSettings.strings
+++ b/Maccy/Settings/bn.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "";
 "NumberOfCopies" = "";
 "SortByTooltip" = "";
+"CompactStorage" = "স্থান খালি করুন";
+"CompactStorageTooltip" = "মুছে ফেলা ক্লিপবোর্ড ডেটা সরিয়ে স্টোরেজ ডেটাবেস ছোট করে।";
+"CompactStorageErrorTitle" = "স্থান খালি করা যায়নি।";
+"CompactStorageErrorDismiss" = "ঠিক আছে";

--- a/Maccy/Settings/bs.lproj/StorageSettings.strings
+++ b/Maccy/Settings/bs.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "Broj kopija";
 "SortByTooltip" = "Standardno: Vrijeme zadnje kopije.";
 "CurrentSizeTooltip" = "Trenutna veličina na disku.";
+"CompactStorage" = "Oslobodi prostor";
+"CompactStorageTooltip" = "Uklanja obrisane podatke međuspremnika i smanjuje bazu podataka pohrane.";
+"CompactStorageErrorTitle" = "Nije moguće osloboditi prostor.";
+"CompactStorageErrorDismiss" = "U redu";

--- a/Maccy/Settings/ca.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ca.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "SizeTooltip" = "Nombre d'elements guardats a l'històric.\nPer defecte: 200.";
 "LastCopiedAt" = "Temps de l'última còpia";
 "CurrentSizeTooltip" = "";
+"CompactStorage" = "Allibera espai";
+"CompactStorageTooltip" = "Elimina les dades suprimides del porta-retalls i compacta la base de dades d’emmagatzematge.";
+"CompactStorageErrorTitle" = "No s’ha pogut alliberar espai.";
+"CompactStorageErrorDismiss" = "D’acord";

--- a/Maccy/Settings/ckb.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ckb.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "کاتی یەکەم کۆپی";
 "NumberOfCopies" = "ژمارەی کۆپییەکان";
 "SortByTooltip" = "بنەڕەت: کاتی دوایین کۆپی.";
+"CompactStorage" = "شوێن چۆڵ بکەرەوە";
+"CompactStorageTooltip" = "داتای سڕدراوی کلیپبۆرد لادەبات و بنکەدراوەی پاشەکەوتکردن بچووک دەکاتەوە.";
+"CompactStorageErrorTitle" = "نەکرا شوێن چۆڵ بکرێتەوە.";
+"CompactStorageErrorDismiss" = "باشە";

--- a/Maccy/Settings/cs.lproj/StorageSettings.strings
+++ b/Maccy/Settings/cs.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Čas prvního kopírování";
 "NumberOfCopies" = "Počet kopírování";
 "SortByTooltip" = "Výchozí: Čas posledního kopírování.";
+"CompactStorage" = "Uvolnit místo";
+"CompactStorageTooltip" = "Odstraní smazaná data schránky a zmenší databázi úložiště.";
+"CompactStorageErrorTitle" = "Nepodařilo se uvolnit místo.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/de.lproj/StorageSettings.strings
+++ b/Maccy/Settings/de.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Zeitpunkt des ersten Eintrags";
 "NumberOfCopies" = "Häufigkeit der Einträge";
 "SortByTooltip" = "Standard: Zeitpunkt des letzten Eintrags.";
+"CompactStorage" = "Speicher bereinigen";
+"CompactStorageTooltip" = "Entfernt gelöschte Zwischenablagedaten und verkleinert die Speicherdatenbank.";
+"CompactStorageErrorTitle" = "Speicher kann nicht bereinigt werden.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/el.lproj/StorageSettings.strings
+++ b/Maccy/Settings/el.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "";
 "NumberOfCopies" = "";
 "SortByTooltip" = "";
+"CompactStorage" = "Ελευθέρωση χώρου";
+"CompactStorageTooltip" = "Αφαιρεί τα διαγραμμένα δεδομένα προχείρου και συμπτύσσει τη βάση δεδομένων αποθήκευσης.";
+"CompactStorageErrorTitle" = "Δεν ήταν δυνατή η ελευθέρωση χώρου.";
+"CompactStorageErrorDismiss" = "Εντάξει";

--- a/Maccy/Settings/en.lproj/StorageSettings.strings
+++ b/Maccy/Settings/en.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Time of first copy";
 "NumberOfCopies" = "Number of copies";
 "SortByTooltip" = "Default: Time of last copy.";
+"CompactStorage" = "Reclaim Space";
+"CompactStorageTooltip" = "Remove deleted clipboard data and shrink the storage database.";
+"CompactStorageErrorTitle" = "Unable to Reclaim Space.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/eo.lproj/StorageSettings.strings
+++ b/Maccy/Settings/eo.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Momento de unua kopio";
 "NumberOfCopies" = "Nombro de kopioj";
 "SortByTooltip" = "Defaŭlta: Momento de lasta kopio.";
+"CompactStorage" = "Liberigi spacon";
+"CompactStorageTooltip" = "Forigas forigitajn tondujajn datumojn kaj kuntirigas la konservan datumbazon.";
+"CompactStorageErrorTitle" = "Ne eblis liberigi spacon.";
+"CompactStorageErrorDismiss" = "Bone";

--- a/Maccy/Settings/es.lproj/StorageSettings.strings
+++ b/Maccy/Settings/es.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Más antiguos, primero";
 "NumberOfCopies" = "Número de copias";
 "SortByTooltip" = "Por defecto: Más nuevos, primero.";
+"CompactStorage" = "Liberar espacio";
+"CompactStorageTooltip" = "Elimina los datos borrados del portapapeles y reduce la base de datos de almacenamiento.";
+"CompactStorageErrorTitle" = "No se puede liberar espacio.";
+"CompactStorageErrorDismiss" = "Aceptar";

--- a/Maccy/Settings/fa.lproj/StorageSettings.strings
+++ b/Maccy/Settings/fa.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "";
 "NumberOfCopies" = "";
 "SortByTooltip" = "";
+"CompactStorage" = "آزادسازی فضا";
+"CompactStorageTooltip" = "داده‌های حذف‌شدهٔ کلیپ‌بورد را پاک می‌کند و پایگاه دادهٔ ذخیره‌سازی را فشرده می‌کند.";
+"CompactStorageErrorTitle" = "آزادسازی فضا ممکن نشد.";
+"CompactStorageErrorDismiss" = "باشه";

--- a/Maccy/Settings/fr.lproj/StorageSettings.strings
+++ b/Maccy/Settings/fr.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Date de première copie";
 "NumberOfCopies" = "Nombre de copies";
 "SortByTooltip" = "Par défaut : Date de dernière copie.";
+"CompactStorage" = "Libérer de l’espace";
+"CompactStorageTooltip" = "Supprime les données de presse-papiers supprimées et compacte la base de données de stockage.";
+"CompactStorageErrorTitle" = "Impossible de libérer de l’espace.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/he.lproj/StorageSettings.strings
+++ b/Maccy/Settings/he.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "מספר עותקים";
 "SortByTooltip" = "ברירת מחדל: מועד העותק האחרון.";
 "CurrentSizeTooltip" = "גודל נוכחי בדיסק.";
+"CompactStorage" = "פנה מקום";
+"CompactStorageTooltip" = "מסיר נתוני לוח גזירים שנמחקו ומכווץ את מסד נתוני האחסון.";
+"CompactStorageErrorTitle" = "לא ניתן לפנות מקום.";
+"CompactStorageErrorDismiss" = "אישור";

--- a/Maccy/Settings/hi.lproj/StorageSettings.strings
+++ b/Maccy/Settings/hi.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "";
 "NumberOfCopies" = "";
 "SortByTooltip" = "";
+"CompactStorage" = "स्थान खाली करें";
+"CompactStorageTooltip" = "हटाए गए क्लिपबोर्ड डेटा को मिटाकर संग्रहण डेटाबेस को छोटा करता है।";
+"CompactStorageErrorTitle" = "स्थान खाली नहीं किया जा सका।";
+"CompactStorageErrorDismiss" = "ठीक है";

--- a/Maccy/Settings/hr.lproj/StorageSettings.strings
+++ b/Maccy/Settings/hr.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "Broj kopija";
 "SortByTooltip" = "Standardno: Vrijeme zadnje kopije.";
 "CurrentSizeTooltip" = "Trenutna veličina na disku.";
+"CompactStorage" = "Oslobodi prostor";
+"CompactStorageTooltip" = "Uklanja obrisane podatke međuspremnika i smanjuje bazu podataka pohrane.";
+"CompactStorageErrorTitle" = "Nije moguće osloboditi prostor.";
+"CompactStorageErrorDismiss" = "U redu";

--- a/Maccy/Settings/hu.lproj/StorageSettings.strings
+++ b/Maccy/Settings/hu.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Első másolás ideje";
 "NumberOfCopies" = "Másolások száma";
 "SortByTooltip" = "Alapértelmezett: Utolsó másolás ideje.";
+"CompactStorage" = "Tárhely felszabadítása";
+"CompactStorageTooltip" = "Eltávolítja a törölt vágólapadatokat és tömöríti a tárolási adatbázist.";
+"CompactStorageErrorTitle" = "Nem sikerült tárhelyet felszabadítani.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/id.lproj/StorageSettings.strings
+++ b/Maccy/Settings/id.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Waktu salinan pertama";
 "NumberOfCopies" = "";
 "SortByTooltip" = "";
+"CompactStorage" = "Kosongkan ruang";
+"CompactStorageTooltip" = "Menghapus data papan klip yang sudah dihapus dan mengecilkan basis data penyimpanan.";
+"CompactStorageErrorTitle" = "Tidak dapat mengosongkan ruang.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/it.lproj/StorageSettings.strings
+++ b/Maccy/Settings/it.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Tempo della prima copia";
 "NumberOfCopies" = "Numero di copie";
 "SortByTooltip" = "Default: Tempo dell'ultima copia.";
+"CompactStorage" = "Libera spazio";
+"CompactStorageTooltip" = "Rimuove i dati degli appunti eliminati e compatta il database di archiviazione.";
+"CompactStorageErrorTitle" = "Impossibile liberare spazio.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/ja.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ja.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "最初にコピーした日時";
 "NumberOfCopies" = "コピー回数";
 "SortByTooltip" = "デフォルト：最後にコピーした日時。";
+"CompactStorage" = "空き容量を回収";
+"CompactStorageTooltip" = "削除済みのクリップボードデータを消去し、保存データベースを圧縮します。";
+"CompactStorageErrorTitle" = "空き容量を回収できません。";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/ko.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ko.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "처음 복사한 시간";
 "NumberOfCopies" = "복사 횟수";
 "SortByTooltip" = "기본값: 마지막 복사한 시간.";
+"CompactStorage" = "공간 정리";
+"CompactStorageTooltip" = "삭제된 클립보드 데이터를 제거하고 저장소 데이터베이스를 축소합니다.";
+"CompactStorageErrorTitle" = "공간을 정리할 수 없습니다.";
+"CompactStorageErrorDismiss" = "확인";

--- a/Maccy/Settings/lt.lproj/StorageSettings.strings
+++ b/Maccy/Settings/lt.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Pirmosios kopijos laikas";
 "NumberOfCopies" = "Kopijų skaičius";
 "SortByTooltip" = "Numatytoji reikšmė: Paskutinės kopijos laikas.";
+"CompactStorage" = "Atlaisvinti vietos";
+"CompactStorageTooltip" = "Pašalina ištrintus iškarpinės duomenis ir sumažina saugyklos duomenų bazę.";
+"CompactStorageErrorTitle" = "Nepavyko atlaisvinti vietos.";
+"CompactStorageErrorDismiss" = "Gerai";

--- a/Maccy/Settings/lv.lproj/StorageSettings.strings
+++ b/Maccy/Settings/lv.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Pirmās kopijas laiks";
 "NumberOfCopies" = "Kopiju skaits";
 "SortByTooltip" = "Noklusējums: pēdējās kopijas laiks.";
+"CompactStorage" = "Atbrīvot vietu";
+"CompactStorageTooltip" = "Noņem izdzēstos starpliktuves datus un samazina glabātuves datubāzi.";
+"CompactStorageErrorTitle" = "Neizdevās atbrīvot vietu.";
+"CompactStorageErrorDismiss" = "Labi";

--- a/Maccy/Settings/nb.lproj/StorageSettings.strings
+++ b/Maccy/Settings/nb.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Tidspunkt første kopiering";
 "NumberOfCopies" = "Antall ganger kopiert";
 "SortByTooltip" = "Standard: Tidspunkt siste kopiering.";
+"CompactStorage" = "Frigjør plass";
+"CompactStorageTooltip" = "Fjerner slettede utklippsdata og komprimerer lagringsdatabasen.";
+"CompactStorageErrorTitle" = "Kunne ikke frigjøre plass.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/nl.lproj/StorageSettings.strings
+++ b/Maccy/Settings/nl.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Tijd van eerste kopie";
 "NumberOfCopies" = "Aantal kopieën";
 "SortByTooltip" = "Standaard: Tijd van laatste kopie.";
+"CompactStorage" = "Ruimte vrijmaken";
+"CompactStorageTooltip" = "Verwijdert verwijderde klembordgegevens en verkleint de opslagdatabase.";
+"CompactStorageErrorTitle" = "Kan geen ruimte vrijmaken.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/pl.lproj/StorageSettings.strings
+++ b/Maccy/Settings/pl.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Czas pierwszego kopiowania";
 "NumberOfCopies" = "Liczba kopii";
 "SortByTooltip" = "Domyślnie: Czas ostatniego kopiowania.";
+"CompactStorage" = "Zwolnij miejsce";
+"CompactStorageTooltip" = "Usuwa skasowane dane schowka i zmniejsza bazę danych przechowywania.";
+"CompactStorageErrorTitle" = "Nie można zwolnić miejsca.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/pt-BR.lproj/StorageSettings.strings
+++ b/Maccy/Settings/pt-BR.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Data da primeira cópia";
 "NumberOfCopies" = "Número de cópias";
 "SortByTooltip" = "Padrão: Data de última cópia.";
+"CompactStorage" = "Liberar espaço";
+"CompactStorageTooltip" = "Remove os dados excluídos da área de transferência e compacta o banco de dados de armazenamento.";
+"CompactStorageErrorTitle" = "Não foi possível liberar espaço.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/pt.lproj/StorageSettings.strings
+++ b/Maccy/Settings/pt.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "Número de cópias";
 "SortByTooltip" = "Padrão: Data de última cópia.";
 "Title" = "Armazenamento";
+"CompactStorage" = "Libertar espaço";
+"CompactStorageTooltip" = "Remove os dados eliminados da área de transferência e compacta a base de dados de armazenamento.";
+"CompactStorageErrorTitle" = "Não foi possível libertar espaço.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/ro.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ro.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "Files" = "Fișiere";
 "SortByTooltip" = "Implicit: Data ultimei copii.";
 "CurrentSizeTooltip" = "Dimensiunea curentă pe disc.";
+"CompactStorage" = "Eliberează spațiu";
+"CompactStorageTooltip" = "Elimină datele șterse din clipboard și compactează baza de date de stocare.";
+"CompactStorageErrorTitle" = "Nu s-a putut elibera spațiu.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/ru.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ru.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Время первого копирования";
 "NumberOfCopies" = "Количество копирований";
 "SortByTooltip" = "По умолчанию: Время последнего копирования.";
+"CompactStorage" = "Освободить место";
+"CompactStorageTooltip" = "Удаляет удалённые данные буфера обмена и сжимает базу данных хранилища.";
+"CompactStorageErrorTitle" = "Не удалось освободить место.";
+"CompactStorageErrorDismiss" = "ОК";

--- a/Maccy/Settings/sl.lproj/StorageSettings.strings
+++ b/Maccy/Settings/sl.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Čas prvega kopiranja";
 "NumberOfCopies" = "Število kopiranj";
 "SortByTooltip" = "Privzeto: Čas zadnjega kopiranja.";
+"CompactStorage" = "Sprosti prostor";
+"CompactStorageTooltip" = "Odstrani izbrisane podatke odložišča in pomanjša podatkovno bazo shrambe.";
+"CompactStorageErrorTitle" = "Prostora ni bilo mogoče sprostiti.";
+"CompactStorageErrorDismiss" = "V redu";

--- a/Maccy/Settings/sv.lproj/StorageSettings.strings
+++ b/Maccy/Settings/sv.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "";
 "NumberOfCopies" = "";
 "SortByTooltip" = "";
+"CompactStorage" = "Frigör utrymme";
+"CompactStorageTooltip" = "Tar bort raderade urklippsdata och krymper lagringsdatabasen.";
+"CompactStorageErrorTitle" = "Det gick inte att frigöra utrymme.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/ta.lproj/StorageSettings.strings
+++ b/Maccy/Settings/ta.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "பிரதிகளின் எண்ணிக்கை";
 "SortByTooltip" = "இயல்புநிலை: கடைசி நகலின் நேரம்.";
 "CurrentSizeTooltip" = "";
+"CompactStorage" = "இடத்தை காலி செய்";
+"CompactStorageTooltip" = "நீக்கப்பட்ட கிளிப்போர்டு தரவை அகற்றி சேமிப்பு தரவுத்தளத்தைச் சுருக்குகிறது.";
+"CompactStorageErrorTitle" = "இடத்தை காலி செய்ய முடியவில்லை.";
+"CompactStorageErrorDismiss" = "சரி";

--- a/Maccy/Settings/th.lproj/StorageSettings.strings
+++ b/Maccy/Settings/th.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "จำนวนการคัดลอก";
 "SortByTooltip" = "ค่าเริ่มต้น: เวลาคัดลอกสุดท้าย";
 "CurrentSizeTooltip" = "ขนาดปัจจุบันบนดิสก์";
+"CompactStorage" = "คืนพื้นที่";
+"CompactStorageTooltip" = "ลบข้อมูลคลิปบอร์ดที่ถูกลบแล้วและย่อฐานข้อมูลที่จัดเก็บข้อมูลให้เล็กลง";
+"CompactStorageErrorTitle" = "ไม่สามารถคืนพื้นที่ได้";
+"CompactStorageErrorDismiss" = "ตกลง";

--- a/Maccy/Settings/tr.lproj/StorageSettings.strings
+++ b/Maccy/Settings/tr.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "İlk kopyanın zamanı";
 "NumberOfCopies" = "Kopya sayısı";
 "SortByTooltip" = "Saptanmış: Son kopyanın zamanı.";
+"CompactStorage" = "Alan aç";
+"CompactStorageTooltip" = "Silinmiş pano verilerini kaldırır ve depolama veritabanını küçültür.";
+"CompactStorageErrorTitle" = "Alan açılamadı.";
+"CompactStorageErrorDismiss" = "Tamam";

--- a/Maccy/Settings/uk.lproj/StorageSettings.strings
+++ b/Maccy/Settings/uk.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "Часом першої копії";
 "NumberOfCopies" = "Кількістю копій";
 "SortByTooltip" = "За замовчуванням: Час останньої копії.";
+"CompactStorage" = "Звільнити місце";
+"CompactStorageTooltip" = "Видаляє вилучені дані буфера обміну та стискає базу даних сховища.";
+"CompactStorageErrorTitle" = "Не вдалося звільнити місце.";
+"CompactStorageErrorDismiss" = "Гаразд";

--- a/Maccy/Settings/uz.lproj/StorageSettings.strings
+++ b/Maccy/Settings/uz.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "SortByTooltip" = "Standart: Oxirgi nusxa vaqti.";
 "Title" = "Hotira";
 "Text" = "Matn";
+"CompactStorage" = "Joy bo‘shatish";
+"CompactStorageTooltip" = "O‘chirilgan almashish buferi ma’lumotlarini olib tashlaydi va saqlash bazasini kichraytiradi.";
+"CompactStorageErrorTitle" = "Joy bo‘shatib bo‘lmadi.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/vi.lproj/StorageSettings.strings
+++ b/Maccy/Settings/vi.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "NumberOfCopies" = "Sao chép nhiều nhất";
 "SortByTooltip" = "Mặc định: Sao chép mới nhất.";
 "CurrentSizeTooltip" = "Dung lượng hiện đang chiếm trên ổ đĩa.";
+"CompactStorage" = "Giải phóng dung lượng";
+"CompactStorageTooltip" = "Xóa dữ liệu bảng tạm đã bị xóa và thu gọn cơ sở dữ liệu lưu trữ.";
+"CompactStorageErrorTitle" = "Không thể giải phóng dung lượng.";
+"CompactStorageErrorDismiss" = "OK";

--- a/Maccy/Settings/zh-Hans.lproj/StorageSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "首次复制时间";
 "NumberOfCopies" = "复制次数";
 "SortByTooltip" = "默认：上次复制时间。";
+"CompactStorage" = "清理空间";
+"CompactStorageTooltip" = "删除已移除的剪贴板数据并压缩存储数据库。";
+"CompactStorageErrorTitle" = "无法清理空间。";
+"CompactStorageErrorDismiss" = "好";

--- a/Maccy/Settings/zh-Hant.lproj/StorageSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/StorageSettings.strings
@@ -12,3 +12,7 @@
 "FirstCopiedAt" = "首次拷貝時間";
 "NumberOfCopies" = "拷貝次數";
 "SortByTooltip" = "預設：上次拷貝時間。";
+"CompactStorage" = "清理空間";
+"CompactStorageTooltip" = "刪除已移除的剪貼簿資料並壓縮儲存資料庫。";
+"CompactStorageErrorTitle" = "無法清理空間。";
+"CompactStorageErrorDismiss" = "好";

--- a/Maccy/Storage.swift
+++ b/Maccy/Storage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import SwiftData
 
 @MainActor
@@ -8,11 +9,15 @@ class Storage {
   var container: ModelContainer
   var context: ModelContext { container.mainContext }
   var size: String {
-    guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).allValues.first?.value as? Int64, size > 1 else {
+    guard let size = fileSize(at: url), size > 1 else {
       return ""
     }
 
     return ByteCountFormatter().string(fromByteCount: size)
+  }
+
+  var hasDatabase: Bool {
+    FileManager.default.fileExists(atPath: url.path)
   }
 
   private let url = URL.applicationSupportDirectory.appending(path: "Maccy/Storage.sqlite")
@@ -30,6 +35,77 @@ class Storage {
       container = try ModelContainer(for: HistoryItem.self, configurations: config)
     } catch let error {
       fatalError("Cannot load database: \(error.localizedDescription).")
+    }
+  }
+
+  func removeOrphanedContents() {
+    let descriptor = FetchDescriptor<HistoryItemContent>(
+      predicate: #Predicate { $0.item == nil }
+    )
+
+    guard let orphanedContents = try? context.fetch(descriptor), !orphanedContents.isEmpty else {
+      return
+    }
+
+    orphanedContents.forEach(context.delete)
+    context.processPendingChanges()
+    try? context.save()
+  }
+
+  func reclaimDiskSpace() async throws -> String {
+    context.processPendingChanges()
+    try context.save()
+    removeOrphanedContents()
+
+    let databaseURL = url
+    try await Task.detached(priority: .utility) {
+      try compactStorageDatabase(at: databaseURL)
+    }.value
+
+    return size
+  }
+}
+
+private func compactStorageDatabase(at url: URL) throws {
+  var database: OpaquePointer?
+  guard sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READWRITE, nil) == SQLITE_OK else {
+    let message = database.flatMap { sqlite3_errmsg($0) }.map { String(cString: $0) } ?? "Unable to open database."
+    sqlite3_close(database)
+    throw StorageCompactError.openDatabase(message)
+  }
+
+  defer {
+    sqlite3_close(database)
+  }
+
+  sqlite3_busy_timeout(database, 5_000)
+
+  try executeSQLite(database, statement: "PRAGMA wal_checkpoint(TRUNCATE);")
+  try executeSQLite(database, statement: "DELETE FROM ZHISTORYITEMCONTENT WHERE ZITEM IS NULL;")
+  try executeSQLite(database, statement: "VACUUM;")
+}
+
+private func executeSQLite(_ database: OpaquePointer?, statement: String) throws {
+  guard sqlite3_exec(database, statement, nil, nil, nil) == SQLITE_OK else {
+    let message = database.flatMap { sqlite3_errmsg($0) }.map { String(cString: $0) } ?? "Database operation failed."
+    throw StorageCompactError.execute(statement, message)
+  }
+}
+
+private func fileSize(at url: URL) -> Int64? {
+  try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize.map(Int64.init)
+}
+
+private enum StorageCompactError: LocalizedError {
+  case openDatabase(String)
+  case execute(String, String)
+
+  var errorDescription: String? {
+    switch self {
+    case let .openDatabase(message):
+      return message
+    case let .execute(statement, message):
+      return "\(statement) \(message)"
     }
   }
 }

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Defaults
+import SwiftData
 @testable import Maccy
 
 @MainActor
@@ -231,6 +232,18 @@ class HistoryTests: XCTestCase {
     let bar = history.add(historyItem("bar"))
     history.delete(foo)
     XCTAssertEqual(history.items, [bar])
+  }
+
+  func testDeletingItemRemovesContentsFromStorage() throws {
+    let item = history.add(historyItem("foo"))
+
+    history.delete(item)
+
+    let historyItemCount = try Storage.shared.context.fetchCount(FetchDescriptor<HistoryItem>())
+    let contentCount = try Storage.shared.context.fetchCount(FetchDescriptor<HistoryItemContent>())
+
+    XCTAssertEqual(historyItemCount, 0)
+    XCTAssertEqual(contentCount, 0)
   }
 
   private func historyItem(_ value: String) -> HistoryItem {

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -541,12 +541,14 @@ class MaccyUITests: XCTestCase {
   private func copyToClipboard(_ content: Data?, _ type: NSPasteboard.PasteboardType) {
     pasteboard.clearContents()
     pasteboard.setData(content, forType: type)
-    waitTillClipboardCheck()
+    // Rich clipboard data can take longer to become visible to Maccy's polling loop on CI.
+    _ = pasteboard.data(forType: type)
+    waitTillClipboardCheck(delayMultiplier: 2)
   }
 
   // Default interval for Maccy to check clipboard is 1 second
-  private func waitTillClipboardCheck() {
-    usleep(1_500_000)
+  private func waitTillClipboardCheck(delayMultiplier: useconds_t = 1) {
+    usleep(1_500_000 * delayMultiplier)
   }
 
   private func pin(_ title: String) {
@@ -638,9 +640,9 @@ class MaccyUITests: XCTestCase {
   }
 
   private func confirmClear() {
-    let button = app.dialogs.firstMatch.buttons["Clear"].firstMatch
-    expectation(for: NSPredicate(format: "isHittable = 1"), evaluatedWith: button)
-    waitForExpectations(timeout: 3)
+    let button = app.sheets.firstMatch.buttons["Clear"].firstMatch
+    expectation(for: NSPredicate(format: "exists = 1 AND isHittable = 1"), evaluatedWith: button)
+    waitForExpectations(timeout: 5)
     button.click()
   }
 }

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -40,7 +40,9 @@ class MaccyUITests: XCTestCase {
   }
 
   var itemTitles: [String] {
-    items.allElementsBoundByIndex
+    app.staticTexts
+      .matching(identifier: "copy-history-item")
+      .allElementsBoundByIndex
       .sorted(by: { $0.frame.origin.y < $1.frame.origin.y })
       .compactMap { $0.value as? String }
   }
@@ -164,8 +166,8 @@ class MaccyUITests: XCTestCase {
     popUpWithHotkey()
     XCTAssertEqual(itemTitles[0...1], ["foo", "bar"])
 
-    app.staticTexts["bar"].firstMatch.click()
-    XCTAssertEqual(pasteboard.data(forType: .rtf), rtf2)
+    items["bar"].firstMatch.click()
+    assertPasteboardDataEquals(rtf2, forType: .rtf)
   }
 
   func testCopyHTML() {


### PR DESCRIPTION
## Summary
- add a Storage settings action to reclaim disk space by removing orphaned clipboard content and compacting the SQLite store
- clean up orphaned content after history deletion paths so stale content does not continue accumulating
- add localized strings for the new storage cleanup UI across existing StorageSettings localizations
- add a regression test that deleting an item removes its stored content

## Notes
This PR intentionally excludes the fork-only GitHub Actions workflow used to build and download a local test app.

## Validation
- GitHub macOS build succeeded in the fork while validating the same application code changes: https://github.com/shallFun4Learning/Maccy/actions/runs/26236455877
