### PR TITLE
Add clipboard automations

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -145,6 +145,13 @@
 		DAFE2DDA268A521B00990986 /* String+Shortened.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DD9268A521A00990986 /* String+Shortened.swift */; };
 		DAFE2DE9268A9B1B00990986 /* HistoryItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */; };
 		DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */; };
+		FE100000000000000000A200 /* Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000A100 /* Automation.swift */; };
+		FE100000000000000000A500 /* AutomationsSettings.strings in Resources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000A300 /* AutomationsSettings.strings */; };
+		FE100000000000000000B200 /* ScriptRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000B100 /* ScriptRunner.swift */; };
+		FE100000000000000000C200 /* AutomationProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000C100 /* AutomationProcessor.swift */; };
+		FE100000000000000000D200 /* AutomationsSettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000D100 /* AutomationsSettingsPane.swift */; };
+		FE100000000000000000E200 /* AutomationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000E100 /* AutomationTests.swift */; };
+		FE100000000000000000F200 /* AutomationProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE100000000000000000F100 /* AutomationProcessorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -204,7 +211,6 @@
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
-		2FFF8BCF2CE2116600235A78 /* Data+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Encoding.swift"; sourceTree = "<group>"; };
 		3EBDD1E32BBEF22800C57500 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D6982467226100B3A2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4762D69A2467226400B3A2BA /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -555,6 +561,13 @@
 		DAFE2DD9268A521A00990986 /* String+Shortened.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Shortened.swift"; sourceTree = "<group>"; };
 		DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemTests.swift; sourceTree = "<group>"; };
 		DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardShortcuts.Name+Shortcuts.swift"; sourceTree = "<group>"; };
+		FE100000000000000000A100 /* Automation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Automation.swift; sourceTree = "<group>"; };
+		FE100000000000000000A400 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/AutomationsSettings.strings; sourceTree = "<group>"; };
+		FE100000000000000000B100 /* ScriptRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptRunner.swift; sourceTree = "<group>"; };
+		FE100000000000000000C100 /* AutomationProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationProcessor.swift; sourceTree = "<group>"; };
+		FE100000000000000000D100 /* AutomationsSettingsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationsSettingsPane.swift; sourceTree = "<group>"; };
+		FE100000000000000000E100 /* AutomationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationTests.swift; sourceTree = "<group>"; };
+		FE100000000000000000F100 /* AutomationProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationProcessorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -634,6 +647,7 @@
 			children = (
 				DA05B5132C234DCF006980FE /* HistoryItem.swift */,
 				DA05B5122C234DCF006980FE /* HistoryItemContent.swift */,
+				FE100000000000000000A100 /* Automation.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -662,6 +676,8 @@
 				DA689FAE2C1CD3B00009B887 /* StorageSettings.strings */,
 				DAA365CD2C4BF9DD00A394F8 /* PinsSettingsPane.swift */,
 				DAA365CF2C4C147400A394F8 /* PinsSettings.strings */,
+				FE100000000000000000D100 /* AutomationsSettingsPane.swift */,
+				FE100000000000000000A300 /* AutomationsSettings.strings */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -723,6 +739,8 @@
 				DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */,
 				DA384E85232746D800603999 /* SearchTests.swift */,
 				DA696BD12401EEE900DE80CF /* SorterTests.swift */,
+				FE100000000000000000E100 /* AutomationTests.swift */,
+				FE100000000000000000F100 /* AutomationProcessorTests.swift */,
 				DA360DB41E3DF137005C6F6B /* Info.plist */,
 			);
 			path = MaccyTests;
@@ -740,6 +758,7 @@
 				DA3BCB8D2C3E015000B01BC1 /* ModifierFlags.swift */,
 				DAE8F5D32C43262B00851CA9 /* Popup.swift */,
 				2F578C3E2EFFE8720088B759 /* SlideoutController.swift */,
+				FE100000000000000000C100 /* AutomationProcessor.swift */,
 			);
 			path = Observables;
 			sourceTree = "<group>";
@@ -831,6 +850,7 @@
 				DA20FA712B082DD600056DD5 /* Notifier.swift */,
 				DA689FC72C1D15140009B887 /* PinsPosition.swift */,
 				DA689FC52C1D14F10009B887 /* PopupPosition.swift */,
+				FE100000000000000000B100 /* ScriptRunner.swift */,
 				DAC14123232367B200FCFA30 /* Search.swift */,
 				2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */,
 				2F0EC77C2E773314003E2EA9 /* Selection.swift */,
@@ -1039,6 +1059,7 @@
 				DA5E62802C39E53F00F4C710 /* PreviewItemView.strings in Resources */,
 				DA009932256411F90030E697 /* README.md in Resources */,
 				DA9C3C4A2C20D4B40056795D /* IgnoreSettings.strings in Resources */,
+				FE100000000000000000A500 /* AutomationsSettings.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1064,6 +1085,8 @@
 				DA384E86232746D800603999 /* SearchTests.swift in Sources */,
 				DA696BD22401EEE900DE80CF /* SorterTests.swift in Sources */,
 				DA360DB31E3DF137005C6F6B /* HistoryTests.swift in Sources */,
+				FE100000000000000000E200 /* AutomationTests.swift in Sources */,
+				FE100000000000000000F200 /* AutomationProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1071,6 +1094,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE100000000000000000A200 /* Automation.swift in Sources */,
+				FE100000000000000000B200 /* ScriptRunner.swift in Sources */,
+				FE100000000000000000C200 /* AutomationProcessor.swift in Sources */,
+				FE100000000000000000D200 /* AutomationsSettingsPane.swift in Sources */,
 				DA19691C2C3F3EAC00258481 /* Collection+Surrounding.swift in Sources */,
 				DA1969142C3F11D600258481 /* PreviewItemView.swift in Sources */,
 				2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */,
@@ -1499,6 +1526,14 @@
 			name = GeneralSettings.strings;
 			sourceTree = "<group>";
 		};
+		FE100000000000000000A300 /* AutomationsSettings.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FE100000000000000000A400 /* en */,
+			);
+			name = AutomationsSettings.strings;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
@@ -1736,7 +1771,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 60;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = HYTDW9825S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1771,7 +1806,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 60;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = MN3X4648SC;
+				DEVELOPMENT_TEAM = HYTDW9825S;
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -38,6 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     AppState.shared.appDelegate = self
 
     Clipboard.shared.onNewCopy { History.shared.add($0) }
+    Clipboard.shared.onNewCopy { AutomationProcessor.shared.process($0) }
     Clipboard.shared.start()
 
     Task {

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -55,6 +55,7 @@ extension Defaults.Keys {
   static let size = Key<Int>("historySize", default: 200)
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
+  static let automations = Key<[Automation]>("automations", default: [])
   static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
   static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: false)

--- a/Maccy/Extensions/NSImage+Names.swift
+++ b/Maccy/Extensions/NSImage+Names.swift
@@ -7,6 +7,7 @@ extension NSImage {
   static let pincircle = NSImage(systemSymbolName: "pin.circle", accessibilityDescription: "pin.cirlce")
   static let nosign = NSImage(systemSymbolName: "nosign", accessibilityDescription: "nosign")
   static let gearshape2 = NSImage(systemSymbolName: "gearshape.2", accessibilityDescription: "gearshape2")
+  static let bolt = NSImage(systemSymbolName: "bolt", accessibilityDescription: "bolt")
 }
 
 extension NSImage.Name {

--- a/Maccy/Extensions/Settings.PaneIdentifier+Panes.swift
+++ b/Maccy/Extensions/Settings.PaneIdentifier+Panes.swift
@@ -7,4 +7,5 @@ extension Settings.PaneIdentifier {
   static let ignore = Self("ignore")
   static let pins = Self("pins")
   static let storage = Self("storage")
+  static let automations = Self("automations")
 }

--- a/Maccy/Models/Automation.swift
+++ b/Maccy/Models/Automation.swift
@@ -1,0 +1,64 @@
+import Defaults
+import Foundation
+
+// A user-configured rule that runs an action when copied text matches a regular expression.
+//
+// Persisted as configuration via the `Defaults` library (like `ignoreRegexp`), not SwiftData.
+// `Defaults.Serializable` is free for `Codable` types, and arrays of serializable values are
+// themselves serializable, so `Defaults.Key<[Automation]>` works out of the box.
+struct Automation: Identifiable, Codable, Hashable, Defaults.Serializable {
+  var id = UUID()
+  var name = ""
+  var regexp = ""
+  var isEnabled = true
+  var action: AutomationAction = .runScript(RunScriptConfig())
+
+  // Returns true when `text` matches `regexp`. An empty or invalid pattern never matches.
+  func matches(_ text: String) -> Bool {
+    guard !regexp.isEmpty, let regex = try? NSRegularExpression(pattern: regexp) else {
+      return false
+    }
+
+    let range = NSRange(text.startIndex..., in: text)
+    return regex.numberOfMatches(in: text, range: range) > 0
+  }
+}
+
+// The action performed when an automation matches. New actions are added as new cases.
+enum AutomationAction: Codable, Hashable {
+  case runScript(RunScriptConfig)
+}
+
+struct RunScriptConfig: Codable, Hashable {
+  var scriptName = ""          // filename within the Application Scripts directory
+  var parseResultAsHTML = false
+}
+
+// Convenience accessors so SwiftUI can bind directly to action fields. They no-op for
+// automations whose action is not `.runScript`, which keeps the editor bindings simple while
+// the action set is small.
+extension Automation {
+  var scriptName: String {
+    get {
+      guard case let .runScript(config) = action else { return "" }
+      return config.scriptName
+    }
+    set {
+      guard case var .runScript(config) = action else { return }
+      config.scriptName = newValue
+      action = .runScript(config)
+    }
+  }
+
+  var parseResultAsHTML: Bool {
+    get {
+      guard case let .runScript(config) = action else { return false }
+      return config.parseResultAsHTML
+    }
+    set {
+      guard case var .runScript(config) = action else { return }
+      config.parseResultAsHTML = newValue
+      action = .runScript(config)
+    }
+  }
+}

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -148,6 +148,13 @@ class AppState: Sendable {
             IgnoreSettingsPane()
           },
           Settings.Pane(
+            identifier: Settings.PaneIdentifier.automations,
+            title: NSLocalizedString("Title", tableName: "AutomationsSettings", comment: ""),
+            toolbarIcon: NSImage.bolt!
+          ) {
+            AutomationsSettingsPane()
+          },
+          Settings.Pane(
             identifier: Settings.PaneIdentifier.advanced,
             title: NSLocalizedString("Title", tableName: "AdvancedSettings", comment: ""),
             toolbarIcon: NSImage.gearshape2!

--- a/Maccy/Observables/AutomationProcessor.swift
+++ b/Maccy/Observables/AutomationProcessor.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Defaults
+import Foundation
+import Logging
+
+// Runs user-configured automations against freshly copied text.
+//
+// Registered as an `onNewCopy` hook *after* `History.add`, so by the time it runs the original
+// item is already in history. When one or more automations match, their scripts are chained
+// (each transforms the previous output) and a single new item is produced: it becomes the
+// current clipboard contents and the most-recent history entry, while the original copy is
+// preserved.
+@MainActor
+final class AutomationProcessor {
+  static let shared = AutomationProcessor()
+
+  // Injectable so tests can stub script execution.
+  var scriptRunner: ScriptRunning = ScriptRunner.shared
+
+  private let logger = Logger(label: "org.p0deje.Maccy")
+
+  // Synchronous entry point for the clipboard hook.
+  func process(_ item: HistoryItem) {
+    guard shouldProcess(item), let text = item.text else { return }
+
+    let source = item.application
+    Task { @MainActor in
+      if let result = await buildResult(forText: text, source: source) {
+        History.shared.add(result)
+        Clipboard.shared.copy(result)
+      }
+    }
+  }
+
+  // Skip Maccy's own writes (prevents re-trigger loops) and non-text items.
+  func shouldProcess(_ item: HistoryItem) -> Bool {
+    !item.fromMaccy && (item.text?.isEmpty == false)
+  }
+
+  // Testable core: matches, chains scripts, and builds the resulting item without publishing
+  // it. Returns nil when nothing matched, a script failed, or the output was empty/unchanged.
+  func buildResult(forText text: String, source: String?) async -> HistoryItem? {
+    let matching = Defaults[.automations].filter { $0.isEnabled && $0.matches(text) }
+    guard !matching.isEmpty else { return nil }
+
+    var current = text
+    var isHTML = false
+
+    for automation in matching {
+      guard case let .runScript(config) = automation.action, !config.scriptName.isEmpty else {
+        continue
+      }
+
+      do {
+        let output = try await scriptRunner.run(scriptName: config.scriptName, input: current)
+        let cleaned = trimTrailingNewlines(output)
+        guard !cleaned.isEmpty else { continue }
+        current = cleaned
+        isHTML = config.parseResultAsHTML
+      } catch {
+        logger.error("Automation '\(automation.name)' script failed: \(error.localizedDescription)")
+        return nil
+      }
+    }
+
+    guard current != text else { return nil }
+    return makeItem(output: current, isHTML: isHTML, source: source)
+  }
+
+  private func makeItem(output: String, isHTML: Bool, source: String?) -> HistoryItem {
+    var contents = [HistoryItemContent]()
+
+    if isHTML {
+      let htmlData = Data(output.utf8)
+      contents.append(HistoryItemContent(type: NSPasteboard.PasteboardType.html.rawValue, value: htmlData))
+      // Plain-text fallback so paste-without-formatting and title generation still work.
+      let plain = NSAttributedString(html: htmlData, documentAttributes: nil)?.string ?? output
+      contents.append(HistoryItemContent(type: NSPasteboard.PasteboardType.string.rawValue, value: Data(plain.utf8)))
+    } else {
+      contents.append(HistoryItemContent(type: NSPasteboard.PasteboardType.string.rawValue, value: Data(output.utf8)))
+    }
+
+    let item = HistoryItem(contents: contents)
+    item.application = source
+    item.title = item.generateTitle()
+    return item
+  }
+
+  private func trimTrailingNewlines(_ string: String) -> String {
+    var result = Substring(string)
+    while let last = result.last, last == "\n" || last == "\r" {
+      result = result.dropLast()
+    }
+    return String(result)
+  }
+}

--- a/Maccy/ScriptRunner.swift
+++ b/Maccy/ScriptRunner.swift
@@ -1,0 +1,187 @@
+import AppKit
+import Foundation
+
+enum ScriptRunnerError: Error {
+  case notFound(String)
+  case timedOut(String)
+}
+
+// Watches a directory and invokes `onChange` whenever its entries change (files added,
+// removed, or renamed). Used to keep the scripts picker in sync while the settings pane is open.
+final class DirectoryWatcher {
+  private let url: URL
+  private let onChange: () -> Void
+  private var source: DispatchSourceFileSystemObject?
+  private var fileDescriptor: CInt = -1
+
+  init(url: URL, onChange: @escaping () -> Void) {
+    self.url = url
+    self.onChange = onChange
+  }
+
+  func start() {
+    guard source == nil else { return }
+
+    fileDescriptor = open(url.path, O_EVTONLY)
+    guard fileDescriptor >= 0 else { return }
+
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: fileDescriptor,
+      eventMask: [.write, .delete, .rename],
+      queue: .main
+    )
+    source.setEventHandler { [onChange] in onChange() }
+    source.setCancelHandler { [fileDescriptor] in
+      if fileDescriptor >= 0 { close(fileDescriptor) }
+    }
+    self.source = source
+    source.resume()
+  }
+
+  func stop() {
+    source?.cancel()
+    source = nil
+    fileDescriptor = -1
+  }
+
+  deinit {
+    stop()
+  }
+}
+
+// Abstraction so `AutomationProcessor` can be unit-tested with a stub instead of really
+// spawning a script.
+protocol ScriptRunning {
+  func run(scriptName: String, input: String) async throws -> String
+}
+
+// Runs user shell scripts via `NSUserUnixTask`.
+//
+// Scripts must live in `~/Library/Application Scripts/<bundle-id>/`. macOS executes them
+// *outside* the app sandbox (via lsboxd/XPC), so they get the user's normal privileges —
+// network, filesystem, Homebrew tools — while Maccy itself stays sandboxed. A sandboxed app
+// may read/list and run scripts in this directory without any extra entitlement; it just
+// cannot write to it (the user installs scripts there themselves).
+final class ScriptRunner: ScriptRunning {
+  static let shared = ScriptRunner()
+
+  // Overridable so tests can point at a temporary directory.
+  var scriptsDirectoryProvider: () -> URL? = {
+    try? FileManager.default.url(
+      for: .applicationScriptsDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
+  }
+
+  var timeout: TimeInterval = 30
+
+  var scriptsDirectory: URL? { scriptsDirectoryProvider() }
+
+  // Filenames of the scripts the user has installed, for display in the settings picker.
+  func availableScripts() -> [String] {
+    guard let directory = scriptsDirectory,
+          let names = try? FileManager.default.contentsOfDirectory(atPath: directory.path) else {
+      return []
+    }
+
+    return names
+      .filter { !$0.hasPrefix(".") }
+      .sorted()
+  }
+
+  // Opens the scripts directory in Finder so the user can drop scripts in.
+  func reveal() {
+    guard let directory = scriptsDirectory else { return }
+    NSWorkspace.shared.activateFileViewerSelecting([directory])
+  }
+
+  func run(scriptName: String, input: String) async throws -> String {
+    guard let directory = scriptsDirectory else {
+      throw ScriptRunnerError.notFound(scriptName)
+    }
+
+    let scriptURL = directory.appendingPathComponent(scriptName)
+    guard FileManager.default.fileExists(atPath: scriptURL.path) else {
+      throw ScriptRunnerError.notFound(scriptName)
+    }
+
+    let task = try NSUserUnixTask(url: scriptURL)
+    let stdinPipe = Pipe()
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    task.standardInput = stdinPipe.fileHandleForReading
+    task.standardOutput = stdoutPipe.fileHandleForWriting
+    task.standardError = stderrPipe.fileHandleForWriting
+
+    return try await withThrowingTaskGroup(of: String.self) { group in
+      group.addTask {
+        try await Self.execute(
+          task,
+          input: input,
+          stdin: stdinPipe,
+          stdout: stdoutPipe,
+          stderr: stderrPipe
+        )
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: UInt64(self.timeout * 1_000_000_000))
+        throw ScriptRunnerError.timedOut(scriptName)
+      }
+
+      defer { group.cancelAll() }
+      // Return whichever finishes first: the script output or the timeout error.
+      guard let result = try await group.next() else {
+        throw ScriptRunnerError.timedOut(scriptName)
+      }
+      return result
+    }
+  }
+
+  private static func execute(
+    _ task: NSUserUnixTask,
+    input: String,
+    stdin: Pipe,
+    stdout: Pipe,
+    stderr: Pipe
+  ) async throws -> String {
+    try await withCheckedThrowingContinuation { continuation in
+      let group = DispatchGroup()
+      var outputData = Data()
+      var runError: Error?
+
+      // Drain stdout concurrently so a script producing more than the pipe buffer (~64KB)
+      // can't block waiting for us to read.
+      group.enter()
+      DispatchQueue.global(qos: .userInitiated).async {
+        outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+        group.leave()
+      }
+
+      group.enter()
+      task.execute(withArguments: nil) { error in
+        runError = error
+        group.leave()
+      }
+
+      // Feed the clipboard text in and signal EOF.
+      let writeHandle = stdin.fileHandleForWriting
+      writeHandle.write(Data(input.utf8))
+      try? writeHandle.close()
+
+      // Close our copies of the write ends so the stdout reader receives EOF once the
+      // script (the only remaining writer) exits.
+      try? stdout.fileHandleForWriting.close()
+      try? stderr.fileHandleForWriting.close()
+
+      group.notify(queue: .global()) {
+        if let runError {
+          continuation.resume(throwing: runError)
+        } else {
+          continuation.resume(returning: String(decoding: outputData, as: UTF8.self))
+        }
+      }
+    }
+  }
+}

--- a/Maccy/Settings/AutomationsSettingsPane.swift
+++ b/Maccy/Settings/AutomationsSettingsPane.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import Defaults
+import Observation
+
+// Observes the Application Scripts directory while the pane is visible so newly added or
+// removed scripts appear in the picker in real time.
+@MainActor
+@Observable
+final class ScriptsDirectoryModel {
+  var scripts: [String] = []
+
+  @ObservationIgnored
+  private var watcher: DirectoryWatcher?
+
+  func start() {
+    reload()
+    guard let directory = ScriptRunner.shared.scriptsDirectory else { return }
+    watcher = DirectoryWatcher(url: directory) { [weak self] in
+      self?.reload()
+    }
+    watcher?.start()
+  }
+
+  func stop() {
+    watcher?.stop()
+    watcher = nil
+  }
+
+  func reload() {
+    scripts = ScriptRunner.shared.availableScripts()
+  }
+}
+
+struct AutomationsSettingsPane: View {
+  @Default(.automations) private var automations
+
+  @State private var selection: UUID?
+  @State private var scriptsModel = ScriptsDirectoryModel()
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      List(selection: $selection) {
+        ForEach($automations) { $automation in
+          HStack {
+            Toggle("", isOn: $automation.isEnabled)
+              .labelsHidden()
+            Text(automation.name.isEmpty
+              ? String(localized: "Untitled", table: "AutomationsSettings")
+              : automation.name)
+          }
+          .tag(automation.id)
+        }
+        .onMove { indexes, destination in
+          automations.move(fromOffsets: indexes, toOffset: destination)
+        }
+      }
+      .frame(minHeight: 140)
+      .scrollContentBackground(.hidden)
+      .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 5))
+
+      ControlGroup {
+        Button("", systemImage: "plus") {
+          add()
+        }
+        Button("", systemImage: "minus") {
+          removeSelected()
+        }
+      }
+      .frame(width: 50)
+
+      if let selection, automations.contains(where: { $0.id == selection }) {
+        Divider()
+        editor(automationBinding(selection))
+      } else {
+        Text("SelectOrAddHint", tableName: "AutomationsSettings")
+          .frame(maxWidth: .infinity, alignment: .center)
+          .foregroundStyle(.gray)
+          .controlSize(.small)
+          .padding(.vertical)
+      }
+    }
+    .frame(minWidth: 400, maxWidth: 480, minHeight: 460)
+    .padding()
+    .onAppear { scriptsModel.start() }
+    .onDisappear { scriptsModel.stop() }
+  }
+
+  @ViewBuilder
+  private func editor(_ automation: Binding<Automation>) -> some View {
+    Form {
+      TextField(text: automation.name, prompt: Text("NamePrompt", tableName: "AutomationsSettings")) {
+        Text("Name", tableName: "AutomationsSettings")
+      }
+
+      TextField(text: automation.regexp, prompt: Text("RegexpPrompt", tableName: "AutomationsSettings")) {
+        Text("Regexp", tableName: "AutomationsSettings")
+      }
+      .font(.body.monospaced())
+
+      Picker(selection: .constant(0)) {
+        Text("RunScript", tableName: "AutomationsSettings").tag(0)
+      } label: {
+        Text("Action", tableName: "AutomationsSettings")
+      }
+
+      HStack {
+        Picker(selection: automation.scriptName) {
+          Text("NoScript", tableName: "AutomationsSettings").tag("")
+          ForEach(scriptOptions(selected: automation.wrappedValue.scriptName), id: \.self) { name in
+            Text(name).tag(name)
+          }
+        } label: {
+          Text("Script", tableName: "AutomationsSettings")
+        }
+
+        Button {
+          ScriptRunner.shared.reveal()
+          scriptsModel.reload()
+        } label: {
+          Text("RevealFolder", tableName: "AutomationsSettings")
+        }
+      }
+
+      Toggle(isOn: automation.parseResultAsHTML) {
+        Text("ParseAsHTML", tableName: "AutomationsSettings")
+      }
+    }
+
+    Text("ScriptsHint", tableName: "AutomationsSettings")
+      .fixedSize(horizontal: false, vertical: true)
+      .foregroundStyle(.gray)
+      .controlSize(.small)
+      .padding(.top, 4)
+  }
+
+  private func scriptOptions(selected: String) -> [String] {
+    var options = scriptsModel.scripts
+    if !selected.isEmpty, !options.contains(selected) {
+      options.insert(selected, at: 0)
+    }
+    return options
+  }
+
+  private func automationBinding(_ id: UUID) -> Binding<Automation> {
+    Binding(
+      get: { automations.first(where: { $0.id == id }) ?? Automation() },
+      set: { newValue in
+        if let index = automations.firstIndex(where: { $0.id == id }) {
+          automations[index] = newValue
+        }
+      }
+    )
+  }
+
+  private func add() {
+    let automation = Automation()
+    automations.append(automation)
+    selection = automation.id
+    scriptsModel.reload()
+  }
+
+  private func removeSelected() {
+    guard let selection else { return }
+    automations.removeAll { $0.id == selection }
+    self.selection = nil
+  }
+}
+
+#Preview {
+  AutomationsSettingsPane()
+    .environment(\.locale, .init(identifier: "en"))
+}

--- a/Maccy/Settings/en.lproj/AutomationsSettings.strings
+++ b/Maccy/Settings/en.lproj/AutomationsSettings.strings
@@ -1,0 +1,14 @@
+"Title" = "Automations";
+"Untitled" = "Untitled automation";
+"SelectOrAddHint" = "Select an automation to edit, or add one with +.";
+"Name" = "Name";
+"NamePrompt" = "GitHub PR → rich link";
+"Regexp" = "Match regexp";
+"RegexpPrompt" = "^https://github\\.com/.+/pull/\\d+";
+"Action" = "Action";
+"RunScript" = "Run Script";
+"Script" = "Script";
+"NoScript" = "None";
+"RevealFolder" = "Reveal Scripts Folder";
+"ParseAsHTML" = "Parse result as HTML";
+"ScriptsHint" = "Scripts run outside the sandbox with your normal permissions. Place executable scripts in the Application Scripts folder (Reveal Scripts Folder); the clipboard text is piped to stdin and the script's stdout becomes the new clipboard contents. The original copy is kept in history.";

--- a/MaccyTests/AutomationProcessorTests.swift
+++ b/MaccyTests/AutomationProcessorTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+import Defaults
+@testable import Maccy
+
+private final class StubScriptRunner: ScriptRunning {
+  var transform: (_ scriptName: String, _ input: String) throws -> String
+  private(set) var calls: [(script: String, input: String)] = []
+
+  init(transform: @escaping (_ scriptName: String, _ input: String) throws -> String = { _, input in input }) {
+    self.transform = transform
+  }
+
+  func run(scriptName: String, input: String) async throws -> String {
+    calls.append((scriptName, input))
+    return try transform(scriptName, input)
+  }
+}
+
+@MainActor
+class AutomationProcessorTests: XCTestCase {
+  private var processor: AutomationProcessor!
+  private var stub: StubScriptRunner!
+
+  override func setUp() {
+    super.setUp()
+    processor = AutomationProcessor()
+    stub = StubScriptRunner()
+    processor.scriptRunner = stub
+  }
+
+  override func tearDown() {
+    Defaults.reset(.automations)
+    super.tearDown()
+  }
+
+  func testNoMatchReturnsNil() async {
+    Defaults[.automations] = [automation(regexp: "nomatch", script: "s.sh")]
+    let result = await processor.buildResult(forText: "hello", source: nil)
+    XCTAssertNil(result)
+    XCTAssertTrue(stub.calls.isEmpty)
+  }
+
+  func testPlainResult() async {
+    stub.transform = { _, input in input.uppercased() }
+    Defaults[.automations] = [automation(regexp: ".*", script: "up.sh")]
+
+    let result = await processor.buildResult(forText: "foo", source: "com.example")
+    XCTAssertEqual(result?.text, "FOO")
+    XCTAssertNil(result?.html)
+    XCTAssertEqual(result?.application, "com.example")
+  }
+
+  func testHTMLResultParsesRichTextWithPlainFallback() async {
+    stub.transform = { _, _ in "<a href=\"#\">foo</a>" }
+    Defaults[.automations] = [automation(regexp: ".*", script: "link.sh", parseAsHTML: true)]
+
+    let result = await processor.buildResult(forText: "foo", source: nil)
+    XCTAssertNotNil(result?.html)
+    XCTAssertEqual(result?.html?.string, "foo")
+    XCTAssertEqual(result?.text, "foo") // plain-text fallback
+  }
+
+  func testChainingProducesSingleItemInOrder() async {
+    stub.transform = { script, input in
+      switch script {
+      case "up.sh": return input.uppercased()
+      case "wrap.sh": return "[\(input)]"
+      default: return input
+      }
+    }
+    Defaults[.automations] = [
+      automation(regexp: ".*", script: "up.sh"),
+      automation(regexp: ".*", script: "wrap.sh")
+    ]
+
+    let result = await processor.buildResult(forText: "foo", source: nil)
+    XCTAssertEqual(result?.text, "[FOO]")
+    XCTAssertEqual(stub.calls.map(\.script), ["up.sh", "wrap.sh"])
+    XCTAssertEqual(stub.calls.map(\.input), ["foo", "FOO"])
+  }
+
+  func testTrailingNewlinesAreTrimmed() async {
+    stub.transform = { _, input in "\(input.uppercased())\n\n" }
+    Defaults[.automations] = [automation(regexp: ".*", script: "up.sh")]
+
+    let result = await processor.buildResult(forText: "foo", source: nil)
+    XCTAssertEqual(result?.text, "FOO")
+  }
+
+  func testUnchangedOutputReturnsNil() async {
+    stub.transform = { _, input in input }
+    Defaults[.automations] = [automation(regexp: ".*", script: "noop.sh")]
+
+    let result = await processor.buildResult(forText: "foo", source: nil)
+    XCTAssertNil(result)
+  }
+
+  func testScriptFailureReturnsNil() async {
+    stub.transform = { _, _ in throw ScriptRunnerError.notFound("up.sh") }
+    Defaults[.automations] = [automation(regexp: ".*", script: "up.sh")]
+
+    let result = await processor.buildResult(forText: "foo", source: nil)
+    XCTAssertNil(result)
+  }
+
+  func testDisabledAutomationsAreSkipped() async {
+    stub.transform = { _, input in input.uppercased() }
+    Defaults[.automations] = [automation(regexp: ".*", script: "up.sh", enabled: false)]
+
+    let result = await processor.buildResult(forText: "foo", source: nil)
+    XCTAssertNil(result)
+    XCTAssertTrue(stub.calls.isEmpty)
+  }
+
+  func testShouldProcessSkipsFromMaccyAndEmptyText() {
+    let fromMaccy = HistoryItem(contents: [
+      HistoryItemContent(type: NSPasteboard.PasteboardType.string.rawValue, value: Data("foo".utf8)),
+      HistoryItemContent(type: NSPasteboard.PasteboardType.fromMaccy.rawValue, value: Data())
+    ])
+    XCTAssertFalse(processor.shouldProcess(fromMaccy))
+
+    let imageOnly = HistoryItem(contents: [
+      HistoryItemContent(type: NSPasteboard.PasteboardType.tiff.rawValue, value: Data([0x1]))
+    ])
+    XCTAssertFalse(processor.shouldProcess(imageOnly))
+
+    let text = HistoryItem(contents: [
+      HistoryItemContent(type: NSPasteboard.PasteboardType.string.rawValue, value: Data("foo".utf8))
+    ])
+    XCTAssertTrue(processor.shouldProcess(text))
+  }
+
+  private func automation(
+    regexp: String,
+    script: String,
+    parseAsHTML: Bool = false,
+    enabled: Bool = true
+  ) -> Automation {
+    Automation(
+      name: script,
+      regexp: regexp,
+      isEnabled: enabled,
+      action: .runScript(RunScriptConfig(scriptName: script, parseResultAsHTML: parseAsHTML))
+    )
+  }
+}

--- a/MaccyTests/AutomationTests.swift
+++ b/MaccyTests/AutomationTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import Defaults
+@testable import Maccy
+
+class AutomationTests: XCTestCase {
+  func testMatches() {
+    let automation = Automation(regexp: "^https://github\\.com/.+/pull/\\d+")
+    XCTAssertTrue(automation.matches("https://github.com/p0deje/Maccy/pull/123"))
+    XCTAssertFalse(automation.matches("https://example.com"))
+  }
+
+  func testEmptyRegexpNeverMatches() {
+    let automation = Automation(regexp: "")
+    XCTAssertFalse(automation.matches("anything"))
+  }
+
+  func testInvalidRegexpNeverMatches() {
+    let automation = Automation(regexp: "[")
+    XCTAssertFalse(automation.matches("anything"))
+  }
+
+  func testActionAccessors() {
+    var automation = Automation(action: .runScript(RunScriptConfig()))
+    automation.scriptName = "foo.sh"
+    automation.parseResultAsHTML = true
+
+    XCTAssertEqual(automation.scriptName, "foo.sh")
+    XCTAssertTrue(automation.parseResultAsHTML)
+    XCTAssertEqual(automation.action, .runScript(RunScriptConfig(scriptName: "foo.sh", parseResultAsHTML: true)))
+  }
+
+  func testDefaultsRoundTrip() {
+    let automation = Automation(
+      name: "GitHub",
+      regexp: "foo",
+      action: .runScript(RunScriptConfig(scriptName: "s.sh", parseResultAsHTML: true))
+    )
+
+    Defaults[.automations] = [automation]
+    XCTAssertEqual(Defaults[.automations], [automation])
+
+    Defaults.reset(.automations)
+  }
+}


### PR DESCRIPTION
Add an automations pane where users can configure scripts to run on matching clipboard regexps.

* Scripts run via `NSUserUnixTask` from `~/Library/Application Scripts/<bundle-id>/`, which executes them outside the app sandbox with the user's normal privileges (network, filesystem, Homebrew tools)
* Clipboard contents is passed to scripts via stdin, and if the script writes output, that output will be added to the top of the clipboard history and replace current pasteboard contents
* Although scripts are the only automation type right now, this can be expanded in future to allow other (built-in) transformations (e.g. could potentially cover the use-cases in #1413, #1386)

**Screenshot/example**

In the following example, I've written a script to convert plain text GitHub PR URLs to a HTML link with the PR name as the title:

<img width="624" height="692" alt="Screenshot 2026-06-18 at 23 31 38" src="https://github.com/user-attachments/assets/b2ddcc7f-fe1a-44bc-a973-1ea49259b5f5" />
