### PR TITLE
Enhanced long-text preview and title line settings, along with improved image and file content handling.

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -52,6 +52,7 @@ extension Defaults.Keys {
   static let searchVisibility = Key<SearchVisibility>("searchVisibility", default: .always)
   static let showSpecialSymbols = Key<Bool>("showSpecialSymbols", default: true)
   static let showTitle = Key<Bool>("showTitle", default: true)
+  static let titleLines = Key<Int>("titleLines", default: 1)
   static let size = Key<Int>("historySize", default: 200)
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)

--- a/Maccy/Maccy.entitlements
+++ b/Maccy/Maccy.entitlements
@@ -8,8 +8,8 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
-    	<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
-    	<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
 	</array>
 </dict>
 </plist>

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -85,6 +85,25 @@ class HistoryItem {
       }
   }
 
+  func formatForDisplay(_ raw: String, replaceNewlines: Bool) -> String {
+    var result = raw
+    if Defaults[.showSpecialSymbols] {
+      if let range = result.range(of: "^ +", options: .regularExpression) {
+        result = result.replacingOccurrences(of: " ", with: "·", range: range)
+      }
+      if let range = result.range(of: " +$", options: .regularExpression) {
+        result = result.replacingOccurrences(of: " ", with: "·", range: range)
+      }
+      if replaceNewlines {
+        result = result.replacingOccurrences(of: "\n", with: "⏎")
+      }
+      result = result.replacingOccurrences(of: "\t", with: "⇥")
+    } else {
+      result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return result
+  }
+
   func generateTitle() -> String {
     guard image == nil else {
       Task {
@@ -94,23 +113,8 @@ class HistoryItem {
     }
 
     // 1k characters is trade-off for performance
-    var title = previewableText.shortened(to: 1_000)
-
-    if Defaults[.showSpecialSymbols] {
-      if let range = title.range(of: "^ +", options: .regularExpression) {
-        title = title.replacingOccurrences(of: " ", with: "·", range: range)
-      }
-      if let range = title.range(of: " +$", options: .regularExpression) {
-        title = title.replacingOccurrences(of: " ", with: "·", range: range)
-      }
-      title = title
-        .replacingOccurrences(of: "\n", with: "⏎")
-        .replacingOccurrences(of: "\t", with: "⇥")
-    } else {
-      title = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    return title
+    let raw = previewableText.shortened(to: 1_000)
+    return formatForDisplay(raw, replaceNewlines: true)
   }
 
   var previewableText: String {

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -101,7 +101,7 @@ class HistoryItem {
     return raw.trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
-  private func formatLine(_ line: String) -> String {
+  func formatLine(_ line: String) -> String {
     if Defaults[.showSpecialSymbols] {
       var result = line
       if let range = result.range(of: "^ +", options: .regularExpression) {

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -85,23 +85,35 @@ class HistoryItem {
       }
   }
 
-  func formatForDisplay(_ raw: String, replaceNewlines: Bool) -> String {
-    var result = raw
+  func formatForDisplay(_ raw: String) -> String {
+    let titleLines = Defaults[.titleLines]
+
+    if titleLines > 1 {
+      let lines = raw.components(separatedBy: "\n")
+      let firstLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }.prefix(titleLines)
+      return firstLines.map { formatLine($0) }.joined(separator: "\n")
+    }
+
     if Defaults[.showSpecialSymbols] {
+      return formatLine(raw.replacingOccurrences(of: "\n", with: "⏎"))
+    }
+
+    return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func formatLine(_ line: String) -> String {
+    if Defaults[.showSpecialSymbols] {
+      var result = line
       if let range = result.range(of: "^ +", options: .regularExpression) {
         result = result.replacingOccurrences(of: " ", with: "·", range: range)
       }
       if let range = result.range(of: " +$", options: .regularExpression) {
         result = result.replacingOccurrences(of: " ", with: "·", range: range)
       }
-      if replaceNewlines {
-        result = result.replacingOccurrences(of: "\n", with: "⏎")
-      }
       result = result.replacingOccurrences(of: "\t", with: "⇥")
-    } else {
-      result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+      return result
     }
-    return result
+    return line.trimmingCharacters(in: .whitespaces)
   }
 
   func generateTitle() -> String {
@@ -114,7 +126,7 @@ class HistoryItem {
 
     // 1k characters is trade-off for performance
     let raw = previewableText.shortened(to: 1_000)
-    return formatForDisplay(raw, replaceNewlines: true)
+    return formatForDisplay(raw)
   }
 
   var previewableText: String {

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -48,13 +48,13 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 
-  // 10k characters seems to be more than enough on large displays
-  var text: String { item.previewableText.shortened(to: 10_000) }
+  // 10k characters seems to be more than enough on large displays.
+  // Cached as stored property to avoid recomputing previewableText (which
+  // may parse RTF/HTML) on every SwiftUI access.
+  private(set) var text: String = ""
 
   /// `text` with `showSpecialSymbols` applied, but newlines preserved for multi-line truncation.
-  var displayText: String {
-    item.formatForDisplay(text)
-  }
+  private(set) var displayText: String = ""
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }
@@ -73,6 +73,11 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     self.shortcuts = shortcuts
     self.title = item.title
     self.applicationImage = ApplicationImageCache.shared.getImage(item: item)
+
+    // Precompute text to avoid repeated previewableText (RTF/HTML parsing) on SwiftUI reads.
+    let rawText = item.previewableText.shortened(to: 10_000)
+    self.text = rawText
+    self.displayText = item.formatForDisplay(rawText)
 
     synchronizeItemPin()
     synchronizeItemTitle()

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -40,6 +40,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   }
 
   var hasImage: Bool { item.image != nil }
+  var hasFileURLs: Bool { !item.fileURLs.isEmpty }
 
   var previewImageGenerationTask: Task<(), Error>?
   var thumbnailImageGenerationTask: Task<(), Error>?

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -51,6 +51,11 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   // 10k characters seems to be more than enough on large displays
   var text: String { item.previewableText.shortened(to: 10_000) }
 
+  /// `text` with `showSpecialSymbols` applied, but newlines preserved for multi-line truncation.
+  var displayText: String {
+    item.formatForDisplay(text, replaceNewlines: false)
+  }
+
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }
 

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -51,10 +51,23 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   // 10k characters seems to be more than enough on large displays.
   // Cached as stored property to avoid recomputing previewableText (which
   // may parse RTF/HTML) on every SwiftUI access.
-  private(set) var text: String = ""
+  let text: String
 
-  /// `text` with `showSpecialSymbols` applied, but newlines preserved for multi-line truncation.
-  private(set) var displayText: String = ""
+  /// First `maxTitleLines` non-blank lines, pre-split to avoid re-splitting on every access.
+  private let firstLines: [String]
+
+  /// `text` truncated to `titleLines` with `showSpecialSymbols` applied.
+  /// Computed so that changing `titleLines` in preferences affects all items immediately.
+  var displayText: String {
+    let lines = Defaults[.titleLines]
+    if lines > 1 {
+      return firstLines.prefix(lines).map { item.formatLine($0) }.joined(separator: "\n")
+    }
+    if Defaults[.showSpecialSymbols] {
+      return item.formatLine(text.replacingOccurrences(of: "\n", with: "⏎"))
+    }
+    return text.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }
@@ -77,7 +90,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     // Precompute text to avoid repeated previewableText (RTF/HTML parsing) on SwiftUI reads.
     let rawText = item.previewableText.shortened(to: 10_000)
     self.text = rawText
-    self.displayText = item.formatForDisplay(rawText)
+    self.firstLines = Array(rawText
+      .components(separatedBy: "\n")
+      .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+      .prefix(5))  // max titleLines from stepper range
 
     synchronizeItemPin()
     synchronizeItemTitle()

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -53,7 +53,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   /// `text` with `showSpecialSymbols` applied, but newlines preserved for multi-line truncation.
   var displayText: String {
-    item.formatForDisplay(text, replaceNewlines: false)
+    item.formatForDisplay(text)
   }
 
   var isPinned: Bool { item.pin != nil }

--- a/Maccy/Settings/AppearanceSettingsPane.swift
+++ b/Maccy/Settings/AppearanceSettingsPane.swift
@@ -8,6 +8,7 @@ struct AppearanceSettingsPane: View {
   @Default(.popupScreen) private var popupScreen
   @Default(.pinTo) private var pinTo
   @Default(.imageMaxHeight) private var imageHeight
+  @Default(.titleLines) private var titleLines
   @Default(.previewDelay) private var previewDelay
   @Default(.highlightMatch) private var highlightMatch
   @Default(.menuIcon) private var menuIcon
@@ -26,7 +27,12 @@ struct AppearanceSettingsPane: View {
     formatter.maximum = 200
     return formatter
   }()
-
+  private let titleLinesFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.minimum = 1
+    formatter.maximum = 5
+    return formatter
+  }()
   private let numberOfItemsFormatter: NumberFormatter = {
     let formatter = NumberFormatter()
     formatter.minimum = 0
@@ -96,6 +102,16 @@ struct AppearanceSettingsPane: View {
             .frame(width: 120)
             .help(Text("ImageHeightTooltip", tableName: "AppearanceSettings"))
           Stepper("", value: $imageHeight, in: 1...200)
+            .labelsHidden()
+        }
+      }
+
+      Settings.Section(label: { Text("TitleLines", tableName: "AppearanceSettings") }) {
+        HStack {
+          TextField("", value: $titleLines, formatter: titleLinesFormatter)
+            .frame(width: 120)
+            .help(Text("TitleLinesTooltip", tableName: "AppearanceSettings"))
+          Stepper("", value: $titleLines, in: 1...5)
             .labelsHidden()
         }
       }

--- a/Maccy/Settings/en.lproj/AppearanceSettings.strings
+++ b/Maccy/Settings/en.lproj/AppearanceSettings.strings
@@ -16,6 +16,8 @@
 "PinToTooltip" = "Change the location of pinned items.\nDefault: Top.";
 "ImageHeight" = "Image height:";
 "ImageHeightTooltip" = "Maximum image preview height.\nDefault: 40.\nHint: Set to 16 to look like text items.";
+"TitleLines" = "Title lines:";
+"TitleLinesTooltip" = "Number of lines displayed per history item.\nDefault: 1.\nHint: Increase to see more text in each item.";
 "PreviewDelay" = "Preview delay:";
 "PreviewDelayTooltip" = "Delay in milliseconds until a preview popup is shown.\nDefault: 1500.";
 "HighlightMatches" = "Highlight matches:";

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -39,6 +39,7 @@ struct HistoryItemView: View {
       image: item.thumbnailImage,
       accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
       attributedTitle: item.attributedTitle,
+      rawTitle: item.displayText,
       shortcuts: item.shortcuts,
       isSelected: item.isSelected,
       selectionIndex: visualIndex,
@@ -46,6 +47,7 @@ struct HistoryItemView: View {
     ) {
       Text(verbatim: item.title)
     }
+    .padding(.vertical, 0.5)
     .onAppear {
       item.ensureThumbnailImage()
     }

--- a/Maccy/Views/ListItemTitleView.swift
+++ b/Maccy/Views/ListItemTitleView.swift
@@ -1,23 +1,99 @@
+import Defaults
 import SwiftUI
+
+// MARK: - Truncation helpers
+
+/// Font matching SwiftUI's default `.body` on macOS.
+private let bodyFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+
+/// Truncate a single line by inserting " ... " in the middle if it exceeds maxWidth.
+/// Uses NSAttributedString for accurate pixel-width measurement.
+func truncateLine(_ text: String, maxWidth: CGFloat) -> String {
+  let ellipsis = " ... "
+  let attrs: [NSAttributedString.Key: Any] = [.font: bodyFont]
+
+  func width(of s: String) -> CGFloat {
+    NSAttributedString(string: s, attributes: attrs).size().width
+  }
+
+  guard width(of: text) > maxWidth else { return text }
+
+  let chars = Array(text)
+
+  // Binary search the longest prefix that still allows suffix + ellipsis to fit.
+  var lo = 0
+  var hi = chars.count / 2
+  while lo < hi {
+    let mid = (lo + hi + 1) / 2
+    let suffixStart = chars.count - mid
+    let candidate = String(chars[0..<mid]) + ellipsis + String(chars[suffixStart...])
+    if width(of: candidate) <= maxWidth {
+      lo = mid
+    } else {
+      hi = mid - 1
+    }
+  }
+
+  if lo == 0 {
+    // Nothing fits with ellipsis; just cut to width.
+    var result = ""
+    for ch in chars {
+      guard width(of: result + String(ch)) <= maxWidth else { break }
+      result += String(ch)
+    }
+    return result
+  }
+
+  let suffixStart = chars.count - lo
+  return String(chars[0..<lo]) + ellipsis + String(chars[suffixStart...])
+}
+
+/// Truncate multi-line text: split by newlines, take first maxLines lines,
+/// truncate each long line individually, join with newlines.
+func truncateText(_ raw: String, maxWidth: CGFloat, maxLines: Int) -> String {
+  let lines = raw.components(separatedBy: .newlines)
+  let capped = lines.prefix(maxLines)
+  return capped.map { truncateLine($0, maxWidth: maxWidth) }.joined(separator: "\n")
+}
+
+// MARK: - ListItemTitleView
 
 struct ListItemTitleView<Title: View>: View {
   var attributedTitle: AttributedString?
+  var rawTitle: String?
   @ViewBuilder var title: () -> Title
+  @Default(.titleLines) private var titleLines
+  @Default(.windowSize) private var windowSize
+  @Default(.showApplicationIcons) private var showIcons
+
+  /// Estimated text area width: window width minus padding for icons, spacers,
+  /// shortcuts, and trailing margin.
+  private var estimatedTextWidth: CGFloat {
+    let base = windowSize.width
+    let iconArea: CGFloat = showIcons ? 30 : 15
+    let shortcutsArea: CGFloat = 40
+    let margin: CGFloat = 20
+    return max(base - iconArea - shortcutsArea - margin, 80)
+  }
 
   var body: some View {
-    if let attributedTitle {
-      Text(attributedTitle)
-        .accessibilityIdentifier("copy-history-item")
-        .lineLimit(1)
-        .truncationMode(.middle)
-    } else {
-      title()
-        .accessibilityIdentifier("copy-history-item")
-        .lineLimit(1)
-        .truncationMode(.middle)
-        // Workaround for macOS 26 to avoid flipped text
-        // https://github.com/p0deje/Maccy/issues/1113
-        .drawingGroup()
+    Group {
+      if let attributedTitle {
+        Text(attributedTitle)
+          .accessibilityIdentifier("copy-history-item")
+          .lineLimit(titleLines)
+          .truncationMode(.middle)
+      } else if let rawTitle {
+        Text(truncateText(rawTitle, maxWidth: estimatedTextWidth, maxLines: titleLines))
+          .accessibilityIdentifier("copy-history-item")
+          .lineLimit(titleLines)
+      } else {
+        title()
+          .accessibilityIdentifier("copy-history-item")
+          .lineLimit(titleLines)
+          .truncationMode(.middle)
+          .drawingGroup()
+      }
     }
   }
 }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -35,6 +35,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   var image: NSImage?
   var accessoryImage: NSImage?
   var attributedTitle: AttributedString?
+  var rawTitle: String?
   var shortcuts: [KeyShortcut]
   var isSelected: Bool
   var selectionIndex: Int?
@@ -74,7 +75,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
           .padding(.trailing, 5)
           .padding(.vertical, 5)
       } else {
-        ListItemTitleView(attributedTitle: attributedTitle, title: title)
+        ListItemTitleView(attributedTitle: attributedTitle, rawTitle: rawTitle, title: title)
           .padding(.trailing, 5)
       }
 
@@ -109,10 +110,22 @@ struct ListItemView<Title: View, ID: Hashable>: View {
     .frame(minHeight: Popup.itemHeight)
     .id(id)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .foregroundStyle(isSelected ? Color.white : .primary)
-    // macOS 26 broke hovering if no background is present.
-    // The slight opcaity white background is a workaround
-    .background(isSelected ? Color.accentColor.opacity(0.8) : .white.opacity(0.001))
+    .foregroundStyle(isSelected ? Color.accentColor : .primary)
+    .background(
+      RoundedRectangle(cornerRadius: Popup.cornerRadius)
+        .fill(
+          isSelected
+            ? Color.accentColor.opacity(0.12)
+            : Color.primary.opacity(0.03)
+        )
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: Popup.cornerRadius)
+        .strokeBorder(
+          isSelected ? Color.accentColor : Color.primary.opacity(0.15),
+          lineWidth: 1
+        )
+    )
     .clipShape(selectionAppearance.rect(cornerRadius: Popup.cornerRadius))
     .hoverSelectionId(selectionId)
     .help(help ?? "")

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -88,7 +88,7 @@ struct PreviewItemView: View {
       } else {
         ScrollView {
           LazyVStack(alignment: .leading, spacing: 0) {
-            ForEach(paragraphs, id: \.self) { paragraph in
+            ForEach(Array(paragraphs.enumerated()), id: \.offset) { _, paragraph in
               Text(paragraph)
                 .font(.body)
             }

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -6,6 +6,10 @@ import SwiftUI
 struct PreviewItemView: View {
   var item: HistoryItemDecorator
 
+  private var paragraphs: [String] {
+    item.text.components(separatedBy: "\n")
+  }
+
   private func revealFile(_ url: URL) {
     var isDirectory: ObjCBool = false
     if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
@@ -83,8 +87,12 @@ struct PreviewItemView: View {
         }
       } else {
         ScrollView {
-          Text(item.text)
-            .font(.body)
+          LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(paragraphs, id: \.self) { paragraph in
+              Text(paragraph)
+                .font(.body)
+            }
+          }
         }
       }
 

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -4,6 +4,13 @@ import SwiftUI
 struct PreviewItemView: View {
   var item: HistoryItemDecorator
 
+  private func revealFile(_ url: URL) {
+    var isDirectory: ObjCBool = false
+    if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+      NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+  }
+
   @ViewBuilder
   func previewImage(content: () -> some View) -> some View {
     content()
@@ -50,14 +57,34 @@ struct PreviewItemView: View {
           }
         }
         .id(item.id)
+      } else if item.hasFileURLs {
+        ScrollView {
+          VStack(alignment: .leading, spacing: 4) {
+            ForEach(item.item.fileURLs, id: \.self) { url in
+              HStack {
+                Text(url.absoluteString.removingPercentEncoding ?? url.path)
+                  .font(.body)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+                Spacer()
+                Button {
+                  revealFile(url)
+                } label: {
+                  Image(systemName: "folder")
+                    .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .help(Text("RevealInFinder", tableName: "PreviewItemView"))
+              }
+            }
+          }
+        }
       } else {
         ScrollView {
           Text(item.text)
             .font(.body)
         }
       }
-
-      Spacer(minLength: 0)
 
       Divider()
         .padding(.vertical)

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -1,6 +1,8 @@
 import KeyboardShortcuts
 import SwiftUI
 
+// MARK: - PreviewItemView
+
 struct PreviewItemView: View {
   var item: HistoryItemDecorator
 
@@ -85,6 +87,8 @@ struct PreviewItemView: View {
             .font(.body)
         }
       }
+
+      Spacer(minLength: 0)
 
       Divider()
         .padding(.vertical)

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -49,6 +49,7 @@ struct PreviewItemView: View {
             }
           }
         }
+        .id(item.id)
       } else {
         ScrollView {
           Text(item.text)

--- a/Maccy/Views/ToolbarView.swift
+++ b/Maccy/Views/ToolbarView.swift
@@ -113,12 +113,34 @@ struct ToolbarView: View {
     NSWorkspace.shared.activateFileViewerSelecting([fileURL])
   }
 
+  private func revealInFinder() {
+    guard let item = appState.navigator.leadHistoryItem else {
+      return
+    }
+
+    let urls = item.item.fileURLs.filter { url in
+      var isDirectory: ObjCBool = false
+      return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+    }
+
+    guard !urls.isEmpty else { return }
+
+    NSWorkspace.shared.activateFileViewerSelecting(urls)
+  }
+
   var body: some View {
     HStack {
       if !appState.navigator.selection.isEmpty {
         Spacer()
 
-        if appState.navigator.leadHistoryItem?.hasImage == true {
+        if appState.navigator.leadHistoryItem?.hasFileURLs == true {
+          ToolbarButton {
+            revealInFinder()
+          } label: {
+            Image(systemName: "folder")
+          }
+          .help(Text("RevealInFinder", tableName: "PreviewItemView"))
+        } else if appState.navigator.leadHistoryItem?.hasImage == true {
           ToolbarButton {
             savePreviewImage()
           } label: {

--- a/Maccy/Views/ToolbarView.swift
+++ b/Maccy/Views/ToolbarView.swift
@@ -36,9 +36,10 @@ struct ToolbarButton<Label: View>: View {
   var body: some View {
     Button(action: action) {
       label()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .buttonStyle(.plain)
-    .frame(height: 23)
+    .frame(width: 23, height: 23)
     .onHover(perform: { inside in
       if let window = appState.appDelegate?.panel {
         window.isMovableByWindowBackground = !inside
@@ -82,10 +83,49 @@ struct ToolbarView: View {
       && appState.navigator.selection.items.contains { !$0.isPinned }
   }
 
+  private func savePreviewImage() {
+    guard let item = appState.navigator.leadHistoryItem,
+          let image = item.item.image else {
+      return
+    }
+
+    let picturesDir = FileManager.default.urls(
+      for: .picturesDirectory, in: .userDomainMask
+    ).first ?? FileManager.default.homeDirectoryForCurrentUser
+
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+    let filename = "Maccy-\(formatter.string(from: item.item.firstCopiedAt)).png"
+    let fileURL = picturesDir.appendingPathComponent(filename)
+
+    // Remove existing file before writing to replace it.
+    try? FileManager.default.removeItem(at: fileURL)
+
+    guard let tiffData = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiffData),
+          let pngData = bitmap.representation(using: .png, properties: [:]) else {
+      return
+    }
+
+    try? pngData.write(to: fileURL)
+
+    // Reveal in Finder
+    NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+  }
+
   var body: some View {
     HStack {
       if !appState.navigator.selection.isEmpty {
         Spacer()
+
+        if appState.navigator.leadHistoryItem?.hasImage == true {
+          ToolbarButton {
+            savePreviewImage()
+          } label: {
+            Image(systemName: "square.and.arrow.down.on.square")
+          }
+          .help(Text("SaveImage", tableName: "PreviewItemView"))
+        }
 
         ToolbarButton {
           withAnimation {

--- a/Maccy/Views/en.lproj/PreviewItemView.strings
+++ b/Maccy/Views/en.lproj/PreviewItemView.strings
@@ -5,4 +5,5 @@
 "PinKey" = "Press {pinKey} to pin.";
 "UnpinKey" = "Press {pinKey} to unpin.";
 "DeleteKey" = "Press {deleteKey} to delete.";
+"SaveImage" = "Save image to Pictures folder.";
 "PreviewKey" = "Press {previewKey} to toggle preview.";

--- a/Maccy/Views/en.lproj/PreviewItemView.strings
+++ b/Maccy/Views/en.lproj/PreviewItemView.strings
@@ -6,4 +6,5 @@
 "UnpinKey" = "Press {pinKey} to unpin.";
 "DeleteKey" = "Press {deleteKey} to delete.";
 "SaveImage" = "Save image to Pictures folder.";
+"RevealInFinder" = "Reveal in Finder.";
 "PreviewKey" = "Press {previewKey} to toggle preview.";


### PR DESCRIPTION
**Note:** _I'm a developer, but not a macOS developer. I submitted this entirely out of my love for Maccy, and all the code was written by AI — I only provided the ideas and verification. If you prefer not to merge AI-generated code, please feel free to ignore this PR. However, I do hope these additions and improvements can make it into the project when you have the time._

**Features**:
1. fix: Previewing two adjacent image contents does not switch the slide out preview content.
2. feat: add button to save image content to 'Pictures' folder.
3. feat: add button to locate file content.
4. feat: add title lines setting and improve title truncation in history item views.
5. feat: optimize long-text handling in HistoryItemDecorator and improve display in PreviewItemView.

**Preview multi line in the title:**
<img width="724" height="512" alt="image" src="https://github.com/user-attachments/assets/f13b4065-6a90-4b4f-8134-0566345a551e" />

**Configurable title lines:**
<img width="710" height="524" alt="image" src="https://github.com/user-attachments/assets/13ddf3f8-e27a-4fc0-8d15-b56a61247944" />

**Save image content to file:**
<img width="724" height="539" alt="image" src="https://github.com/user-attachments/assets/01864097-cd47-44a2-a30e-74f8a1ceef08" />


**Locate to files:**
<img width="724" height="488" alt="image" src="https://github.com/user-attachments/assets/2a6bc12a-f983-44b2-a6b7-6f69471f2a6b" />