### PR TITLE
Fix testCopyString asserting against the wrong pasteboard type

### DIFF
--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -226,7 +226,7 @@ class ClipboardTests: XCTestCase {
   func testCopyString() {
     clipboard.copyInMaccy("foo")
     XCTAssertEqual(pasteboard.string(forType: .string), "foo")
-    XCTAssertEqual(pasteboard.string(forType: .string), NSPasteboard.PasteboardType.fromMaccy.rawValue)
+    XCTAssertEqual(pasteboard.string(forType: .source), NSPasteboard.PasteboardType.fromMaccy.rawValue)
   }
 
   @MainActor


### PR DESCRIPTION
## Summary

The `ClipboardTests.testCopyString` unit test could never pass as written. This PR
fixes that failing assertion.

Its second assertion re-read the `.string` pasteboard type and compared the copied
text (`"foo"`) to the `fromMaccy` type identifier (`org.p0deje.Maccy`) — two values
that are never equal, so the test failed deterministically.

`copyInMaccy` stamps the source app's bundle identifier into the `.source` pasteboard
type, and for an in-app copy that value is Maccy's own bundle id, which is the same
string as `NSPasteboard.PasteboardType.fromMaccy.rawValue`. Asserting against `.source`
checks the intended behaviour and mirrors `testCopy`, which already asserts that
`.source` carries the originating app's bundle id.

