### PR TITLE
Allow dragging an image item out to a file

### DIFF
--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -165,6 +165,18 @@ class HistoryItem {
     return NSImage(data: data)
   }
 
+  // PNG-encoded copy of the item's image, used when dragging it out to a file.
+  // Normalizes TIFF/JPEG/HEIC sources to PNG so the dropped file is always valid.
+  var pngImageData: Data? {
+    guard let image = image,
+          let tiff = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiff) else {
+      return nil
+    }
+
+    return bitmap.representation(using: .png, properties: [:])
+  }
+
   var rtfData: Data? { contentData([.rtf]) }
   var rtf: NSAttributedString? {
     guard let data = rtfData else {

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -3,6 +3,7 @@ import Defaults
 import Foundation
 import Observation
 import Sauce
+import UniformTypeIdentifiers
 
 @Observable
 class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
@@ -40,6 +41,40 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   }
 
   var hasImage: Bool { item.image != nil }
+
+  // Drag payload that materializes the image as a PNG file at the drop
+  // destination (e.g. a Finder folder). A file representation lets this work
+  // inside the app sandbox without requesting extra file-access entitlements.
+  func imageFileItemProvider() -> NSItemProvider {
+    let provider = NSItemProvider()
+    let fileName = "\(title.isEmpty ? "Image" : title.replacingOccurrences(of: "/", with: "-")).png"
+    provider.suggestedName = fileName
+    provider.registerFileRepresentation(
+      forTypeIdentifier: UTType.png.identifier,
+      fileOptions: [],
+      visibility: .all
+    ) { [weak self] completion in
+      guard let data = self?.item.pngImageData else {
+        completion(nil, false, CocoaError(.fileWriteUnknown))
+        return nil
+      }
+
+      do {
+        let directory = FileManager.default.temporaryDirectory
+          .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(fileName)
+        try data.write(to: url)
+        completion(url, false, nil)
+      } catch {
+        completion(nil, false, error)
+      }
+
+      return nil
+    }
+
+    return provider
+  }
 
   var previewImageGenerationTask: Task<(), Error>?
   var thumbnailImageGenerationTask: Task<(), Error>?

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -32,6 +32,32 @@ struct HistoryItemView: View {
   @Environment(AppState.self) private var appState
 
   var body: some View {
+    row
+    .onAppear {
+      item.ensureThumbnailImage()
+    }
+    .onTapGesture {
+      if NSEvent.modifierFlags.contains(.command) && appState.multiSelectionEnabled {
+        appState.navigator.addToSelection(item: item)
+      } else {
+        Task {
+          appState.history.select(item)
+        }
+      }
+    }
+  }
+
+  // Image items can be dragged out as a PNG file (e.g. into a Finder folder).
+  @ViewBuilder
+  private var row: some View {
+    if item.hasImage {
+      listItem.onDrag { item.imageFileItemProvider() }
+    } else {
+      listItem
+    }
+  }
+
+  private var listItem: some View {
     ListItemView(
       id: item.id,
       selectionId: item.id,
@@ -45,18 +71,6 @@ struct HistoryItemView: View {
       selectionAppearance: selectionAppearance
     ) {
       Text(verbatim: item.title)
-    }
-    .onAppear {
-      item.ensureThumbnailImage()
-    }
-    .onTapGesture {
-      if NSEvent.modifierFlags.contains(.command) && appState.multiSelectionEnabled {
-        appState.navigator.addToSelection(item: item)
-      } else {
-        Task {
-          appState.history.select(item)
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
## What

Adds drag-and-drop support for image items: you can now drag an image out of Maccy's history into Finder (or any destination that accepts files), and it is written to disk as a PNG.

This addresses #761 (and is the practical answer to the recurring "save/paste image to a file/folder" requests, e.g. #1245 / the dupe #1259) — Maccy stores images but previously had no way to get a copied image back out as a file.

## How

- `HistoryItem.pngImageData` — a PNG-encoded copy of the item's image, normalizing TIFF/JPEG/HEIC sources to PNG so the dropped file is always valid.
- `HistoryItemDecorator.imageFileItemProvider()` — builds an `NSItemProvider` using a **file representation**. This is the sandbox-friendly mechanism: the system grants write access to the drop destination, so **no new entitlements are required**. The PNG is written to a unique temp directory per drag.
- `HistoryItemView` — attaches `.onDrag` only when the item actually contains an image (`item.hasImage`). Text and file items are completely unaffected.

No UI strings were added (drag has no label), so there are no localization changes.

## Testing

- `xcodebuild -scheme Maccy` builds cleanly (Debug, macOS 14 deployment target).
- Verified the drag payload programmatically by exercising the same API Finder uses on drop (`loadFileRepresentation(forTypeIdentifier: "public.png")`): it yields an `Image.png` file whose contents have valid PNG signature bytes.
- I have **not** yet done a live drag-into-Finder test on a running build — would appreciate a maintainer sanity-checking the actual gesture, or I can follow up with a confirmation.

## Notes

- Dropped files are named after the item's title (falling back to `Image.png`). Happy to adjust the naming scheme (e.g. include dimensions or a timestamp) if preferred.