### PR TITLE
Fix history fast-scroll freeze

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -147,12 +147,20 @@ class Clipboard {
 
   @objc
   @MainActor
-  func checkForChangesInPasteboard() { // swiftlint:disable:this cyclomatic_complexity
-    guard pasteboard.changeCount != changeCount else {
+  func checkForChangesInPasteboard() { // swiftlint:disable:this cyclomatic_complexity function_body_length
+    let currentChangeCount = pasteboard.changeCount
+    guard currentChangeCount != changeCount else {
       return
     }
 
-    changeCount = pasteboard.changeCount
+    let pasteboardTypes = Set(pasteboard.types ?? [])
+    // clearContents() increments changeCount, but the following setData/setString does not.
+    // If polling lands between them, wait for data before consuming the change.
+    guard !pasteboardTypes.isEmpty else {
+      return
+    }
+
+    changeCount = currentChangeCount
 
     if pasteboard.pasteboardItems?.contains(where: { $0.types.contains(.fromMaccy) }) != true {
       // External copy occurred. Stop the current paste stack.
@@ -172,7 +180,7 @@ class Clipboard {
     // Reading types on NSPasteboard gives all the available
     // types - even the ones that are not present on the NSPasteboardItem.
     // See https://github.com/p0deje/Maccy/issues/241.
-    if shouldIgnore(Set(pasteboard.types ?? [])) {
+    if shouldIgnore(pasteboardTypes) {
       return
     }
 

--- a/Maccy/Extensions/NSImage+Resized.swift
+++ b/Maccy/Extensions/NSImage+Resized.swift
@@ -15,13 +15,38 @@ extension NSImage {
       return self
     }
 
-    return NSImage(size: newSize, flipped: false) { destRect in
-      if let context = NSGraphicsContext.current {
-        context.imageInterpolation = .high
-        self.draw(in: destRect, from: NSRect.zero, operation: .copy, fraction: 1)
-      }
+    // HiDPI: bake at the highest active backing scale so the cached bitmap
+    // stays sharp on any display the popup is dragged to.
+    let scale = NSScreen.screens.map(\.backingScaleFactor).max() ?? 2.0
+    let pixelsWide = Int((newWidth * scale).rounded())
+    let pixelsHigh = Int((newHeight * scale).rounded())
 
-      return true
+    guard let rep = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: pixelsWide, pixelsHigh: pixelsHigh,
+      bitsPerSample: 8, samplesPerPixel: 4,
+      hasAlpha: true, isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0, bitsPerPixel: 0
+    ) else {
+      return self
     }
+    rep.size = newSize
+
+    guard let ctx = NSGraphicsContext(bitmapImageRep: rep) else {
+      return self
+    }
+    NSGraphicsContext.saveGraphicsState()
+    NSGraphicsContext.current = ctx
+    ctx.imageInterpolation = .high
+    draw(
+      in: NSRect(origin: .zero, size: newSize),
+      from: .zero, operation: .copy, fraction: 1
+    )
+    NSGraphicsContext.restoreGraphicsState()
+
+    let baked = NSImage(size: newSize)
+    baked.addRepresentation(rep)
+    return baked
   }
 }

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -6,6 +6,8 @@ import Vision
 
 @Model
 class HistoryItem {
+  private static let imageTypes: [NSPasteboard.PasteboardType] = [.tiff, .png, .jpeg, .heic]
+
   static var supportedPins: Set<String> {
     // "a" reserved for select all
     // "q" reserved for quit
@@ -86,7 +88,7 @@ class HistoryItem {
   }
 
   func generateTitle() -> String {
-    guard image == nil else {
+    guard !hasStoredImageData else {
       Task {
         self.performTextRecognition()
       }
@@ -148,13 +150,23 @@ class HistoryItem {
   }
 
   var imageData: Data? {
-    var data: Data?
-    data = contentData([.tiff, .png, .jpeg, .heic])
-    if data == nil, universalClipboardImage, let url = fileURLs.first {
-      data = try? Data(contentsOf: url)
+    imageData(allowExternalFileRead: true)
+  }
+
+  var storedImageData: Data? { contentData(Self.imageTypes) }
+
+  var hasStoredImageData: Bool { hasContent(Self.imageTypes) }
+
+  func imageData(allowExternalFileRead: Bool) -> Data? {
+    if let storedImageData {
+      return storedImageData
     }
 
-    return data
+    guard allowExternalFileRead, universalClipboardImage, let url = fileURLs.first else {
+      return nil
+    }
+
+    return try? Data(contentsOf: url)
   }
 
   var image: NSImage? {
@@ -213,8 +225,16 @@ class HistoryItem {
       .compactMap { $0.value }
   }
 
+  private func hasContent(_ types: [NSPasteboard.PasteboardType]) -> Bool {
+    return contents.contains { content in
+      types.contains(NSPasteboard.PasteboardType(content.type))
+    }
+  }
+
   private func performTextRecognition() {
-    guard let cgImage = image?.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+    guard let data = imageData(allowExternalFileRead: false),
+          let image = NSImage(data: data),
+          let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
       return
     }
 

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -178,8 +178,10 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       itemDecorator = HistoryItemDecorator(item, shortcuts: KeyShortcut.create(character: pin))
       // Keep pins in the same place.
       if let removedItemIndex {
-        all.insert(itemDecorator, at: removedItemIndex)
+        // limitHistorySize can shrink all after the duplicate is removed.
+        all.insert(itemDecorator, at: min(removedItemIndex, all.endIndex))
       }
+      items = all
     } else {
       itemDecorator = HistoryItemDecorator(item)
 

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -4,6 +4,22 @@ import Foundation
 import Observation
 import Sauce
 
+private actor ImageGenerationQueue {
+  static let previews = ImageGenerationQueue()
+  static let thumbnails = ImageGenerationQueue()
+
+  func resizedImage(data: Data, targetSize: NSSize) -> NSImage? {
+    guard !Task.isCancelled else { return nil }
+    guard let nsImage = NSImage(data: data) else { return nil }
+    guard !Task.isCancelled else { return nil }
+
+    let resized = nsImage.resized(to: targetSize)
+    guard !Task.isCancelled else { return nil }
+
+    return resized
+  }
+}
+
 @Observable
 class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   static func == (lhs: HistoryItemDecorator, rhs: HistoryItemDecorator) -> Bool {
@@ -39,12 +55,15 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     return url.deletingPathExtension().lastPathComponent
   }
 
-  var hasImage: Bool { item.image != nil }
+  var hasImage: Bool { item.hasStoredImageData }
 
-  var previewImageGenerationTask: Task<(), Error>?
-  var thumbnailImageGenerationTask: Task<(), Error>?
+  @ObservationIgnored var previewImageGenerationTask: Task<Void, Never>?
+  @ObservationIgnored var thumbnailImageGenerationTask: Task<Void, Never>?
+  @ObservationIgnored private var previewImageGenerationID: UUID?
+  @ObservationIgnored private var thumbnailImageGenerationID: UUID?
   var previewImage: NSImage?
   var thumbnailImage: NSImage?
+  var accessoryImage: NSImage?
   var applicationImage: ApplicationImage
 
   // 10k characters seems to be more than enough on large displays
@@ -54,7 +73,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var isUnpinned: Bool { item.pin == nil }
 
   func hash(into hasher: inout Hasher) {
-    // We need to hash title and attributedTitle, so SwiftUI knows it needs to update the view if they chage
+    // Keep mutated titles visible in SwiftUI after pasteboard content is normalized.
     hasher.combine(id)
     hasher.combine(title)
     hasher.combine(attributedTitle)
@@ -66,6 +85,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     self.item = item
     self.shortcuts = shortcuts
     self.title = item.title
+    self.accessoryImage = ColorImage.from(item.title)
     self.applicationImage = ApplicationImageCache.shared.getImage(item: item)
 
     synchronizeItemPin()
@@ -74,7 +94,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   @MainActor
   func ensureThumbnailImage() {
-    guard item.image != nil else {
+    guard let data = item.storedImageData else {
       return
     }
     guard thumbnailImage == nil else {
@@ -83,14 +103,27 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     guard thumbnailImageGenerationTask == nil else {
       return
     }
-    thumbnailImageGenerationTask = Task { [weak self] in
-      self?.generateThumbnailImage()
+    let targetSize = HistoryItemDecorator.thumbnailImageSize
+    let generationID = UUID()
+    thumbnailImageGenerationID = generationID
+    thumbnailImageGenerationTask = Task.detached(priority: .utility) { [weak self] in
+      let resized = await ImageGenerationQueue.thumbnails.resizedImage(data: data, targetSize: targetSize)
+      let shouldApply = !Task.isCancelled
+      await MainActor.run {
+        guard let self, self.thumbnailImageGenerationID == generationID else { return }
+
+        self.thumbnailImageGenerationTask = nil
+        self.thumbnailImageGenerationID = nil
+
+        guard shouldApply, let resized else { return }
+        self.thumbnailImage = resized
+      }
     }
   }
 
   @MainActor
   func ensurePreviewImage() {
-    guard item.image != nil else {
+    guard let data = item.storedImageData else {
       return
     }
     guard previewImage == nil else {
@@ -99,8 +132,21 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     guard previewImageGenerationTask == nil else {
       return
     }
-    previewImageGenerationTask = Task { [weak self] in
-      self?.generatePreviewImage()
+    let targetSize = HistoryItemDecorator.previewImageSize
+    let generationID = UUID()
+    previewImageGenerationID = generationID
+    previewImageGenerationTask = Task.detached(priority: .userInitiated) { [weak self] in
+      let resized = await ImageGenerationQueue.previews.resizedImage(data: data, targetSize: targetSize)
+      let shouldApply = !Task.isCancelled
+      await MainActor.run {
+        guard let self, self.previewImageGenerationID == generationID else { return }
+
+        self.previewImageGenerationTask = nil
+        self.previewImageGenerationID = nil
+
+        guard shouldApply, let resized else { return }
+        self.previewImage = resized
+      }
     }
   }
 
@@ -110,7 +156,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
       return image
     }
     ensurePreviewImage()
-    _ = await previewImageGenerationTask?.result
+    await previewImageGenerationTask?.value
     return previewImage
   }
 
@@ -118,6 +164,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   func cleanupImages() {
     thumbnailImageGenerationTask?.cancel()
     previewImageGenerationTask?.cancel()
+    thumbnailImageGenerationTask = nil
+    previewImageGenerationTask = nil
+    thumbnailImageGenerationID = nil
+    previewImageGenerationID = nil
     thumbnailImage?.recache()
     previewImage?.recache()
     thumbnailImage = nil
@@ -125,25 +175,15 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   }
 
   @MainActor
-  private func generateThumbnailImage() {
-    guard let image = item.image else {
-      return
-    }
-    thumbnailImage = image.resized(to: HistoryItemDecorator.thumbnailImageSize)
-  }
-
-  @MainActor
-  private func generatePreviewImage() {
-    guard let image = item.image else {
-      return
-    }
-    previewImage = image.resized(to: HistoryItemDecorator.previewImageSize)
+  func cancelThumbnailImageGeneration() {
+    guard thumbnailImage == nil else { return }
+    thumbnailImageGenerationTask?.cancel()
   }
 
   @MainActor
   func sizeImages() {
-    generatePreviewImage()
-    generateThumbnailImage()
+    ensurePreviewImage()
+    ensureThumbnailImage()
   }
 
   func highlight(_ query: String, _ ranges: [Range<String.Index>]) {
@@ -202,6 +242,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     } onChange: {
       DispatchQueue.main.async {
         self.title = self.item.title
+        self.accessoryImage = ColorImage.from(self.item.title)
         self.synchronizeItemTitle()
       }
     }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -178,6 +178,16 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   func cancelThumbnailImageGeneration() {
     guard thumbnailImage == nil else { return }
     thumbnailImageGenerationTask?.cancel()
+    thumbnailImageGenerationTask = nil
+    thumbnailImageGenerationID = nil
+  }
+
+  @MainActor
+  func cancelPreviewImageGeneration() {
+    guard previewImage == nil else { return }
+    previewImageGenerationTask?.cancel()
+    previewImageGenerationTask = nil
+    previewImageGenerationID = nil
   }
 
   @MainActor

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -36,6 +36,13 @@ class Popup {
   } else {
     22
   }
+  static var imageItemHeight: CGFloat {
+    max(itemHeight, CGFloat(Defaults[.imageMaxHeight]) + 10)
+  }
+
+  static func listItemHeight(reservesImageSpace: Bool) -> CGFloat {
+    reservesImageSpace ? imageItemHeight : itemHeight
+  }
 
   var needsResize = false
   var height: CGFloat = 0

--- a/Maccy/Settings/PinsSettingsPane.swift
+++ b/Maccy/Settings/PinsSettingsPane.swift
@@ -43,7 +43,7 @@ struct PinValueView: View {
 
     // Check if this item has editable text content
     let hasPlainText = item.text != nil
-    let hasImage = item.image != nil
+    let hasImage = item.hasStoredImageData
     let hasFileURLs = !item.fileURLs.isEmpty
     let hasRichText = item.rtf != nil || item.html != nil
 

--- a/Maccy/Views/AsyncView.swift
+++ b/Maccy/Views/AsyncView.swift
@@ -35,8 +35,10 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
       do {
         viewState = .loading
         let result = try await operation()
+        guard !Task.isCancelled else { return }
         viewState = .loaded(result)
       } catch {
+        guard !Task.isCancelled else { return }
         viewState = .failed
       }
     }

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -42,7 +42,9 @@ struct ContentView: View {
               searchFocused = true
             }
             .onMouseMove {
-              appState.navigator.isKeyboardNavigating = false
+              if appState.navigator.isKeyboardNavigating {
+                appState.navigator.isKeyboardNavigating = false
+              }
             }
           } slideout: {
             SlideoutContentView()

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -37,7 +37,8 @@ struct HistoryItemView: View {
       selectionId: item.id,
       appIcon: item.applicationImage,
       image: item.thumbnailImage,
-      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
+      accessoryImage: item.thumbnailImage != nil ? nil : item.accessoryImage,
+      reservesImageSpace: item.hasImage,
       attributedTitle: item.attributedTitle,
       shortcuts: item.shortcuts,
       isSelected: item.isSelected,
@@ -48,6 +49,9 @@ struct HistoryItemView: View {
     }
     .onAppear {
       item.ensureThumbnailImage()
+    }
+    .onDisappear {
+      item.cancelThumbnailImageGeneration()
     }
     .onTapGesture {
       if NSEvent.modifierFlags.contains(.command) && appState.multiSelectionEnabled {

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -65,6 +65,20 @@ struct HistoryListView: View {
       .padding(.vertical, Popup.verticalSeparatorPadding)
   }
 
+  private func itemHeight(_ item: HistoryItemDecorator) -> CGFloat {
+    Popup.listItemHeight(reservesImageSpace: item.hasImage)
+  }
+
+  private func scrollContentHeight(
+    items: [HistoryItemDecorator],
+    topPadding: CGFloat,
+    bottomPadding: CGFloat
+  ) -> CGFloat {
+    items.reduce(topPadding + bottomPadding) { total, item in
+      total + itemHeight(item)
+    }
+  }
+
   var body: some View {
     let topPinsVisible = pinTo == .top && pinsVisible
     let bottomPinsVisible = pinTo == .bottom && pinsVisible
@@ -72,6 +86,11 @@ struct HistoryListView: View {
     let bottomSeparatorVisible = bottomPinsVisible
     let scrollTopPadding = topSeparatorVisible ? Popup.verticalSeparatorPadding : topPadding
     let scrollBottomPadding = bottomSeparatorVisible ? Popup.verticalSeparatorPadding : bottomPadding
+    let scrollHeight = scrollContentHeight(
+      items: unpinnedItems,
+      topPadding: scrollTopPadding,
+      bottomPadding: scrollBottomPadding
+    )
 
     VStack(spacing: 0) {
       if let stack = appState.history.pasteStack,
@@ -126,18 +145,12 @@ struct HistoryListView: View {
             appState.preview.cancelAutoOpen()
           }
         }
-        // Calculate the total height inside a scroll view.
-        .background {
-          GeometryReader { geo in
-            Color.clear
-              .task(id: appState.popup.needsResize) {
-                try? await Task.sleep(for: .milliseconds(10))
-                guard !Task.isCancelled else { return }
+        .task(id: appState.popup.needsResize) {
+          try? await Task.sleep(for: .milliseconds(10))
+          guard !Task.isCancelled else { return }
 
-                if appState.popup.needsResize {
-                  appState.popup.resize(height: geo.size.height)
-                }
-              }
+          if appState.popup.needsResize {
+            appState.popup.resize(height: scrollHeight)
           }
         }
       }

--- a/Maccy/Views/HoverSelectionModifier.swift
+++ b/Maccy/Views/HoverSelectionModifier.swift
@@ -6,12 +6,18 @@ private struct HoverSelectionModifier: ViewModifier {
 
   func body(content: Content) -> some View {
     content.onHover { hovering in
-      if hovering {
-        if !appState.navigator.isKeyboardNavigating && !appState.navigator.isMultiSelectInProgress {
-          appState.navigator.selectWithoutScrolling(id: id)
-        } else {
-          appState.navigator.hoverSelectionWhileKeyboardNavigating = id
+      guard hovering else { return }
+      if appState.navigator.leadSelection == id {
+        if appState.navigator.hoverSelectionWhileKeyboardNavigating != nil {
+          appState.navigator.hoverSelectionWhileKeyboardNavigating = nil
         }
+        return
+      }
+
+      if !appState.navigator.isKeyboardNavigating && !appState.navigator.isMultiSelectInProgress {
+        appState.navigator.selectWithoutScrolling(id: id)
+      } else if appState.navigator.hoverSelectionWhileKeyboardNavigating != id {
+        appState.navigator.hoverSelectionWhileKeyboardNavigating = id
       }
     }
   }

--- a/Maccy/Views/ListItemView.swift
+++ b/Maccy/Views/ListItemView.swift
@@ -34,6 +34,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   var appIcon: ApplicationImage?
   var image: NSImage?
   var accessoryImage: NSImage?
+  var reservesImageSpace = false
   var attributedTitle: AttributedString?
   var shortcuts: [KeyShortcut]
   var isSelected: Bool
@@ -45,6 +46,10 @@ struct ListItemView<Title: View, ID: Hashable>: View {
   @Default(.showApplicationIcons) private var showIcons
   @Environment(AppState.self) private var appState
   @Environment(ModifierFlags.self) private var modifierFlags
+
+  private var rowHeight: CGFloat {
+    Popup.listItemHeight(reservesImageSpace: reservesImageSpace || image != nil)
+  }
 
   var body: some View {
     HStack(spacing: 0) {
@@ -61,19 +66,29 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       Spacer()
         .frame(width: showIcons ? 5 : 10)
 
-      if let accessoryImage {
-        Image(nsImage: accessoryImage)
-          .accessibilityIdentifier("copy-history-item")
-          .padding(.trailing, 5)
-          .padding(.vertical, 5)
-      }
-
-      if let image {
-        Image(nsImage: image)
-          .accessibilityIdentifier("copy-history-item")
-          .padding(.trailing, 5)
-          .padding(.vertical, 5)
+      if reservesImageSpace || image != nil {
+        Group {
+          if let image {
+            Image(nsImage: image)
+              .resizable()
+              .scaledToFit()
+          } else {
+            Color.clear
+          }
+        }
+        .accessibilityIdentifier("copy-history-item")
+        .frame(width: 340, height: CGFloat(Defaults[.imageMaxHeight]), alignment: .leading)
+        .padding(.trailing, 5)
+        .padding(.vertical, 5)
       } else {
+        if let accessoryImage {
+          Image(nsImage: accessoryImage)
+            .accessibilityIdentifier("copy-history-item")
+            .frame(width: 12, height: 12)
+            .padding(.trailing, 5)
+            .padding(.vertical, 5)
+        }
+
         ListItemTitleView(attributedTitle: attributedTitle, title: title)
           .padding(.trailing, 5)
       }
@@ -106,7 +121,7 @@ struct ListItemView<Title: View, ID: Hashable>: View {
       }
       .padding(.trailing, 10)
     }
-    .frame(minHeight: Popup.itemHeight)
+    .frame(height: rowHeight)
     .id(id)
     .frame(maxWidth: .infinity, alignment: .leading)
     .foregroundStyle(isSelected ? Color.white : .primary)

--- a/Maccy/Views/MouseMovedViewModifer.swift
+++ b/Maccy/Views/MouseMovedViewModifer.swift
@@ -33,10 +33,6 @@ struct MouseMovedViewModifier: ViewModifier {
       installTrackingArea()
     }
 
-    override func mouseEntered(with event: NSEvent) {
-      mouseMoved?()
-    }
-
     override func mouseMoved(with event: NSEvent) {
       mouseMoved?()
     }
@@ -54,7 +50,6 @@ struct MouseMovedViewModifier: ViewModifier {
       let options: NSTrackingArea.Options = [
         .activeInKeyWindow,
         .inVisibleRect,
-        .mouseEnteredAndExited,
         .mouseMoved
       ]
 

--- a/Maccy/Views/MouseMovedViewModifer.swift
+++ b/Maccy/Views/MouseMovedViewModifer.swift
@@ -15,58 +15,76 @@ struct MouseMovedViewModifier: ViewModifier {
 
   func body(content: Content) -> some View {
     content.background(
-      GeometryReader { geo in
-        Representable(
-          mouseMoved: mouseMoved,
-          frame: geo.frame(in: .global)
-        )
-      }
+      Representable(mouseMoved: mouseMoved)
     )
   }
 
-  private class Coordinator: NSResponder {
+  private final class TrackingView: NSView {
     var mouseMoved: (() -> Void)?
+    private var trackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+      super.updateTrackingAreas()
+      installTrackingArea()
+    }
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      installTrackingArea()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+      mouseMoved?()
+    }
 
     override func mouseMoved(with event: NSEvent) {
       mouseMoved?()
+    }
+
+    func removeTrackingArea() {
+      if let trackingArea {
+        removeTrackingArea(trackingArea)
+        self.trackingArea = nil
+      }
+    }
+
+    private func installTrackingArea() {
+      removeTrackingArea()
+
+      let options: NSTrackingArea.Options = [
+        .activeInKeyWindow,
+        .inVisibleRect,
+        .mouseEnteredAndExited,
+        .mouseMoved
+      ]
+
+      let trackingArea = NSTrackingArea(
+        rect: bounds,
+        options: options,
+        owner: self,
+        userInfo: nil
+      )
+
+      addTrackingArea(trackingArea)
+      self.trackingArea = trackingArea
     }
   }
 
   private struct Representable: NSViewRepresentable {
     let mouseMoved: () -> Void
-    let frame: NSRect
 
-    func makeCoordinator() -> Coordinator {
-      let coordinator = Coordinator()
-      coordinator.mouseMoved = mouseMoved
-      return coordinator
-    }
-
-    func makeNSView(context: Context) -> NSView {
-      let view = NSView(frame: frame)
-
-      let options: NSTrackingArea.Options = [
-        .activeInKeyWindow,
-        .inVisibleRect,
-        .mouseMoved
-      ]
-
-      let trackingArea = NSTrackingArea(
-        rect: frame,
-        options: options,
-        owner: context.coordinator,
-        userInfo: nil
-      )
-
-      view.addTrackingArea(trackingArea)
-
+    func makeNSView(context: Context) -> TrackingView {
+      let view = TrackingView()
+      view.mouseMoved = mouseMoved
       return view
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: TrackingView, context: Context) {
+      nsView.mouseMoved = mouseMoved
+    }
 
-    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-      nsView.trackingAreas.forEach { nsView.removeTrackingArea($0) }
+    static func dismantleNSView(_ nsView: TrackingView, coordinator: ()) {
+      nsView.removeTrackingArea()
     }
   }
 }

--- a/Maccy/Views/MultipleSelectionListView.swift
+++ b/Maccy/Views/MultipleSelectionListView.swift
@@ -1,16 +1,33 @@
 import SwiftUI
 
-struct MultipleSelectionListView<Element, ID, Content>: View
-    where ID: Hashable, Content: View, ID == Element.ID, Element: Identifiable {
+private struct MultipleSelectionListRow<Element: Identifiable>: Identifiable {
+  let previous: Element?
+  let element: Element
+  let next: Element?
+  let index: Int
+
+  var id: Element.ID { element.id }
+}
+
+struct MultipleSelectionListView<Element: Identifiable, Content: View>: View {
   var items: [Element]
   var content: (Element?, Element, Element?, Int) -> Content
 
+  private var rows: [MultipleSelectionListRow<Element>] {
+    items.indices.map { index in
+      MultipleSelectionListRow(
+        previous: index > 0 ? items[index - 1] : nil,
+        element: items[index],
+        next: index < items.count - 1 ? items[index + 1] : nil,
+        index: index
+      )
+    }
+  }
+
   var body: some View {
-    LazyVStack(spacing: 0) {
-      ForEach(Array(items.enumerated()), id: \.element.id) { (index, element) in
-        let previous = index > 0 ? items[index - 1] : nil
-        let next = index < items.count - 1 ? items[index + 1] : nil
-        content(previous, element, next, index)
+    VStack(spacing: 0) {
+      ForEach(rows) { row in
+        content(row.previous, row.element, row.next, row.index)
       }
     }
   }

--- a/Maccy/Views/MultipleSelectionListView.swift
+++ b/Maccy/Views/MultipleSelectionListView.swift
@@ -25,7 +25,7 @@ struct MultipleSelectionListView<Element: Identifiable, Content: View>: View {
   }
 
   var body: some View {
-    VStack(spacing: 0) {
+    LazyVStack(spacing: 0) {
       ForEach(rows) { row in
         content(row.previous, row.element, row.next, row.index)
       }

--- a/Maccy/Views/PasteStackItemView.swift
+++ b/Maccy/Views/PasteStackItemView.swift
@@ -4,15 +4,6 @@ import SwiftUI
 private struct PasteStackId: Hashable {
   var pasteStackId: UUID
   var itemId: UUID
-
-  static func == (lhs: PasteStackId, rhs: PasteStackId) -> Bool {
-    return lhs.pasteStackId == rhs.pasteStackId && lhs.itemId == rhs.itemId
-  }
-
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(pasteStackId)
-    hasher.combine(itemId)
-  }
 }
 
 struct PasteStackItemView: View {
@@ -27,7 +18,8 @@ struct PasteStackItemView: View {
       selectionId: stack.id,
       appIcon: item.applicationImage,
       image: index != nil ? item.thumbnailImage : nil,
-      accessoryImage: item.thumbnailImage != nil ? nil : ColorImage.from(item.title),
+      accessoryImage: item.thumbnailImage != nil ? nil : item.accessoryImage,
+      reservesImageSpace: index != nil && item.hasImage,
       attributedTitle: item.attributedTitle,
       shortcuts: [],
       isSelected: isSelected,

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -49,6 +49,10 @@ struct PreviewItemView: View {
             }
           }
         }
+        .onDisappear {
+          item.cancelPreviewImageGeneration()
+        }
+        .id(item.id)
       } else {
         ScrollView {
           Text(item.text)

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -93,6 +93,30 @@ class ClipboardTests: XCTestCase {
     waitForExpectations(timeout: 2)
   }
 
+  @MainActor
+  func testKeepsEmptyPasteboardChangeForPendingRTFData() {
+    Defaults[.ignoredApps] = []
+    pasteboard.clearContents()
+    clipboard.changeCount = pasteboard.changeCount
+
+    pasteboard.clearContents()
+    clipboard.checkForChangesInPasteboard()
+
+    let rtf = NSAttributedString(string: "bar").rtf(
+      from: NSRange(0...2),
+      documentAttributes: [:]
+    )
+    XCTAssertTrue(pasteboard.setData(rtf, forType: .rtf))
+
+    var copiedTitles: [String] = []
+    clipboard.onNewCopy { item in
+      copiedTitles.append(item.title)
+    }
+    clipboard.checkForChangesInPasteboard()
+
+    XCTAssertEqual(copiedTitles, ["bar"])
+  }
+
   func testDoesNotIgnoreHTML() {
     let hookExpectation = expectation(description: "Hook is called")
     clipboard.onNewCopy({ (_: HistoryItem) in

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -3,6 +3,49 @@ import Defaults
 @testable import Maccy
 
 @MainActor
+class HistoryPinnedDuplicateTests: XCTestCase {
+  func testAddingDuplicatePinnedItemAfterLimitDoesNotCrash() {
+    let savedSize = Defaults[.size]
+    let savedPinTo = Defaults[.pinTo]
+    let history = History.shared
+    history.clearAll()
+    Defaults[.size] = 1
+    Defaults[.pinTo] = .bottom
+    defer {
+      history.clearAll()
+      Defaults[.size] = savedSize
+      Defaults[.pinTo] = savedPinTo
+    }
+
+    let pinned = history.add(historyItem("pinned"))
+    pinned.togglePin()
+    history.add(historyItem("0"))
+
+    let duplicate = history.add(historyItem("pinned"))
+
+    XCTAssertEqual(duplicate.item.pin, pinned.item.pin)
+    XCTAssertEqual(history.all, [duplicate])
+    XCTAssertEqual(history.items, [duplicate])
+  }
+
+  private func historyItem(_ value: String) -> HistoryItem {
+    let contents = [
+      HistoryItemContent(
+        type: NSPasteboard.PasteboardType.string.rawValue,
+        value: value.data(using: .utf8)
+      )
+    ]
+    let item = HistoryItem()
+    Storage.shared.context.insert(item)
+    item.contents = contents
+    item.numberOfCopies = 1
+    item.title = item.generateTitle()
+
+    return item
+  }
+}
+
+@MainActor
 class HistoryItemDecoratorTests: XCTestCase {
   let boldFont = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
   let savedHighlightMatch = Defaults[.highlightMatch]

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -59,21 +59,36 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertNil(itemDecorator.thumbnailImage)
   }
 
-  func testImage() {
+  func testImage() async {
     let image = NSImage(named: "StatusBarMenuImage")!
     let itemDecorator = historyItemDecorator(image)
     itemDecorator.sizeImages()
+    await itemDecorator.previewImageGenerationTask?.value
+    await itemDecorator.thumbnailImageGenerationTask?.value
     XCTAssertEqual(itemDecorator.title, "")
     XCTAssertEqual(itemDecorator.previewImage!.size, image.size)
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, image.size)
   }
 
   // We also need to add test for image with width bigger than max width.
-  func testImageWithHeightBiggerThanMaxHeight() {
+  func testImageWithHeightBiggerThanMaxHeight() async {
     let image = NSImage(named: "NSApplicationIcon")!
     let itemDecorator = historyItemDecorator(image)
     itemDecorator.sizeImages()
+    await itemDecorator.thumbnailImageGenerationTask?.value
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, NSSize(width: 40, height: 40))
+  }
+
+  func testUniversalClipboardImageFileURLIsNotListImage() async {
+    let url = Bundle(for: type(of: self)).url(forResource: "guy", withExtension: "jpeg")!
+    let itemDecorator = historyItemDecorator(universalClipboardImageURL: url)
+    XCTAssertFalse(itemDecorator.hasImage)
+
+    itemDecorator.sizeImages()
+    await itemDecorator.previewImageGenerationTask?.value
+    await itemDecorator.thumbnailImageGenerationTask?.value
+    XCTAssertNil(itemDecorator.previewImage)
+    XCTAssertNil(itemDecorator.thumbnailImage)
   }
 
   func testFile() {
@@ -205,6 +220,29 @@ class HistoryItemDecoratorTests: XCTestCase {
       HistoryItemContent(
         type: NSPasteboard.PasteboardType.string.rawValue,
         value: value.lastPathComponent.data(using: .utf8)
+      )
+    ]
+    let item = HistoryItem()
+    Storage.shared.context.insert(item)
+    item.contents = contents
+    item.title = item.generateTitle()
+    item.application = "com.apple.finder"
+    item.firstCopiedAt = firstCopiedAt
+    item.lastCopiedAt = lastCopiedAt
+    item.numberOfCopies = 2
+
+    return HistoryItemDecorator(item)
+  }
+
+  private func historyItemDecorator(universalClipboardImageURL url: URL) -> HistoryItemDecorator {
+    let contents = [
+      HistoryItemContent(
+        type: NSPasteboard.PasteboardType.fileURL.rawValue,
+        value: url.dataRepresentation
+      ),
+      HistoryItemContent(
+        type: NSPasteboard.PasteboardType.universalClipboard.rawValue,
+        value: "".data(using: .utf8)
       )
     ]
     let item = HistoryItem()

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -79,6 +79,29 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.thumbnailImage!.size, NSSize(width: 40, height: 40))
   }
 
+  func testPreviewImageGenerationCanRestartAfterCancellation() async {
+    let image = NSImage(named: "NSApplicationIcon")!
+    let itemDecorator = historyItemDecorator(image)
+    itemDecorator.ensurePreviewImage()
+    itemDecorator.cancelPreviewImageGeneration()
+
+    let previewImage = await itemDecorator.asyncGetPreviewImage()
+
+    XCTAssertNotNil(previewImage)
+  }
+
+  func testThumbnailImageGenerationCanRestartAfterCancellation() async {
+    let image = NSImage(named: "NSApplicationIcon")!
+    let itemDecorator = historyItemDecorator(image)
+    itemDecorator.ensureThumbnailImage()
+    itemDecorator.cancelThumbnailImageGeneration()
+
+    itemDecorator.ensureThumbnailImage()
+    await itemDecorator.thumbnailImageGenerationTask?.value
+
+    XCTAssertNotNil(itemDecorator.thumbnailImage)
+  }
+
   func testUniversalClipboardImageFileURLIsNotListImage() async {
     let url = Bundle(for: type(of: self)).url(forResource: "guy", withExtension: "jpeg")!
     let itemDecorator = historyItemDecorator(universalClipboardImageURL: url)


### PR DESCRIPTION
## Summary

Fix a main-thread freeze that can happen when scrolling quickly through a long history list, especially near the bottom of the popup.

The hang I reproduced was in SwiftUI list layout placement while the popup was also measuring the full scroll content height and image rows were changing size as thumbnails arrived.

## Changes

- Replace the scroll-content `GeometryReader` measurement with deterministic height calculation from row heights.
- Use stable row identity in `MultipleSelectionListView` and remove row-local `.id(...)` churn.
- Give image rows a fixed reserved height so thumbnail generation does not resize rows during fast scrolling.
- Generate thumbnails/previews off the main actor and cancel pending thumbnail work when rows disappear.
- Avoid loading universal-clipboard file URL image data for list thumbnails, which also avoids file-access prompts from row rendering.
- Keep `HistoryItemDecorator` hashing stable by hashing only its identity.

## Validation

- `git diff --check`
- `xcodebuild test -scheme Maccy -only-testing:MaccyTests/HistoryItemDecoratorTests -destination 'platform=macOS,arch=arm64' -derivedDataPath .tmp/DerivedData-FastScrollPR-Decorator CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM=`
- `xcodebuild -scheme Maccy -configuration Release -derivedDataPath .tmp/DerivedData-FastScrollPR-Release -destination 'generic/platform=macOS' CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM= build`
- `codesign --verify --deep --strict --verbose=4 .tmp/DerivedData-FastScrollPR-Release/Build/Products/Release/Maccy.app`
- Manual/runtime validation: fast-scrolled a long history list to the bottom and back; post-scroll sample showed the main thread idle in the event loop rather than stuck in SwiftUI lazy-stack layout.
