### PR TITLE
Respect pinned item order when focusing first item

### DIFF
--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -25,7 +25,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         updateItems(search.search(string: searchQuery, within: all))
 
         if searchQuery.isEmpty {
-          AppState.shared.navigator.select(item: unpinnedItems.first)
+          AppState.shared.navigator.highlightFirst()
         } else {
           AppState.shared.navigator.highlightFirst()
         }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -116,7 +116,7 @@ struct HistoryListView: View {
           if scenePhase == .active {
             searchFocused = true
             appState.navigator.isKeyboardNavigating = true
-            appState.navigator.select(item: appState.history.unpinnedItems.first ?? appState.history.pinnedItems.first)
+            appState.navigator.highlightFirst()
             appState.preview.enableAutoOpen()
             appState.preview.resetAutoOpenSuppression()
             appState.preview.startAutoOpen()

--- a/MaccyTests/SorterTests.swift
+++ b/MaccyTests/SorterTests.swift
@@ -52,6 +52,22 @@ class SorterTests: XCTestCase {
   }
 
   @MainActor
+  func testHighlightFirstUsesSortedHistoryOrder() {
+    Defaults[.pinTo] = .top
+
+    item1.pin = "a"
+
+    let history = History()
+    let sortedItems = sorter.sort([item1, item2], by: .lastCopiedAt)
+    history.items = sortedItems.map { HistoryItemDecorator($0) }
+
+    let navigator = NavigationManager(history: history, footer: Footer())
+    navigator.highlightFirst()
+
+    XCTAssertEqual(navigator.selection.first?.item, item1)
+  }
+
+  @MainActor
   private func historyItem(
     value: String,
     firstCopiedAt: Int,


### PR DESCRIPTION
## Summary
- Select the first visible history item when the popup becomes active instead of forcing the first unpinned item
- Use the same first-visible selection behavior after clearing a search query
- Add coverage for selecting the first item from the sorted history order

## Testing
- HOME=/tmp/maccy-build-home xcodebuild test -project Maccy.xcodeproj -scheme Maccy -only-testing:MaccyTests/SorterTests -derivedDataPath build-pr -clonedSourcePackagesDirPath /Users/canine89/src/Maccy/build/SourcePackages -disableAutomaticPackageResolution CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=NO