### PR TITLE
Add option to remove tracking parameters from URLs

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94D2E774B570093D72C /* NavigationManager.swift */; };
 		2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94F2E7808420093D72C /* AppImageView.swift */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
+		C79DD37304014B95BD4FEA0F /* URLCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB90554083F47B289F85CDB /* URLCleaner.swift */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
 		DA009934256411F90030E697 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = DA00992F256411F90030E697 /* LICENSE */; };
@@ -145,6 +146,7 @@
 		DAFE2DDA268A521B00990986 /* String+Shortened.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DD9268A521A00990986 /* String+Shortened.swift */; };
 		DAFE2DE9268A9B1B00990986 /* HistoryItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */; };
 		DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */; };
+		FBD0129416EA4143A7C53CCC /* TrackingParameters.plist in Resources */ = {isa = PBXBuildFile; fileRef = 63D1151E49BE43409077B32C /* TrackingParameters.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -204,11 +206,11 @@
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
-		2FFF8BCF2CE2116600235A78 /* Data+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Encoding.swift"; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4DC4D112252713D700FE5FAC /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		4EB90554083F47B289F85CDB /* URLCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCleaner.swift; sourceTree = "<group>"; };
 		5212BB662E59AA5200E74A24 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/AdvancedSettings.strings; sourceTree = "<group>"; };
 		5212BB672E59AA5200E74A24 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/AppearanceSettings.strings; sourceTree = "<group>"; };
 		5212BB682E59AA5200E74A24 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/GeneralSettings.strings; sourceTree = "<group>"; };
@@ -217,6 +219,7 @@
 		5212BB6B2E59AA5200E74A24 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/PinsSettings.strings; sourceTree = "<group>"; };
 		5212BB6C2E59AA5200E74A24 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/PreviewItemView.strings; sourceTree = "<group>"; };
 		5212BB6D2E59AA5200E74A24 /* ckb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ckb; path = ckb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		63D1151E49BE43409077B32C /* TrackingParameters.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TrackingParameters.plist; sourceTree = "<group>"; };
 		7CEEFDF124F41F8500ECAD2A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		ABC72863283A9053001EE086 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA00992C256411F90030E697 /* appcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = appcast.xml; sourceTree = "<group>"; };
@@ -818,6 +821,8 @@
 				2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */,
 				DA555F072CF0F98F009608BD /* ApplicationImageCache.swift */,
 				DA0EF1871E444B2A00E58577 /* Clipboard.swift */,
+				4EB90554083F47B289F85CDB /* URLCleaner.swift */,
+				63D1151E49BE43409077B32C /* TrackingParameters.plist */,
 				DAE284FF232257D20080E394 /* ColorImage.swift */,
 				DAA54BF92C3C951900B7FDD8 /* FloatingPanel.swift */,
 				DA689FC92C1D18890009B887 /* HighlightMatch.swift */,
@@ -1039,6 +1044,7 @@
 				DA5E62802C39E53F00F4C710 /* PreviewItemView.strings in Resources */,
 				DA009932256411F90030E697 /* README.md in Resources */,
 				DA9C3C4A2C20D4B40056795D /* IgnoreSettings.strings in Resources */,
+				FBD0129416EA4143A7C53CCC /* TrackingParameters.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1116,6 +1122,7 @@
 				DAA5ACB22C1B3F8800B58513 /* GeneralSettingsPane.swift in Sources */,
 				DA1969122C3F0DD200258481 /* HistoryItemView.swift in Sources */,
 				DA0EF1881E444B2A00E58577 /* Clipboard.swift in Sources */,
+				C79DD37304014B95BD4FEA0F /* URLCleaner.swift in Sources */,
 				DA3F1B452C90084600267632 /* Sauce+KeyboardShortcuts.swift in Sources */,
 				DA689FCC2C1D1D510009B887 /* MenuIcon.swift in Sources */,
 				DAAEB196219694AE00A7883C /* About.swift in Sources */,
@@ -1736,7 +1743,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 60;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = UHT33EFSBG;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1771,7 +1778,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 60;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = UHT33EFSBG;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -208,7 +208,14 @@ class Clipboard {
       }
 
       types.forEach { type in
-        contents.append(HistoryItemContent(type: type.rawValue, value: item.data(forType: type)))
+        var value = item.data(forType: type)
+        if type == .string,
+           Defaults[.removeTrackingParameters],
+           let string = item.string(forType: .string),
+           URLCleaner.isURL(string) {
+          value = URLCleaner.clean(string).data(using: .utf8)
+        }
+        contents.append(HistoryItemContent(type: type.rawValue, value: value))
       }
     })
 

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -44,6 +44,7 @@ extension Defaults.Keys {
   static let popupScreen = Key<Int>("popupScreen", default: 0)
   static let previewDelay = Key<Int>("previewDelay", default: 1500)
   static let removeFormattingByDefault = Key<Bool>("removeFormattingByDefault", default: false)
+  static let removeTrackingParameters = Key<Bool>("removeTrackingParameters", default: false)
   static let searchMode = Key<Search.Mode>("searchMode", default: .exact)
   static let showFooter = Key<Bool>("showFooter", default: true)
   static let showInStatusBar = Key<Bool>("showInStatusBar", default: true)

--- a/Maccy/Settings/GeneralSettingsPane.swift
+++ b/Maccy/Settings/GeneralSettingsPane.swift
@@ -91,6 +91,11 @@ struct GeneralSettingsPane: View {
         .onChange(refreshModifiers)
         .fixedSize()
 
+        Defaults.Toggle(key: .removeTrackingParameters) {
+          Text("RemoveTrackingParameters", tableName: "GeneralSettings")
+        }
+        .fixedSize()
+
         Text(String(
           format: NSLocalizedString("Modifiers", tableName: "GeneralSettings", comment: ""),
           copyModifier, pasteModifier, pasteWithoutFormatting

--- a/Maccy/Settings/en.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/en.lproj/GeneralSettings.strings
@@ -19,4 +19,5 @@
 "Fuzzy" = "Fuzzy";
 "Regex" = "Regular expressions";
 "Mixed" = "Mixed";
+"RemoveTrackingParameters" = "Remove tracking parameters from URLs";
 "NotificationsAndSounds" = "Notifications and sounds 􀱁";

--- a/Maccy/TrackingParameters.plist
+++ b/Maccy/TrackingParameters.plist
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<!-- UTM (Universal Tracking Module) -->
+	<string>xmt</string>
+	<string>utm_source</string>
+	<string>utm_medium</string>
+	<string>utm_campaign</string>
+	<string>utm_term</string>
+	<string>utm_content</string>
+	<string>utm_id</string>
+	<string>utm_reader</string>
+	<string>utm_name</string>
+	<string>utm_social</string>
+	<string>utm_social-type</string>
+
+	<!-- Google Ads -->
+	<string>gclid</string>
+	<string>gclsrc</string>
+	<string>dclid</string>
+	<string>gbraid</string>
+	<string>wbraid</string>
+
+	<!-- Facebook / Meta -->
+	<string>fbclid</string>
+	<string>fb_ref</string>
+	<string>fb_source</string>
+	<string>fb_action_ids</string>
+	<string>fb_action_types</string>
+
+	<!-- Microsoft Ads -->
+	<string>msclkid</string>
+
+	<!-- Twitter / X -->
+	<string>twclid</string>
+	<string>twsrc</string>
+	<string>twgr</string>
+	<string>twcon</string>
+
+	<!-- Instagram -->
+	<string>igshid</string>
+
+	<!-- Yandex -->
+	<string>yclid</string>
+
+	<!-- HubSpot -->
+	<string>_hsenc</string>
+	<string>_hsmi</string>
+	<string>hsctaTracking</string>
+	<string>hsa_acc</string>
+	<string>hsa_cam</string>
+	<string>hsa_grp</string>
+	<string>hsa_ad</string>
+	<string>hsa_src</string>
+	<string>hsa_tgt</string>
+	<string>hsa_kw</string>
+	<string>hsa_mt</string>
+	<string>hsa_net</string>
+	<string>hsa_ver</string>
+
+	<!-- Mailchimp -->
+	<string>mc_cid</string>
+	<string>mc_eid</string>
+
+	<!-- Marketo -->
+	<string>mkt_tok</string>
+
+	<!-- Drip -->
+	<string>__s</string>
+
+	<!-- Vero -->
+	<string>vero_id</string>
+	<string>vero_conv</string>
+
+	<!-- WickedReports -->
+	<string>wickedid</string>
+
+	<!-- Olytics -->
+	<string>oly_enc_id</string>
+	<string>oly_anon_id</string>
+
+	<!-- Amazon -->
+	<string>pd_rd_r</string>
+	<string>pd_rd_w</string>
+	<string>pd_rd_wg</string>
+	<string>pf_rd_i</string>
+	<string>pf_rd_m</string>
+	<string>pf_rd_p</string>
+	<string>pf_rd_r</string>
+	<string>pf_rd_s</string>
+	<string>pf_rd_t</string>
+	<string>pd_rd_i</string>
+
+	<!-- Adobe Analytics -->
+	<string>s_cid</string>
+	<string>s_kwcid</string>
+	<string>icid</string>
+
+	<!-- Iterable -->
+	<string>_kx</string>
+
+	<!-- Others -->
+	<string>soc_src</string>
+	<string>soc_trk</string>
+	<string>ncid</string>
+	<string>ref_src</string>
+	<string>ref_url</string>
+	<string>ML_subscriber_hash</string>
+	<string>nr_email_referer</string>
+</array>
+</plist>

--- a/Maccy/URLCleaner.swift
+++ b/Maccy/URLCleaner.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct URLCleaner {
+  static let trackingParameters: Set<String> = {
+    guard let url = Bundle.main.url(forResource: "TrackingParameters", withExtension: "plist"),
+          let data = try? Data(contentsOf: url),
+          let list = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String]
+    else { return [] }
+    return Set(list.map { $0.lowercased() })
+  }()
+
+  static func clean(_ urlString: String) -> String {
+    guard var components = URLComponents(string: urlString),
+          let queryItems = components.queryItems,
+          !queryItems.isEmpty else {
+      return urlString
+    }
+    let cleaned = queryItems.filter { !trackingParameters.contains($0.name.lowercased()) }
+    components.queryItems = cleaned.isEmpty ? nil : cleaned
+    return components.string ?? urlString
+  }
+
+  static func isURL(_ string: String) -> Bool {
+    guard let url = URL(string: string) else { return false }
+    return url.scheme == "http" || url.scheme == "https"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new **"Remove tracking parameters from URLs"** toggle in General → Behavior (default: off)
- When enabled, strips known tracking query parameters from copied URLs at capture time — so the clean URL is what gets stored and pasted
- Parameters are loaded from a bundled `TrackingParameters.plist`, making the list easy to extend without recompiling

## What's included

| File | Change |
|------|--------|
| `Maccy/TrackingParameters.plist` | New bundle resource listing 80+ tracking params grouped by vendor (UTM, Google Ads, Meta/Facebook, Microsoft, Twitter/X, HubSpot, Mailchimp, Marketo, Amazon, Adobe Analytics, and others) |
| `Maccy/URLCleaner.swift` | New struct — loads the plist once at launch, exposes `isURL(_:)` and `clean(_:)` using `URLComponents` |
| `Defaults.Keys+Names.swift` | Adds `removeTrackingParameters` Bool key (default `false`) |
| `Clipboard.swift` | In the pasteboard capture loop, when the setting is on and the copied string is an `http`/`https` URL, replaces the stored value with the cleaned URL |
| `GeneralSettingsPane.swift` | Toggle added in the Behavior section, below "Paste without formatting" |
| `en.lproj/GeneralSettings.strings` | Localization string added |

## Example

Copying `https://example.com/page?utm_source=newsletter&utm_campaign=summer&id=42` stores `https://example.com/page?id=42`.