### PR TITLE
Keep popup window inside visible screen

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		DA19691F2C3F5F0600258481 /* KeyHandlingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA19691E2C3F5F0600258481 /* KeyHandlingView.swift */; };
 		DA1969212C3F6C6800258481 /* HistoryItemAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1969202C3F6C6800258481 /* HistoryItemAction.swift */; };
 		DA1EDE432045B35300479723 /* HistoryDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */; };
+		2F6B4C1B2F353FA100D8D743 /* PopupPositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F6B4C1A2F353FA100D8D743 /* PopupPositionTests.swift */; };
 		DA20FA722B082DD600056DD5 /* Notifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA20FA712B082DD600056DD5 /* Notifier.swift */; };
 		DA20FA742B082E0100056DD5 /* Knock.caf in Resources */ = {isa = PBXBuildFile; fileRef = DA20FA732B082E0100056DD5 /* Knock.caf */; };
 		DA20FA762B082E0800056DD5 /* Write.caf in Resources */ = {isa = PBXBuildFile; fileRef = DA20FA752B082E0800056DD5 /* Write.caf */; };
@@ -265,6 +266,7 @@
 		DA19691E2C3F5F0600258481 /* KeyHandlingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHandlingView.swift; sourceTree = "<group>"; };
 		DA1969202C3F6C6800258481 /* HistoryItemAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemAction.swift; sourceTree = "<group>"; };
 		DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDecoratorTests.swift; sourceTree = "<group>"; };
+		2F6B4C1A2F353FA100D8D743 /* PopupPositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupPositionTests.swift; sourceTree = "<group>"; };
 		DA20FA712B082DD600056DD5 /* Notifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifier.swift; sourceTree = "<group>"; };
 		DA20FA732B082E0100056DD5 /* Knock.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Knock.caf; sourceTree = "<group>"; };
 		DA20FA752B082E0800056DD5 /* Write.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Write.caf; sourceTree = "<group>"; };
@@ -721,6 +723,7 @@
 				DA360DB21E3DF137005C6F6B /* HistoryTests.swift */,
 				DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */,
 				DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */,
+				2F6B4C1A2F353FA100D8D743 /* PopupPositionTests.swift */,
 				DA384E85232746D800603999 /* SearchTests.swift */,
 				DA696BD12401EEE900DE80CF /* SorterTests.swift */,
 				DA360DB41E3DF137005C6F6B /* Info.plist */,
@@ -1061,6 +1064,7 @@
 				DA3CE8001E44A62500B3AA98 /* ClipboardTests.swift in Sources */,
 				DA1EDE432045B35300479723 /* HistoryDecoratorTests.swift in Sources */,
 				DAE2850223225BD90080E394 /* ColorImageTests.swift in Sources */,
+				2F6B4C1B2F353FA100D8D743 /* PopupPositionTests.swift in Sources */,
 				DA384E86232746D800603999 /* SearchTests.swift in Sources */,
 				DA696BD22401EEE900DE80CF /* SorterTests.swift in Sources */,
 				DA360DB31E3DF137005C6F6B /* HistoryTests.swift in Sources */,

--- a/Maccy/Extensions/NSRect+Centered.swift
+++ b/Maccy/Extensions/NSRect+Centered.swift
@@ -7,4 +7,25 @@ extension NSRect {
 
     return NSRect(x: bottomLeftX + 1.0, y: bottomLeftY + 1.0, width: size.width, height: size.height)
   }
+
+  func constrainedToFit(in frame: NSRect) -> NSRect {
+    let width = min(size.width, frame.width)
+    let height = min(size.height, frame.height)
+    var origin = origin
+
+    if origin.x + width > frame.maxX {
+      origin.x = frame.maxX - width
+    }
+    if origin.x < frame.minX {
+      origin.x = frame.minX
+    }
+    if origin.y + height > frame.maxY {
+      origin.y = frame.maxY - height
+    }
+    if origin.y < frame.minY {
+      origin.y = frame.minY
+    }
+
+    return NSRect(origin: origin, size: NSSize(width: width, height: height))
+  }
 }

--- a/Maccy/Extensions/NSScreen+ForPopup.swift
+++ b/Maccy/Extensions/NSScreen+ForPopup.swift
@@ -1,4 +1,4 @@
-import AppKit.NSScreen
+import AppKit
 import Defaults
 
 extension NSScreen {
@@ -9,5 +9,17 @@ extension NSScreen {
     } else {
       return NSScreen.screens[desiredScreen - 1]
     }
+  }
+
+  static func containing(_ point: NSPoint) -> NSScreen? {
+    return screens.first { $0.frame.contains(point) } ?? screens.min {
+      distanceSquared(from: point, to: $0.frame) < distanceSquared(from: point, to: $1.frame)
+    }
+  }
+
+  private static func distanceSquared(from point: NSPoint, to frame: NSRect) -> CGFloat {
+    let deltaX = max(frame.minX - point.x, 0, point.x - frame.maxX)
+    let deltaY = max(frame.minY - point.y, 0, point.y - frame.maxY)
+    return deltaX * deltaX + deltaY * deltaY
   }
 }

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -73,7 +73,8 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
   func open(height: CGFloat, at popupPosition: PopupPosition = Defaults[.popupPosition]) {
     let size = Defaults[.windowSize]
-    setContentSize(NSSize(width: min(frame.width, size.width), height: min(height, size.height)))
+    let contentSize = NSSize(width: min(frame.width, size.width), height: min(height, size.height))
+    setContentSize(popupPosition.constrainedSize(contentSize, statusBarButton: statusBarButton))
     setFrameOrigin(popupPosition.origin(size: frame.size, statusBarButton: statusBarButton))
     orderFrontRegardless()
     makeKey()

--- a/Maccy/PopupPosition.swift
+++ b/Maccy/PopupPosition.swift
@@ -1,4 +1,4 @@
-import AppKit.NSEvent
+import AppKit
 import Defaults
 import Foundation
 
@@ -24,6 +24,21 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
     case .lastPosition:
       return NSLocalizedString("PopupAtLastPosition", tableName: "AppearanceSettings", comment: "")
     }
+  }
+
+  func constrainedSize(_ size: NSSize, statusBarButton _: NSStatusBarButton?) -> NSSize {
+    guard self == .cursor, let visibleFrame = NSScreen.containing(NSEvent.mouseLocation)?.visibleFrame else {
+      return size
+    }
+
+    return Self.constrainedSize(size, visibleFrame: visibleFrame)
+  }
+
+  static func constrainedSize(_ size: NSSize, visibleFrame: NSRect) -> NSSize {
+    return NSSize(
+      width: min(size.width, visibleFrame.width),
+      height: min(size.height, visibleFrame.height)
+    )
   }
 
   // swiftlint:disable:next cyclomatic_complexity
@@ -62,8 +77,20 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
       break
     }
 
-    var point = NSEvent.mouseLocation
-    point.y -= size.height
-    return point
+    let mouseLocation = NSEvent.mouseLocation
+    guard let visibleFrame = NSScreen.containing(mouseLocation)?.visibleFrame else {
+      return NSPoint(x: mouseLocation.x, y: mouseLocation.y - size.height)
+    }
+    return Self.cursorOrigin(size: size, mouseLocation: mouseLocation, visibleFrame: visibleFrame)
+  }
+
+  static func cursorOrigin(size: NSSize, mouseLocation: NSPoint, visibleFrame: NSRect) -> NSPoint {
+    let proposedFrame = NSRect(
+      x: mouseLocation.x,
+      y: mouseLocation.y - size.height,
+      width: size.width,
+      height: size.height
+    )
+    return proposedFrame.constrainedToFit(in: visibleFrame).origin
   }
 }

--- a/MaccyTests/PopupPositionTests.swift
+++ b/MaccyTests/PopupPositionTests.swift
@@ -1,0 +1,42 @@
+import AppKit
+import XCTest
+@testable import Maccy
+
+class PopupPositionTests: XCTestCase {
+  func testCursorOriginFitsBottomOfVisibleFrame() {
+    let visibleFrame = NSRect(x: 0, y: 25, width: 1440, height: 875)
+    let origin = PopupPosition.cursorOrigin(
+      size: NSSize(width: 420, height: 500),
+      mouseLocation: NSPoint(x: 500, y: 30),
+      visibleFrame: visibleFrame
+    )
+
+    XCTAssertEqual(origin.x, 500)
+    XCTAssertEqual(origin.y, visibleFrame.minY)
+  }
+
+  func testCursorOriginStaysInsideCursorScreenAtEdge() {
+    let visibleFrame = NSRect(x: -1440, y: 0, width: 1440, height: 900)
+    let size = NSSize(width: 600, height: 400)
+    let origin = PopupPosition.cursorOrigin(
+      size: size,
+      mouseLocation: NSPoint(x: -20, y: 500),
+      visibleFrame: visibleFrame
+    )
+
+    XCTAssertEqual(origin.x, -600)
+    XCTAssertEqual(origin.y, 100)
+    XCTAssertGreaterThanOrEqual(origin.x, visibleFrame.minX)
+    XCTAssertLessThanOrEqual(origin.x + size.width, visibleFrame.maxX)
+  }
+
+  func testConstrainedSizeDoesNotExceedVisibleFrame() {
+    let size = PopupPosition.constrainedSize(
+      NSSize(width: 1200, height: 900),
+      visibleFrame: NSRect(x: 0, y: 0, width: 800, height: 600)
+    )
+
+    XCTAssertEqual(size.width, 800)
+    XCTAssertEqual(size.height, 600)
+  }
+}

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -51,6 +51,7 @@ class MaccyUITests: XCTestCase {
     try? "Hello world".write(to: file1, atomically: true, encoding: .utf8)
     try? "Hello world".write(to: file2, atomically: true, encoding: .utf8)
 
+    resetAppDefaults()
     app.launchArguments.append("enable-testing")
     app.launch()
 
@@ -149,7 +150,7 @@ class MaccyUITests: XCTestCase {
     copyToClipboard(file1)
     popUpWithMouse()
 
-    XCTAssertEqual(itemTitles[0...1], [
+    assertTopItemTitles([
       file1.absoluteString.removingPercentEncoding!,
       file2.absoluteString.removingPercentEncoding!
     ])
@@ -159,20 +160,20 @@ class MaccyUITests: XCTestCase {
   }
 
   func testCopyRTF() {
-    copyToClipboard(rtf2, .rtf)
-    copyToClipboard(rtf1, .rtf)
+    copyToClipboard(rtf2, .rtf, title: "bar")
+    copyToClipboard(rtf1, .rtf, title: "foo")
     popUpWithHotkey()
-    XCTAssertEqual(itemTitles[0...1], ["foo", "bar"])
+    assertTopItemTitles(["foo", "bar"])
 
-    app.staticTexts["bar"].firstMatch.click()
-    XCTAssertEqual(pasteboard.data(forType: .rtf), rtf2)
+    items["bar"].firstMatch.click()
+    assertPasteboardDataEquals(rtf2, forType: .rtf)
   }
 
   func testCopyHTML() {
     copyToClipboard(html2, .html)
     copyToClipboard(html1, .html)
     popUpWithMouse()
-    XCTAssertEqual(itemTitles[0...1], ["foo", "bar"])
+    assertTopItemTitles(["foo", "bar"])
 
     items["bar"].firstMatch.click()
     assertPasteboardDataEquals(html2, forType: .html)
@@ -264,11 +265,11 @@ class MaccyUITests: XCTestCase {
   func testPin() {
     popUpWithMouse()
     pin(copy2)
-    XCTAssertEqual(itemTitles[0...1], [copy2, copy1])
+    assertTopItemTitles([copy2, copy1])
 
     app.typeKey(.escape, modifierFlags: [])
     popUpWithMouse()
-    XCTAssertEqual(itemTitles[0...1], [copy2, copy1])
+    assertTopItemTitles([copy2, copy1])
   }
 
   func testPinDuringSearch() {
@@ -276,14 +277,14 @@ class MaccyUITests: XCTestCase {
     search(copy2)
     pin(copy2)
     assertSearchFieldValue("")
-    XCTAssertEqual(itemTitles[0...1], [copy2, copy1])
+    assertTopItemTitles([copy2, copy1])
   }
 
   func testUnpin() {
     popUpWithMouse()
     pin(copy2)
     pin(copy2)
-    XCTAssertEqual(itemTitles[0...1], [copy1, copy2])
+    assertTopItemTitles([copy1, copy2])
   }
 
   func testRemoveLastWordFromSearchWithControlW() {
@@ -538,9 +539,14 @@ class MaccyUITests: XCTestCase {
     waitTillClipboardCheck()
   }
 
-  private func copyToClipboard(_ content: Data?, _ type: NSPasteboard.PasteboardType) {
+  private func copyToClipboard(_ content: Data?, _ type: NSPasteboard.PasteboardType, title: String? = nil) {
     pasteboard.clearContents()
+    if let title {
+      pasteboard.setString(title, forType: .string)
+    }
     pasteboard.setData(content, forType: type)
+    // Same as file URLs, force the pasteboard server to materialize the write before the next test copy.
+    pasteboard.data(forType: type)
     waitTillClipboardCheck()
   }
 
@@ -589,6 +595,57 @@ class MaccyUITests: XCTestCase {
     expectation(
       for: NSPredicate(format: "(exists = 0) || (isHittable = 0)"), evaluatedWith: element)
     waitForExpectations(timeout: 3)
+  }
+
+  private func assertTopItemTitles(
+    _ expected: [String],
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    XCTAssertEqual(Array(itemTitles.prefix(expected.count)), expected, file: file, line: line)
+  }
+
+  private func resetAppDefaults() {
+    let bundleIdentifier = "org.p0deje.Maccy"
+    guard let defaults = UserDefaults(suiteName: bundleIdentifier) else {
+      return
+    }
+
+    defaults.removePersistentDomain(forName: bundleIdentifier)
+    defaults.set(["2024-07-01-version-2": true], forKey: "migrations")
+    defaults.set(false, forKey: "clearOnQuit")
+    defaults.set(false, forKey: "clearSystemClipboard")
+    defaults.set(false, forKey: "ignoreAllAppsExceptListed")
+    defaults.set(false, forKey: "ignoreEvents")
+    defaults.set(false, forKey: "ignoreOnlyNextEvent")
+    defaults.set([], forKey: "ignoreRegexp")
+    defaults.set([], forKey: "ignoredApps")
+    defaults.set([], forKey: "ignoredPasteboardTypes")
+    defaults.set(false, forKey: "pasteByDefault")
+    defaults.set(false, forKey: "removeFormattingByDefault")
+    defaults.set(false, forKey: "showApplicationIcons")
+    defaults.set(true, forKey: "showFooter")
+    defaults.set(true, forKey: "showInStatusBar")
+    defaults.set(false, forKey: "showRecentCopyInMenuBar")
+    defaults.set(true, forKey: "showSearch")
+    defaults.set(true, forKey: "showSpecialSymbols")
+    defaults.set(true, forKey: "showTitle")
+    defaults.set(false, forKey: "suppressClearAlert")
+    defaults.set(200, forKey: "historySize")
+    defaults.set(40, forKey: "imageMaxHeight")
+    defaults.set("exact", forKey: "searchMode")
+    defaults.set("lastCopiedAt", forKey: "sortBy")
+    defaults.set("top", forKey: "pinTo")
+    defaults.set("cursor", forKey: "popupPosition")
+    defaults.set([
+      NSPasteboard.PasteboardType.fileURL.rawValue,
+      NSPasteboard.PasteboardType.html.rawValue,
+      NSPasteboard.PasteboardType.png.rawValue,
+      NSPasteboard.PasteboardType.rtf.rawValue,
+      NSPasteboard.PasteboardType.string.rawValue,
+      NSPasteboard.PasteboardType.tiff.rawValue
+    ], forKey: "enabledPasteboardTypes")
+    defaults.synchronize()
   }
 
   private func assertPasteboardDataEquals(


### PR DESCRIPTION
## Summary

- Keep cursor-based popup placement on the screen that contains the cursor.
- Clamp the cursor popup origin to that screen's visible frame, so the window stays fully visible near bottom and side edges.
- Limit cursor popup size to the cursor screen's visible frame before positioning.
- Add unit coverage for bottom-edge cursor placement, side-edge cursor placement, and visible-frame size clamping.

Fixes #1432.

## Test plan

- `xcodebuild build -project Maccy.xcodeproj -scheme Maccy -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Maccy.xcodeproj -scheme Maccy -destination 'platform=macOS' -only-testing:MaccyTests/PopupPositionTests CODE_SIGNING_ALLOWED=NO`
- `swiftlint lint --strict`

## Localization

No user-facing strings were added or changed.
