### PR TITLE
Add time-based history retention ("keep for N days")

### DIFF
--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -18,6 +18,7 @@ extension Defaults.Keys {
     "enabledPasteboardTypes", default: Set(StorageType.all.types)
   )
   static let highlightMatch = Key<HighlightMatch>("highlightMatch", default: .bold)
+  static let historyKeepDays = Key<Int>("historyKeepDays", default: 0)
   static let ignoreAllAppsExceptListed = Key<Bool>("ignoreAllAppsExceptListed", default: false)
   static let ignoreEvents = Key<Bool>("ignoreEvents", default: false)
   static let ignoreOnlyNextEvent = Key<Bool>("ignoreOnlyNextEvent", default: false)

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -59,6 +59,12 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @ObservationIgnored
   private var sessionLog: [Int: HistoryItem] = [:]
 
+  // Enforces the time-based retention limit while the app stays open and idle,
+  // covering the case where no new copies arrive to trigger a purge.
+  @ObservationIgnored
+  private var purgeTimer: Timer?
+  private static let purgeInterval: TimeInterval = 60 * 60 // 1 hour
+
   // The distinction between `all` and `items` is the following:
   // - `all` stores all history items, even the ones that are currently hidden by a search
   // - `items` stores only visible history items, updated during a search
@@ -99,6 +105,18 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         }
       }
     }
+
+    Task {
+      for await _ in Defaults.updates(.historyKeepDays, initial: false) {
+        await purgeExpiredItems()
+      }
+    }
+
+    purgeTimer = Timer.scheduledTimer(withTimeInterval: Self.purgeInterval, repeats: true) { _ in
+      Task { @MainActor in
+        History.shared.purgeExpiredItems()
+      }
+    }
   }
 
   @MainActor
@@ -109,6 +127,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     items = all
 
     limitHistorySize(to: Defaults[.size])
+    purgeExpiredItems()
 
     updateShortcuts()
     // Ensure that panel size is proper *after* loading all items.
@@ -123,6 +142,22 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     if unpinned.count >= maxSize {
       unpinned[maxSize...].forEach(delete)
     }
+  }
+
+  // Removes unpinned items whose last copy is older than the configured retention window.
+  // A value of `0` disables the time-based limit, leaving existing behaviour unchanged.
+  @MainActor
+  func purgeExpiredItems() {
+    let keepDays = Defaults[.historyKeepDays]
+    guard keepDays > 0 else { return }
+
+    guard let cutoff = Calendar.current.date(byAdding: .day, value: -keepDays, to: Date.now) else {
+      return
+    }
+
+    all
+      .filter { $0.isUnpinned && $0.item.lastCopiedAt < cutoff }
+      .forEach(delete)
   }
 
   @MainActor
@@ -170,6 +205,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     // Remove exceeding items. Do this after the item is added to avoid removing something
     // if a duplicate was found as then the size already stayed the same.
     limitHistorySize(to: Defaults[.size] - 1)
+    purgeExpiredItems()
 
     sessionLog[Clipboard.shared.changeCount] = item
 

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -59,6 +59,8 @@ struct StorageSettingsPane: View {
   @Default(.size) private var size
   @Default(.sortBy) private var sortBy
 
+  @Default(.historyKeepDays) private var keepDays
+
   @State private var viewModel = ViewModel()
   @State private var storageSize = Storage.shared.size
 
@@ -66,6 +68,13 @@ struct StorageSettingsPane: View {
     let formatter = NumberFormatter()
     formatter.minimum = 1
     formatter.maximum = 999
+    return formatter
+  }()
+
+  private let keepDaysFormatter: NumberFormatter = {
+    let formatter = NumberFormatter()
+    formatter.minimum = 0
+    formatter.maximum = 365
     return formatter
   }()
 
@@ -106,6 +115,21 @@ struct StorageSettingsPane: View {
             .onAppear {
               storageSize = Storage.shared.size
             }
+        }
+      }
+
+      Settings.Section(label: { Text("KeepFor", tableName: "StorageSettings") }) {
+        HStack {
+          TextField("", value: $keepDays, formatter: keepDaysFormatter)
+            .frame(width: 80)
+            .help(Text("KeepForTooltip", tableName: "StorageSettings"))
+          Stepper("", value: $keepDays, in: 0...365)
+            .labelsHidden()
+          (keepDays == 0
+           ? Text("KeepForDisabled", tableName: "StorageSettings")
+           : Text("KeepForDays", tableName: "StorageSettings"))
+            .controlSize(.small)
+            .foregroundStyle(.gray)
         }
       }
 

--- a/Maccy/Settings/en.lproj/StorageSettings.strings
+++ b/Maccy/Settings/en.lproj/StorageSettings.strings
@@ -7,6 +7,10 @@
 "Size" = "Size:";
 "SizeTooltip" = "Number of history items to keep.\nDefault: 200.";
 "CurrentSizeTooltip" = "Current size on disk.";
+"KeepFor" = "Keep for:";
+"KeepForTooltip" = "Automatically remove unpinned items older than this many days.\n0 disables the time-based limit.\nDefault: 0.";
+"KeepForDisabled" = "Disabled";
+"KeepForDays" = "days";
 "SortBy" = "Sort by:";
 "LastCopiedAt" = "Time of last copy";
 "FirstCopiedAt" = "Time of first copy";

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -6,6 +6,7 @@ import Defaults
 class HistoryTests: XCTestCase {
   let savedSize = Defaults[.size]
   let savedSortBy = Defaults[.sortBy]
+  let savedKeepDays = Defaults[.historyKeepDays]
   let history = History.shared
 
   override func setUp() {
@@ -13,12 +14,14 @@ class HistoryTests: XCTestCase {
     history.clearAll()
     Defaults[.size] = 10
     Defaults[.sortBy] = .firstCopiedAt
+    Defaults[.historyKeepDays] = 0
   }
 
   override func tearDown() {
     super.tearDown()
     Defaults[.size] = savedSize
     Defaults[.sortBy] = savedSortBy
+    Defaults[.historyKeepDays] = savedKeepDays
   }
 
   func testDefaultIsEmpty() {
@@ -231,6 +234,52 @@ class HistoryTests: XCTestCase {
     let bar = history.add(historyItem("bar"))
     history.delete(foo)
     XCTAssertEqual(history.items, [bar])
+  }
+
+  func testKeepForRemovesExpiredItems() {
+    let old = history.add(historyItem("old"))
+    let recent = history.add(historyItem("recent"))
+    old.item.lastCopiedAt = daysAgo(10)
+
+    Defaults[.historyKeepDays] = 7
+    history.purgeExpiredItems()
+
+    XCTAssertEqual(history.items, [recent])
+  }
+
+  func testKeepForPreservesRecentItems() {
+    let recent = history.add(historyItem("recent"))
+    recent.item.lastCopiedAt = daysAgo(3)
+
+    Defaults[.historyKeepDays] = 7
+    history.purgeExpiredItems()
+
+    XCTAssertEqual(history.items, [recent])
+  }
+
+  func testKeepForPreservesPinnedItems() {
+    let pinned = history.add(historyItem("pinned"))
+    pinned.togglePin()
+    pinned.item.lastCopiedAt = daysAgo(30)
+
+    Defaults[.historyKeepDays] = 7
+    history.purgeExpiredItems()
+
+    XCTAssertEqual(history.items, [pinned])
+  }
+
+  func testKeepForDisabledKeepsEverything() {
+    let old = history.add(historyItem("old"))
+    old.item.lastCopiedAt = daysAgo(100)
+
+    Defaults[.historyKeepDays] = 0
+    history.purgeExpiredItems()
+
+    XCTAssertEqual(history.items, [old])
+  }
+
+  private func daysAgo(_ days: Int) -> Date {
+    Calendar.current.date(byAdding: .day, value: -days, to: Date.now)!
   }
 
   private func historyItem(_ value: String) -> HistoryItem {


### PR DESCRIPTION
## Summary

Implements time-based history retention, as discussed in #368. A new optional setting, **Keep for** (`historyKeepDays`), automatically removes unpinned history items whose last copy is older than a configured number of days. Pinned items are never removed.

The setting defaults to `0`, which disables the time-based limit, so existing behaviour is unchanged unless the user opts in.

## Motivation

Per the discussion in #368, the maintainer noted that a time-based limit was desirable but should follow the in-memory storage work (#384). Because this implementation **deletes** expired items from the SwiftData store, it reduces the number of items loaded into memory over long-running sessions rather than adding to the footprint, so it also acts as a partial mitigation for the memory growth reported in #384 and #1240.

To keep the first iteration simple, format-specific retention (separate limits for text vs. images) is intentionally left out; it can be layered on later if there is demand.

## Changes

- `Defaults.Keys.historyKeepDays` (`Int`, default `0` = disabled).
- `History.purgeExpiredItems()` removes unpinned items with `lastCopiedAt` older than the cutoff. It is invoked:
  - on launch (`History.load()`),
  - after each new copy (`History.add()`),
  - when the setting changes, and
  - on an hourly timer, so the limit is enforced while the app stays open and idle (the case the count-based limit cannot cover).
- A **Keep for** control in the Storage settings pane, alongside Size, showing "Disabled" when set to `0`.
- English strings for the new control.
- Unit tests covering removal of expired items, preservation of recent and pinned items, and the disabled (`0`) case.

## Testing

- `xcodebuild ... build` succeeds.
- The new tests pass when run directly.
- The full `MaccyTests` run shows no new failures introduced by this change.

## Notes for reviewers

- The new tests are added to `HistoryTests`, which is currently listed under `skippedTests` in `Maccy.xctestplan`; they therefore will not run in CI as-is. They pass when the class is run directly. Happy to adjust the test plan if preferred.
- Only English (`en.lproj`) strings are included. The other localizations fall back to English until translated.
