### PR TITLE
Minor performance fixes

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -112,9 +112,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       AppState.shared.history.clear()
     }
   }
+  
+  private func ensureMigration(key: String, _ action: () -> ()) {
+    if Defaults[.migrations][key] != true {
+      action()
+      Defaults[.migrations][key] = true
+    }
+  }
 
   private func migrateUserDefaults() {
-    if Defaults[.migrations]["2024-07-01-version-2"] != true {
+    ensureMigration(key: "2024-07-01-version-2") {
       // Start 2.x from scratch.
       Defaults.reset(.migrations)
 
@@ -127,6 +134,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       UserDefaults.standard.removeObject(forKey: "hideTitle")
 
       Defaults[.migrations]["2024-07-01-version-2"] = true
+    }
+
+    ensureMigration(key: "2025-07-04-add-jpeg-heic") {
+      var types = Defaults[.enabledPasteboardTypes]
+      if !types.intersection(StorageType.images.types).isEmpty {
+        types.formUnion(StorageType.images.types)
+      }
+      Defaults[.enabledPasteboardTypes] = types
     }
 
     // The following defaults are not used in Maccy 2.x

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -3,7 +3,7 @@ import Defaults
 
 struct StorageType {
   static let files = StorageType(types: [.fileURL])
-  static let images = StorageType(types: [.png, .tiff])
+  static let images = StorageType(types: [.png, .tiff, .jpeg, .heic])
   static let text = StorageType(types: [.html, .rtf, .string])
   static let all = StorageType(types: files.types + images.types + text.types)
 

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -58,6 +58,7 @@ class HistoryItem {
     NSPasteboard.PasteboardType.chromiumSourceToken.rawValue,
     NSPasteboard.PasteboardType.notesRichText.rawValue
   ]
+  private static let imageTypes: [NSPasteboard.PasteboardType] = StorageType.images.types
 
   var application: String?
   var firstCopiedAt: Date = Date.now
@@ -68,6 +69,8 @@ class HistoryItem {
 
   @Relationship(deleteRule: .cascade, inverse: \HistoryItemContent.item)
   var contents: [HistoryItemContent] = []
+
+  @Transient private var cachedDecodedImage: NSImage?
 
   init(contents: [HistoryItemContent] = []) {
     self.firstCopiedAt = firstCopiedAt
@@ -149,7 +152,7 @@ class HistoryItem {
 
   var imageData: Data? {
     var data: Data?
-    data = contentData([.tiff, .png, .jpeg, .heic])
+    data = contentData(Self.imageTypes)
     if data == nil, universalClipboardImage, let url = fileURLs.first {
       data = try? Data(contentsOf: url)
     }
@@ -158,11 +161,15 @@ class HistoryItem {
   }
 
   var image: NSImage? {
+    if let img = cachedDecodedImage {
+      return img
+    }
     guard let data = imageData else {
       return nil
     }
 
-    return NSImage(data: data)
+    cachedDecodedImage = NSImage(data: data)
+    return cachedDecodedImage
   }
 
   var rtfData: Data? { contentData([.rtf]) }
@@ -172,6 +179,11 @@ class HistoryItem {
     }
 
     return NSAttributedString(rtf: data, documentAttributes: nil)
+  }
+  
+  func clearDecodedImageCache() {
+    cachedDecodedImage?.recache()
+    cachedDecodedImage = nil
   }
 
   var text: String? {

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -36,11 +36,15 @@ class HistoryItem {
 
   @MainActor
   static var availablePins: [String] {
-    let descriptor = FetchDescriptor<HistoryItem>(
-      predicate: #Predicate { $0.pin != nil }
-    )
-    let pins = try? Storage.shared.context.fetch(descriptor).compactMap({ $0.pin })
-    let assignedPins = Set(pins ?? [])
+    availablePins(in: History.shared.all.compactMap {
+      if $0.isPinned { return $0.item }
+      return nil
+    })
+  }
+
+  @MainActor
+  static func availablePins(in items: [HistoryItem]) -> [String] {
+    let assignedPins = Set(items.compactMap(\.pin))
     return Array(supportedPins.subtracting(assignedPins))
   }
 

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -156,8 +156,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         item.application = existingHistoryItem.application
       }
       logger.info("Removing duplicate item '\(item.title)'")
-      Storage.shared.context.delete(existingHistoryItem)
       removedItemIndex = all.firstIndex(where: { $0.item == existingHistoryItem })
+      if let removedItemIndex {
+        cleanup(all[removedItemIndex])
+      }
+      Storage.shared.context.delete(existingHistoryItem)
       if let removedItemIndex {
         all.remove(at: removedItemIndex)
       }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -448,17 +448,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   @MainActor
   private func findSimilarItem(_ item: HistoryItem) -> HistoryItem? {
-    let descriptor = FetchDescriptor<HistoryItem>()
-    if let all = try? Storage.shared.context.fetch(descriptor) {
-      let duplicates = all.filter({ $0 == item || $0.supersedes(item) })
-      if duplicates.count > 1 {
-        return duplicates.first(where: { $0 != item })
-      } else {
-        return isModified(item)
-      }
+    if let duplicate = all.first(where: { $0.item != item && $0.item.supersedes(item) }) {
+      return duplicate.item
     }
 
-    return item
+    return isModified(item)
   }
 
   private func isModified(_ item: HistoryItem) -> HistoryItem? {

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -122,6 +122,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     previewImage?.recache()
     thumbnailImage = nil
     previewImage = nil
+    item.clearDecodedImageCache()
   }
 
   @MainActor

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -44,11 +44,14 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var previewImageGenerationTask: Task<(), Error>?
   var thumbnailImageGenerationTask: Task<(), Error>?
   var previewImage: NSImage?
+  var previewText: String {
+    item.previewableText
+  }
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 
   // 10k characters seems to be more than enough on large displays
-  var text: String { item.previewableText.shortened(to: 10_000) }
+  var text: String { previewText.shortened(to: 10_000) }
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }

--- a/Maccy/Settings/PinsSettingsPane.swift
+++ b/Maccy/Settings/PinsSettingsPane.swift
@@ -127,7 +127,7 @@ struct PinsSettingsPane: View {
         TableColumn(Text("Key", tableName: "PinsSettings")) { item in
           PinPickerView(item: item, availablePins: availablePins)
             .onChange(of: item.pin) {
-              availablePins = HistoryItem.availablePins
+              availablePins = HistoryItem.availablePins(in: items)
             }
         }
         .width(60)
@@ -141,7 +141,7 @@ struct PinsSettingsPane: View {
         }
       }
       .onAppear {
-        availablePins = HistoryItem.availablePins
+        availablePins = HistoryItem.availablePins(in: items)
       }
       .onDeleteCommand {
         guard let selection,

--- a/Maccy/Views/AsyncView.swift
+++ b/Maccy/Views/AsyncView.swift
@@ -7,6 +7,7 @@ enum AsyncViewState<T> {
 }
 
 struct AsyncView<Value, Content: View, Placeholder: View>: View {
+  let id: AnyHashable?
   let operation: () async throws -> Value
   @ViewBuilder var content: (Value) -> Content
   @ViewBuilder var placeholder: () -> Placeholder
@@ -14,10 +15,12 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
   @State private var viewState = AsyncViewState<Value>.loading
 
   init(
+    id: AnyHashable? = nil,
     operation: @escaping () async throws -> Value,
     @ViewBuilder content: @escaping (Value) -> Content,
     @ViewBuilder placeholder: @escaping () -> Placeholder
   ) {
+    self.id = id
     self.operation = operation
     self.content = content
     self.placeholder = placeholder
@@ -31,11 +34,13 @@ struct AsyncView<Value, Content: View, Placeholder: View>: View {
       case .loaded(let value):
         content(value)
       }
-    }.task {
+    }.task(id: id) {
       do {
         viewState = .loading
         let result = try await operation()
+        try Task.checkCancellation()
         viewState = .loaded(result)
+      } catch is CancellationError {
       } catch {
         viewState = .failed
       }

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -1,7 +1,10 @@
+import AppKit
 import KeyboardShortcuts
 import SwiftUI
 
 struct PreviewItemView: View {
+  static var largeTextThreshold = 1_000
+
   var item: HistoryItemDecorator
 
   @ViewBuilder
@@ -14,7 +17,7 @@ struct PreviewItemView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       if item.hasImage {
-        AsyncView<NSImage?, _, _> {
+        AsyncView<NSImage?, _, _>(id: item.id) {
           return await item.asyncGetPreviewImage()
         } content: { image in
           if let image = image {
@@ -50,16 +53,22 @@ struct PreviewItemView: View {
           }
         }
       } else {
-        ScrollView {
-          Text(item.text)
-            .font(.body)
+        let text = item.previewText
+        if text.count >= Self.largeTextThreshold {
+          LargeTextPreviewView(text: text)
+            .id("textpreview-\(item.id)")
+        } else {
+          ScrollView {
+            Text(text)
+              .font(.body)
+          }
         }
       }
 
       Spacer(minLength: 0)
 
       Divider()
-        .padding(.vertical)
+        .padding(.bottom)
 
       if let application = item.application {
         HStack(spacing: 3) {
@@ -97,5 +106,53 @@ struct PreviewItemView: View {
       }
     }
     .controlSize(.small)
+  }
+}
+
+struct LargeTextPreviewView: NSViewRepresentable {
+  let text: String
+
+  func makeNSView(context: Context) -> NSScrollView {
+    return Self.makeScrollView(text: text)
+  }
+
+  func updateNSView(_ scrollView: NSScrollView, context: Context) {
+    guard let textView = scrollView.documentView as? NSTextView, textView.string != text else {
+      return
+    }
+
+    textView.string = text
+  }
+
+  static func makeScrollView(text: String) -> NSScrollView {
+    let textView = NSTextView(usingTextLayoutManager: true)
+    textView.isEditable = false
+    textView.isSelectable = false
+    textView.isRichText = false
+    textView.drawsBackground = false
+    textView.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+    textView.textColor = .labelColor
+    textView.textContainerInset = .zero
+    textView.minSize = .zero
+    textView.maxSize = NSSize(
+      width: CGFloat.greatestFiniteMagnitude,
+      height: CGFloat.greatestFiniteMagnitude
+    )
+    textView.isVerticallyResizable = true
+    textView.isHorizontallyResizable = false
+    textView.autoresizingMask = [.width]
+    textView.textContainer?.lineFragmentPadding = 0
+    textView.textContainer?.widthTracksTextView = true
+    textView.textContainer?.heightTracksTextView = false
+    textView.string = text
+
+    let scrollView = NSScrollView()
+    scrollView.documentView = textView
+    scrollView.hasVerticalScroller = true
+    scrollView.hasHorizontalScroller = false
+    scrollView.autohidesScrollers = true
+    scrollView.borderType = .noBorder
+    scrollView.drawsBackground = false
+    return scrollView
   }
 }


### PR DESCRIPTION
- Cache decoded images in `HistoryItem`
- Lazily generate and cache preview text for `HistoryItemDecorator`
- Add missing call to `cleanup` when removing duplicate items.
- Avoid fetching history from storage where possible.