### PR TITLE
Add zh-Hans and zh-Hant translations for RemoveTrackingParameters

### DIFF
--- a/Maccy/Settings/zh-Hans.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/zh-Hans.lproj/GeneralSettings.strings
@@ -19,4 +19,5 @@
 "Fuzzy" = "模糊";
 "Regex" = "正则表达式";
 "Mixed" = "混合";
+"RemoveTrackingParameters" = "移除 URL 中的追踪参数";
 "NotificationsAndSounds" = "通知和声音 􀱁";

--- a/Maccy/Settings/zh-Hant.lproj/GeneralSettings.strings
+++ b/Maccy/Settings/zh-Hant.lproj/GeneralSettings.strings
@@ -19,4 +19,5 @@
 "Fuzzy" = "模糊";
 "Regex" = "正規表示式";
 "Mixed" = "混合";
+"RemoveTrackingParameters" = "移除 URL 中的追蹤碼";
 "NotificationsAndSounds" = "通知和聲音 􀱁";


### PR DESCRIPTION
Adds Simplified Chinese (zh-Hans) and Traditional Chinese (zh-Hant) translations for the `RemoveTrackingParameters` setting key introduced in #1413.

- `zh-Hans`: 移除 URL 中的追踪参数
- `zh-Hant`: 移除 URL 中的追蹤碼