### PR TITLE
Custom pin reordering through drag and drop and new item editor

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		2F578C422EFFE8920088B759 /* SlideoutContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F578C402EFFE8920088B759 /* SlideoutContentView.swift */; };
 		2F578C432EFFE8920088B759 /* SlideoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F578C412EFFE8920088B759 /* SlideoutView.swift */; };
 		2F59CC4C302B580300136053 /* Array+MoveElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59CC4B302B57FC00136053 /* Array+MoveElements.swift */; };
+		2F8A0DBE303A1FA0004BA51F /* ConcatenatedCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A0DBD303A1F9D004BA51F /* ConcatenatedCollection.swift */; };
 		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
 		2F9B42EF2F1A494C006548E5 /* ListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9B42EE2F1A4948006548E5 /* ListHeaderView.swift */; };
 		2F9B42F12F1A499D006548E5 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9B42F02F1A4999006548E5 /* ToolbarView.swift */; };
@@ -215,6 +216,7 @@
 		2F578C402EFFE8920088B759 /* SlideoutContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutContentView.swift; sourceTree = "<group>"; };
 		2F578C412EFFE8920088B759 /* SlideoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutView.swift; sourceTree = "<group>"; };
 		2F59CC4B302B57FC00136053 /* Array+MoveElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+MoveElements.swift"; sourceTree = "<group>"; };
+		2F8A0DBD303A1F9D004BA51F /* ConcatenatedCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConcatenatedCollection.swift; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2F9B42EE2F1A4948006548E5 /* ListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListHeaderView.swift; sourceTree = "<group>"; };
 		2F9B42F02F1A4999006548E5 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
@@ -867,6 +869,7 @@
 				DA555F072CF0F98F009608BD /* ApplicationImageCache.swift */,
 				DA0EF1871E444B2A00E58577 /* Clipboard.swift */,
 				DAE284FF232257D20080E394 /* ColorImage.swift */,
+				2F8A0DBD303A1F9D004BA51F /* ConcatenatedCollection.swift */,
 				DAA54BF92C3C951900B7FDD8 /* FloatingPanel.swift */,
 				DA689FC92C1D18890009B887 /* HighlightMatch.swift */,
 				DA1969202C3F6C6800258481 /* HistoryItemAction.swift */,
@@ -1151,6 +1154,7 @@
 				DAA072E72C423617006DDFD2 /* NSSize+DefaultsSerializable.swift in Sources */,
 				DA9C3C452C207AF80056795D /* IgnoreSettingsPane.swift in Sources */,
 				DA13D7D82C1A223E00FA9E23 /* Select.swift in Sources */,
+				2F8A0DBE303A1FA0004BA51F /* ConcatenatedCollection.swift in Sources */,
 				DA689FC82C1D15140009B887 /* PinsPosition.swift in Sources */,
 				2FD5DE512FFE6DD50023FF60 /* LegacyReorderableContainer.swift in Sources */,
 				2F9B42EF2F1A494C006548E5 /* ListHeaderView.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
-		2F0E055F2FFD2EB300CCD1DE /* ReorderableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0E055E2FFD2EAF00CCD1DE /* ReorderableContainer.swift */; };
 		21FFF308D9217B43FD4C393F /* VoiceOver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21DCA6C3D17E48D33D6E608 /* VoiceOver.swift */; };
+		2F0E055F2FFD2EB300CCD1DE /* ReorderableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0E055E2FFD2EAF00CCD1DE /* ReorderableContainer.swift */; };
 		2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */; };
 		2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77A2E772899003E2EA9 /* PinsView.swift */; };
 		2F0EC77D2E773314003E2EA9 /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77C2E773314003E2EA9 /* Selection.swift */; };
@@ -245,17 +245,17 @@
 		67B1B7B16C214A9A8146309C /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/GeneralSettings.strings; sourceTree = "<group>"; };
 		72C94C4B662B4F0BBD150C82 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7CEEFDF124F41F8500ECAD2A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		9DC045710F4F8773D1A5EC87 /* View+Invisible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Invisible.swift"; sourceTree = "<group>"; };
 		82BF523B9E3C48AE8C38EB5B /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/GeneralSettings.strings; sourceTree = "<group>"; };
 		9C200975CB6B4E258D86BCA2 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/PreviewItemView.strings; sourceTree = "<group>"; };
+		9DC045710F4F8773D1A5EC87 /* View+Invisible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Invisible.swift"; sourceTree = "<group>"; };
 		ABC72863283A9053001EE086 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B21DCA6C3D17E48D33D6E608 /* VoiceOver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOver.swift; sourceTree = "<group>"; };
 		BA40A81B03FF445A83CCD4E7 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/IgnoreSettings.strings; sourceTree = "<group>"; };
 		BC59C5474269463B8A32BCEF /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AppearanceSettings.strings; sourceTree = "<group>"; };
 		C0FFEE000000000000000004 /* ShortenedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortenedTests.swift; sourceTree = "<group>"; };
 		C2BC0DBD627544668E9BE9C1 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/StorageSettings.strings; sourceTree = "<group>"; };
 		CA110ED10000000000000002 /* CollectionSurroundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSurroundingTests.swift; sourceTree = "<group>"; };
 		CF8FD822BE40469D80B10A06 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AdvancedSettings.strings; sourceTree = "<group>"; };
-		B21DCA6C3D17E48D33D6E608 /* VoiceOver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOver.swift; sourceTree = "<group>"; };
 		DA00992C256411F90030E697 /* appcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = appcast.xml; sourceTree = "<group>"; };
 		DA00992D256411F90030E697 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DA00992F256411F90030E697 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -591,8 +591,8 @@
 		DAFE2DD9268A521A00990986 /* String+Shortened.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Shortened.swift"; sourceTree = "<group>"; };
 		DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemTests.swift; sourceTree = "<group>"; };
 		DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardShortcuts.Name+Shortcuts.swift"; sourceTree = "<group>"; };
-		EB2945CD7912BE7C7D330C27 /* View+ButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ButtonAction.swift"; sourceTree = "<group>"; };
 		E5885F0587B04A99933245E6 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/AdvancedSettings.strings; sourceTree = "<group>"; };
+		EB2945CD7912BE7C7D330C27 /* View+ButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ButtonAction.swift"; sourceTree = "<group>"; };
 		F2E5FA9061DA4866BCFAFE90 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/AppearanceSettings.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -131,7 +131,6 @@
 		DAA072E32C41D1D5006DDFD2 /* ListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA072E22C41D1D5006DDFD2 /* ListItemView.swift */; };
 		DAA072E72C423617006DDFD2 /* NSSize+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA072E62C423617006DDFD2 /* NSSize+DefaultsSerializable.swift */; };
 		DAA072E92C42C6AA006DDFD2 /* ListItemTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA072E82C42C6AA006DDFD2 /* ListItemTitleView.swift */; };
-		DAA365CE2C4BF9DD00A394F8 /* PinsSettingsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA365CD2C4BF9DD00A394F8 /* PinsSettingsPane.swift */; };
 		DAA365D12C4C147400A394F8 /* PinsSettings.strings in Resources */ = {isa = PBXBuildFile; fileRef = DAA365CF2C4C147400A394F8 /* PinsSettings.strings */; };
 		DAA365E72C4C57E600A394F8 /* KeyEquivalent+Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA365E62C4C57E600A394F8 /* KeyEquivalent+Keys.swift */; };
 		DAA54BFA2C3C951900B7FDD8 /* FloatingPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA54BF92C3C951900B7FDD8 /* FloatingPanel.swift */; };
@@ -493,7 +492,6 @@
 		DAA072E62C423617006DDFD2 /* NSSize+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSSize+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		DAA072E82C42C6AA006DDFD2 /* ListItemTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTitleView.swift; sourceTree = "<group>"; };
 		DAA2BDCE24676CA7007FE090 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
-		DAA365CD2C4BF9DD00A394F8 /* PinsSettingsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsSettingsPane.swift; sourceTree = "<group>"; };
 		DAA365D02C4C147400A394F8 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/PinsSettings.strings; sourceTree = "<group>"; };
 		DAA365D22C4C147C00A394F8 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/PinsSettings.strings; sourceTree = "<group>"; };
 		DAA365D32C4C147D00A394F8 /* bs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/PinsSettings.strings; sourceTree = "<group>"; };
@@ -694,7 +692,6 @@
 				DA9C3C482C20D4B40056795D /* IgnoreSettings.strings */,
 				DA44C5E32C1C858400819834 /* StorageSettingsPane.swift */,
 				DA689FAE2C1CD3B00009B887 /* StorageSettings.strings */,
-				DAA365CD2C4BF9DD00A394F8 /* PinsSettingsPane.swift */,
 				DAA365CF2C4C147400A394F8 /* PinsSettings.strings */,
 			);
 			path = Settings;
@@ -1217,7 +1214,6 @@
 				DA0FFA2A2C8D100C00A66C97 /* ModifierFlags+Description.swift in Sources */,
 				DAEE38471E3DBEB100DD2966 /* AppDelegate.swift in Sources */,
 				DAA072DF2C41C63C006DDFD2 /* ConfirmationView.swift in Sources */,
-				DAA365CE2C4BF9DD00A394F8 /* PinsSettingsPane.swift in Sources */,
 				DA3BCB8E2C3E015000B01BC1 /* ModifierFlags.swift in Sources */,
 				DA181177247D14DA00066D55 /* Settings.PaneIdentifier+Panes.swift in Sources */,
 				DA3BCB942C3EECBB00B01BC1 /* HistoryItemDecorator.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABDD5112BB47F1E0054963B /* NSWorkspace+ApplicationName.swift */; };
+		2F0E055F2FFD2EB300CCD1DE /* ReorderableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0E055E2FFD2EAF00CCD1DE /* ReorderableContainer.swift */; };
 		21FFF308D9217B43FD4C393F /* VoiceOver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21DCA6C3D17E48D33D6E608 /* VoiceOver.swift */; };
 		2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */; };
 		2F0EC77B2E772899003E2EA9 /* PinsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0EC77A2E772899003E2EA9 /* PinsView.swift */; };
@@ -33,7 +34,10 @@
 		2F9B42F12F1A499D006548E5 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9B42F02F1A4999006548E5 /* ToolbarView.swift */; };
 		2FA81FE02E43D9B700C12F92 /* Dictionary+RemoveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */; };
 		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
+		2FD4993E2FFBA57800149F02 /* PinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD4993D2FFBA57400149F02 /* PinManager.swift */; };
+		2FD499452FFC489400149F02 /* MovableByWindowBackgroundModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD499442FFC487F00149F02 /* MovableByWindowBackgroundModifier.swift */; };
 		2FD499472FFC4AEF00149F02 /* ItemEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD499462FFC4AEF00149F02 /* ItemEditorView.swift */; };
+		2FD5DE512FFE6DD50023FF60 /* LegacyReorderableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD5DE502FFE6DCE0023FF60 /* LegacyReorderableContainer.swift */; };
 		2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94D2E774B570093D72C /* NavigationManager.swift */; };
 		2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94F2E7808420093D72C /* AppImageView.swift */; };
 		42E9C329301B7F9C00B6B55B /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 42E9C328301B7F9C00B6B55B /* AppIcon.icon */; };
@@ -192,6 +196,7 @@
 		11EB892C281DADFF00A78CB4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2BA57666588D49AFA9B68B93 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PreviewItemView.strings; sourceTree = "<group>"; };
 		2C2CB1D293534FF0958B3C90 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/IgnoreSettings.strings; sourceTree = "<group>"; };
+		2F0E055E2FFD2EAF00CCD1DE /* ReorderableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReorderableContainer.swift; sourceTree = "<group>"; };
 		2F0EC7782E7727E3003E2EA9 /* HeightReaderModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightReaderModifier.swift; sourceTree = "<group>"; };
 		2F0EC77A2E772899003E2EA9 /* PinsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinsView.swift; sourceTree = "<group>"; };
 		2F0EC77C2E773314003E2EA9 /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
@@ -213,7 +218,10 @@
 		2F9B42F02F1A4999006548E5 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
+		2FD4993D2FFBA57400149F02 /* PinManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinManager.swift; sourceTree = "<group>"; };
+		2FD499442FFC487F00149F02 /* MovableByWindowBackgroundModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovableByWindowBackgroundModifier.swift; sourceTree = "<group>"; };
 		2FD499462FFC4AEF00149F02 /* ItemEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemEditorView.swift; sourceTree = "<group>"; };
+		2FD5DE502FFE6DCE0023FF60 /* LegacyReorderableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyReorderableContainer.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
 		37AC3B8902CB40CA8294C336 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -700,6 +708,9 @@
 		DA19690C2C3EEF9300258481 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2FD5DE502FFE6DCE0023FF60 /* LegacyReorderableContainer.swift */,
+				2F0E055E2FFD2EAF00CCD1DE /* ReorderableContainer.swift */,
+				2FD499442FFC487F00149F02 /* MovableByWindowBackgroundModifier.swift */,
 				2F1091D62F2B6E8100F5C454 /* AsyncView.swift */,
 				2FF2E94F2E7808420093D72C /* AppImageView.swift */,
 				DAA072DE2C41C63C006DDFD2 /* ConfirmationView.swift */,
@@ -772,6 +783,7 @@
 				DA3BCB912C3EEC3C00B01BC1 /* History.swift */,
 				DA3BCB932C3EECBB00B01BC1 /* HistoryItemDecorator.swift */,
 				DA3BCB8D2C3E015000B01BC1 /* ModifierFlags.swift */,
+				2FD4993D2FFBA57400149F02 /* PinManager.swift */,
 				DAE8F5D32C43262B00851CA9 /* Popup.swift */,
 				2F578C3E2EFFE8720088B759 /* SlideoutController.swift */,
 			);
@@ -1137,6 +1149,7 @@
 				DA9C3C452C207AF80056795D /* IgnoreSettingsPane.swift in Sources */,
 				DA13D7D82C1A223E00FA9E23 /* Select.swift in Sources */,
 				DA689FC82C1D15140009B887 /* PinsPosition.swift in Sources */,
+				2FD5DE512FFE6DD50023FF60 /* LegacyReorderableContainer.swift in Sources */,
 				2F9B42EF2F1A494C006548E5 /* ListHeaderView.swift in Sources */,
 				DA13D7D92C1A223E00FA9E23 /* Get.swift in Sources */,
 				2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */,
@@ -1161,6 +1174,7 @@
 				DA0EF1881E444B2A00E58577 /* Clipboard.swift in Sources */,
 				DA3F1B452C90084600267632 /* Sauce+KeyboardShortcuts.swift in Sources */,
 				DA689FCC2C1D1D510009B887 /* MenuIcon.swift in Sources */,
+				2FD499452FFC489400149F02 /* MovableByWindowBackgroundModifier.swift in Sources */,
 				DAAEB196219694AE00A7883C /* About.swift in Sources */,
 				DA6D98E22AEABE03008A77CE /* Accessibility.swift in Sources */,
 				2F0EC7792E7727E3003E2EA9 /* HeightReaderModifier.swift in Sources */,
@@ -1168,6 +1182,7 @@
 				DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */,
 				DA1969212C3F6C6800258481 /* HistoryItemAction.swift in Sources */,
 				0ABDD5122BB47F1E0054963B /* NSWorkspace+ApplicationName.swift in Sources */,
+				2F0E055F2FFD2EB300CCD1DE /* ReorderableContainer.swift in Sources */,
 				DA19691A2C3F369800258481 /* HeaderView.swift in Sources */,
 				DA555F082CF0F994009608BD /* ApplicationImageCache.swift in Sources */,
 				DA44C5E42C1C858400819834 /* StorageSettingsPane.swift in Sources */,
@@ -1196,6 +1211,7 @@
 				DA9C3C5E2C20E1190056795D /* IgnoreApplicationsSettingsView.swift in Sources */,
 				2F0EC7872E774099003E2EA9 /* PasteStackItemView.swift in Sources */,
 				DA20FA722B082DD600056DD5 /* Notifier.swift in Sources */,
+				2FD4993E2FFBA57800149F02 /* PinManager.swift in Sources */,
 				2F578C3F2EFFE8720088B759 /* SlideoutController.swift in Sources */,
 				DAA072DB2C41C5DD006DDFD2 /* FooterItem.swift in Sources */,
 				DA689FC62C1D14F10009B887 /* PopupPosition.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		2F578C3F2EFFE8720088B759 /* SlideoutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F578C3E2EFFE8720088B759 /* SlideoutController.swift */; };
 		2F578C422EFFE8920088B759 /* SlideoutContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F578C402EFFE8920088B759 /* SlideoutContentView.swift */; };
 		2F578C432EFFE8920088B759 /* SlideoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F578C412EFFE8920088B759 /* SlideoutView.swift */; };
+		2F59CC4C302B580300136053 /* Array+MoveElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59CC4B302B57FC00136053 /* Array+MoveElements.swift */; };
 		2F8B9DE62C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */; };
 		2F9B42EF2F1A494C006548E5 /* ListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9B42EE2F1A4948006548E5 /* ListHeaderView.swift */; };
 		2F9B42F12F1A499D006548E5 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9B42F02F1A4999006548E5 /* ToolbarView.swift */; };
@@ -213,6 +214,7 @@
 		2F578C3E2EFFE8720088B759 /* SlideoutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutController.swift; sourceTree = "<group>"; };
 		2F578C402EFFE8920088B759 /* SlideoutContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutContentView.swift; sourceTree = "<group>"; };
 		2F578C412EFFE8920088B759 /* SlideoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutView.swift; sourceTree = "<group>"; };
+		2F59CC4B302B57FC00136053 /* Array+MoveElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+MoveElements.swift"; sourceTree = "<group>"; };
 		2F8B9DE52C5D6E5D0046EF69 /* NSPoint+DefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+DefaultsSerializable.swift"; sourceTree = "<group>"; };
 		2F9B42EE2F1A4948006548E5 /* ListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListHeaderView.swift; sourceTree = "<group>"; };
 		2F9B42F02F1A4999006548E5 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
@@ -632,6 +634,7 @@
 		2FBB7A252B5FECBB00C65BBE /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				2F59CC4B302B57FC00136053 /* Array+MoveElements.swift */,
 				2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */,
 				DA19691B2C3F3EAC00258481 /* Collection+Surrounding.swift */,
 				DAA072D22C40A961006DDFD2 /* Color+Random.swift */,
@@ -1233,6 +1236,7 @@
 				DA3BCB8E2C3E015000B01BC1 /* ModifierFlags.swift in Sources */,
 				DA181177247D14DA00066D55 /* Settings.PaneIdentifier+Panes.swift in Sources */,
 				DA3BCB942C3EECBB00B01BC1 /* HistoryItemDecorator.swift in Sources */,
+				2F59CC4C302B580300136053 /* Array+MoveElements.swift in Sources */,
 				DAE28500232257D20080E394 /* ColorImage.swift in Sources */,
 				DA7A753E26A52F0F00DC16EF /* NSImage+Names.swift in Sources */,
 				2F0EC7852E774083003E2EA9 /* PasteStackView.swift in Sources */,

--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2F9B42F12F1A499D006548E5 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9B42F02F1A4999006548E5 /* ToolbarView.swift */; };
 		2FA81FE02E43D9B700C12F92 /* Dictionary+RemoveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */; };
 		2FB5BCA02CD8F73F008B33F4 /* ApplicationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */; };
+		2FD499472FFC4AEF00149F02 /* ItemEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD499462FFC4AEF00149F02 /* ItemEditorView.swift */; };
 		2FF2E94E2E774B5B0093D72C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94D2E774B570093D72C /* NavigationManager.swift */; };
 		2FF2E9502E7808470093D72C /* AppImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF2E94F2E7808420093D72C /* AppImageView.swift */; };
 		42E9C329301B7F9C00B6B55B /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 42E9C328301B7F9C00B6B55B /* AppIcon.icon */; };
@@ -213,6 +214,7 @@
 		2F9B42F02F1A4999006548E5 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
 		2FA81FDF2E43D9A600C12F92 /* Dictionary+RemoveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+RemoveItem.swift"; sourceTree = "<group>"; };
 		2FB5BC9F2CD8F73C008B33F4 /* ApplicationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationImage.swift; sourceTree = "<group>"; };
+		2FD499462FFC4AEF00149F02 /* ItemEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemEditorView.swift; sourceTree = "<group>"; };
 		2FF2E94D2E774B570093D72C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		2FF2E94F2E7808420093D72C /* AppImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppImageView.swift; sourceTree = "<group>"; };
 		37AC3B8902CB40CA8294C336 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -722,6 +724,7 @@
 				2F0EC7862E774093003E2EA9 /* PasteStackItemView.swift */,
 				2F162E7F2F1E7B28001FBAFF /* PasteStackPreviewView.swift */,
 				2F0EC7842E77407C003E2EA9 /* PasteStackView.swift */,
+				2FD499462FFC4AEF00149F02 /* ItemEditorView.swift */,
 				2F0EC77A2E772899003E2EA9 /* PinsView.swift */,
 				DA5E627E2C39E53F00F4C710 /* PreviewItemView.strings */,
 				DA1969132C3F11D600258481 /* PreviewItemView.swift */,
@@ -1128,6 +1131,7 @@
 				2F0EC7812E773F1D003E2EA9 /* PasteStack.swift in Sources */,
 				DA5078992CF2676B00215488 /* MouseMovedViewModifer.swift in Sources */,
 				DA19690E2C3EEFA900258481 /* KeyboardShortcutView.swift in Sources */,
+				2FD499472FFC4AEF00149F02 /* ItemEditorView.swift in Sources */,
 				DA243D122C2F64830012A27F /* ContentView.swift in Sources */,
 				DAD665662898A1C000975096 /* KeyChord.swift in Sources */,
 				DA689FC42C1CF0F00009B887 /* AppearanceSettingsPane.swift in Sources */,

--- a/Maccy/ConcatenatedCollection.swift
+++ b/Maccy/ConcatenatedCollection.swift
@@ -1,0 +1,45 @@
+/// A random-access view over two arrays that does not allocate combined storage.
+struct ConcatenatedCollection<Element>: RandomAccessCollection {
+  typealias Index = Int
+
+  private let leading: [Element]
+  private let trailing: [Element]
+
+  init(_ leading: [Element], _ trailing: [Element]) {
+    self.leading = leading
+    self.trailing = trailing
+  }
+
+  var startIndex: Int { 0 }
+  var endIndex: Int { leading.count + trailing.count }
+
+  subscript(position: Int) -> Element {
+    precondition(position >= startIndex && position < endIndex, "Index out of bounds")
+    if position < leading.count {
+      return leading[position]
+    }
+    return trailing[position - leading.count]
+  }
+
+  func index(after index: Int) -> Int {
+    index + 1
+  }
+
+  func index(before index: Int) -> Int {
+    index - 1
+  }
+
+  func index(_ index: Int, offsetBy distance: Int) -> Int {
+    index + distance
+  }
+
+  func distance(from start: Int, to end: Int) -> Int {
+    end - start
+  }
+
+  func toArray() -> [Element] {
+    leading + trailing
+  }
+}
+
+extension ConcatenatedCollection: Equatable where Element: Equatable {}

--- a/Maccy/Extensions/Array+MoveElements.swift
+++ b/Maccy/Extensions/Array+MoveElements.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+extension Array {
+  mutating func moveElements(
+    from source: IndexSet,
+    to destination: Int
+  ) {
+    let movingIndexes = source.sorted()
+    let movingElements = movingIndexes.compactMap {
+      indices.contains($0) ? self[$0] : nil
+    }
+    guard !movingElements.isEmpty else { return }
+
+    for index in movingIndexes.reversed() where indices.contains(index) {
+      remove(at: index)
+    }
+
+    let removedBeforeDestination = movingIndexes.filter { $0 < destination }
+      .count
+    let insertionIndex = Swift.max(
+      0,
+      Swift.min(destination - removedBeforeDestination, count)
+    )
+    insert(contentsOf: movingElements, at: insertionIndex)
+  }
+}

--- a/Maccy/Extensions/Collection+Surrounding.swift
+++ b/Maccy/Extensions/Collection+Surrounding.swift
@@ -49,7 +49,7 @@ extension Collection where Element: Equatable {
   }
 }
 
-extension Array where Element: Equatable {
+extension RandomAccessCollection where Element: Equatable {
   func nearest(to element: Element, where condition: (Element) -> Bool) -> Element? {
     guard let currentIndex = firstIndex(of: element) else {
       return nil
@@ -64,7 +64,7 @@ extension Array where Element: Equatable {
     case (.none, .some(let index)):
       return self[index]
     case (.some(let next), .some(let previous)):
-      return (next - currentIndex) <= (currentIndex - previous)
+      return distance(from: currentIndex, to: next) <= distance(from: previous, to: currentIndex)
       ? self[next]
       : self[previous]
     }

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -53,6 +53,7 @@ extension Defaults.Keys {
   static let migrations = Key<[String: Bool]>("migrations", default: [:], suite: preferencesSuite)
   static let numberOfUsages = Key<Int>("numberOfUsages", default: 0, suite: preferencesSuite)
   static let pasteByDefault = Key<Bool>("pasteByDefault", default: false, suite: preferencesSuite)
+  static let pinOrder = Key<PinOrder>("pinOrder", default: PinOrder(), suite: preferencesSuite)
   static let pinTo = Key<PinsPosition>("pinTo", default: .top, suite: preferencesSuite)
   static let popupPosition = Key<PopupPosition>("popupPosition", default: .cursor, suite: preferencesSuite)
   static let popupScreen = Key<Int>("popupScreen", default: 0, suite: preferencesSuite)

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -54,6 +54,7 @@ extension Defaults.Keys {
   static let numberOfUsages = Key<Int>("numberOfUsages", default: 0, suite: preferencesSuite)
   static let pasteByDefault = Key<Bool>("pasteByDefault", default: false, suite: preferencesSuite)
   static let pinOrder = Key<PinOrder>("pinOrder", default: PinOrder(), suite: preferencesSuite)
+  static let pinSortBy = Key<Sorter.PinBy>("pinSortBy", default: .lastCopiedAt, suite: preferencesSuite)
   static let pinTo = Key<PinsPosition>("pinTo", default: .top, suite: preferencesSuite)
   static let popupPosition = Key<PopupPosition>("popupPosition", default: .cursor, suite: preferencesSuite)
   static let popupScreen = Key<Int>("popupScreen", default: 0, suite: preferencesSuite)

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -54,7 +54,6 @@ extension Defaults.Keys {
   static let numberOfUsages = Key<Int>("numberOfUsages", default: 0, suite: preferencesSuite)
   static let pasteByDefault = Key<Bool>("pasteByDefault", default: false, suite: preferencesSuite)
   static let pinOrder = Key<PinOrder>("pinOrder", default: PinOrder(), suite: preferencesSuite)
-  static let pinSortBy = Key<Sorter.PinBy>("pinSortBy", default: .lastCopiedAt, suite: preferencesSuite)
   static let pinTo = Key<PinsPosition>("pinTo", default: .top, suite: preferencesSuite)
   static let popupPosition = Key<PopupPosition>("popupPosition", default: .cursor, suite: preferencesSuite)
   static let popupScreen = Key<Int>("popupScreen", default: 0, suite: preferencesSuite)

--- a/Maccy/Extensions/NSImage+Names.swift
+++ b/Maccy/Extensions/NSImage+Names.swift
@@ -4,7 +4,6 @@ extension NSImage {
   static let gearshape = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "gearshape")
   static let externaldrive = NSImage(systemSymbolName: "externaldrive", accessibilityDescription: "externaldrive")
   static let paintpalette = NSImage(systemSymbolName: "paintpalette", accessibilityDescription: "paintpalette")
-  static let pincircle = NSImage(systemSymbolName: "pin.circle", accessibilityDescription: "pin.cirlce")
   static let nosign = NSImage(systemSymbolName: "nosign", accessibilityDescription: "nosign")
   static let gearshape2 = NSImage(systemSymbolName: "gearshape.2", accessibilityDescription: "gearshape2")
 }

--- a/Maccy/Extensions/Settings.PaneIdentifier+Panes.swift
+++ b/Maccy/Extensions/Settings.PaneIdentifier+Panes.swift
@@ -5,6 +5,5 @@ extension Settings.PaneIdentifier {
   static let appearance = Self("appearance")
   static let general = Self("general")
   static let ignore = Self("ignore")
-  static let pins = Self("pins")
   static let storage = Self("storage")
 }

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -54,13 +54,17 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
     standardWindowButton(.zoomButton)?.isHidden = true
 
     contentView = NSHostingView(
-      rootView: view()
-        // The safe area is ignored because the title bar still interferes with the geometry
-        .ignoresSafeArea()
-        .gesture(DragGesture()
-          .onEnded { _ in
-            self.saveWindowPosition()
-        })
+      rootView: FloatingPanelRootView(
+        content: view(),
+        onWindowDragEnded: { [weak self] in
+          self?.saveWindowPosition()
+        },
+        onDragAndDropStateChange: { [weak self] isDragAndDropInProgress in
+          // At screenSaver level the drag preview is behind the popup, which prevents
+          // the drag-and-drop lifecycle from being triggered.
+          self?.level = isDragAndDropInProgress ? .popUpMenu : .screenSaver
+        }
+      )
     )
     applyRoundedCorners()
   }
@@ -232,5 +236,31 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
   // Allow text inputs inside the panel can receive focus
   override var canBecomeKey: Bool {
     return true
+  }
+}
+
+private struct FloatingPanelRootView<Content: View>: View {
+  @State private var appState = AppState.shared
+
+  let content: Content
+  let onWindowDragEnded: () -> Void
+  let onDragAndDropStateChange: (Bool) -> Void
+
+  var body: some View {
+    content
+      // The safe area is ignored because the title bar still interferes with the geometry
+      .ignoresSafeArea()
+      .gesture(
+        DragGesture()
+          .onEnded { _ in
+            onWindowDragEnded()
+          }
+      )
+      .onChange(
+        of: appState.navigator.isDragAndDropInProgress,
+        initial: true
+      ) { _, isDragAndDropInProgress in
+        onDragAndDropStateChange(isDragAndDropInProgress)
+      }
   }
 }

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -62,7 +62,18 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
             self.saveWindowPosition()
         })
     )
-    contentView?.layer?.cornerRadius = Popup.cornerRadius + Popup.horizontalPadding
+    applyRoundedCorners()
+  }
+
+  private func applyRoundedCorners() {
+    let radius = Popup.cornerRadius + Popup.horizontalPadding
+
+    for view in [contentView, contentView?.superview].compactMap({ $0 }) {
+      view.wantsLayer = true
+      view.layer?.cornerRadius = radius
+      view.layer?.cornerCurve = .continuous
+      view.layer?.masksToBounds = true
+    }
   }
 
   func toggle(height: CGFloat, at popupPosition: PopupPosition = Defaults[.popupPosition]) {

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -219,7 +219,11 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
   override func close() {
     super.close()
-    AppState.shared.preview.state = .closed
+    let appState = AppState.shared
+    appState.preview.state = .closed
+    appState.isEditingItem = false
+    appState.navigator.isDragAndDropInProgress = false
+    appState.navigator.isManualMultiSelect = false
     isPresented = false
     statusBarButton?.isHighlighted = false
     onClose()

--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -200,8 +200,8 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
   // Close automatically when out of focus, e.g. outside click.
   override func resignKey() {
     super.resignKey()
-    // Don't hide if confirmation is shown.
-    if NSApp.alertWindow == nil {
+    // Don't hide while a modal interaction from this panel is active.
+    if NSApp.alertWindow == nil && !AppState.shared.suppressPopupAutoClose {
       close()
     }
   }

--- a/Maccy/Info.plist
+++ b/Maccy/Info.plist
@@ -34,5 +34,20 @@
 	<true/>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/p0deje/Maccy/master/appcast.xml</string>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+	<dict>
+		<key>UTTypeIdentifier</key>
+		<string>org.p0deje.Maccy.pin-reorder</string>
+		<key>UTTypeTagSpecification</key>
+		<dict/>
+		<key>UTTypeDescription</key>
+		<string>Maccy Pin Reorder Type</string>
+		<key>UTTypeConformsTo</key>
+		<array>
+		<string>public.data</string>
+		</array>
+	</dict>
+	</array>
 </dict>
 </plist>

--- a/Maccy/ItemsProtocol.swift
+++ b/Maccy/ItemsProtocol.swift
@@ -16,11 +16,6 @@ private extension ItemsContainer where Item: HasVisibility {}
 
 extension ItemsContainer where Item: HasVisibility {
 
-  var visibleItems: [Item] {
-    guard containerVisible else { return [] }
-    return self.items.lazy.filter(\.isVisible)
-  }
-
   var firstVisibleItem: Item? {
     guard containerVisible else { return nil }
     return self.items.first(where: \.isVisible)
@@ -40,6 +35,29 @@ extension ItemsContainer where Item: HasVisibility {
 }
 
 extension ItemsContainer where Item: HasVisibility, Item: Equatable {
+  func visibleBetween(
+    from fromItem: Item,
+    to toItem: Item,
+    inOrder: Bool = false
+  ) -> [Item]? {
+    guard containerVisible, fromItem.isVisible, toItem.isVisible else { return nil }
+    guard let fromIndex = items.firstIndex(of: fromItem),
+          let toIndex = items.firstIndex(of: toItem) else { return nil }
+
+    let lowerBound = min(fromIndex, toIndex)
+    let upperBound = max(fromIndex, toIndex)
+    let range = items[lowerBound...upperBound].lazy.filter(\.isVisible)
+    if !inOrder && fromIndex > toIndex {
+      return Array(range.reversed())
+    }
+    return Array(range)
+  }
+
+  func nearestVisible(to item: Item, where predicate: (Item) -> Bool) -> Item? {
+    guard containerVisible, item.isVisible else { return nil }
+    return items.nearest(to: item) { $0.isVisible && predicate($0) }
+  }
+
   func visibleItem(before: Item) -> Item? {
     return self.items.item(before: before, where: \.isVisible)
   }

--- a/Maccy/ItemsProtocol.swift
+++ b/Maccy/ItemsProtocol.swift
@@ -5,7 +5,7 @@ protocol HasVisibility {
 protocol ItemsContainer {
   associatedtype Item
   var containerVisible: Bool { get }
-  var items: [Item] { get set }
+  var items: [Item] { get }
 }
 
 extension ItemsContainer {

--- a/Maccy/ItemsProtocol.swift
+++ b/Maccy/ItemsProtocol.swift
@@ -4,8 +4,9 @@ protocol HasVisibility {
 
 protocol ItemsContainer {
   associatedtype Item
+  associatedtype Items: RandomAccessCollection where Items.Element == Item
   var containerVisible: Bool { get }
-  var items: [Item] { get }
+  var items: Items { get }
 }
 
 extension ItemsContainer {

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -36,10 +36,7 @@ class HistoryItem {
 
   @MainActor
   static var availablePins: [String] {
-    availablePins(in: History.shared.all.compactMap {
-      if $0.isPinned { return $0.item }
-      return nil
-    })
+    History.shared.availablePins
   }
 
   @MainActor

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -96,7 +96,7 @@ class AppState: Sendable {
   @MainActor
   func deleteSelection() {
     guard let leadItem = navigator.leadHistoryItem else { return }
-    let nextUnselectedItem = history.visibleItems.nearest(to: leadItem) { !$0.isSelected }
+    let nextUnselectedItem = history.nearestVisible(to: leadItem) { !$0.isSelected }
 
     withTransaction(Transaction()) {
       navigator.selection.forEach { _, item in

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -16,7 +16,7 @@ class AppState: Sendable {
   var footer: Footer
   var navigator: NavigationManager
   var preview: SlideoutController
-  
+
   var isEditingItem: Bool = false
   var suppressPopupAutoClose: Bool {
     return isEditingItem
@@ -116,10 +116,9 @@ class AppState: Sendable {
       let generalTitle = NSLocalizedString("Title", tableName: "GeneralSettings", comment: "")
       let storageTitle = NSLocalizedString("Title", tableName: "StorageSettings", comment: "")
       let appearanceTitle = NSLocalizedString("Title", tableName: "AppearanceSettings", comment: "")
-      let pinsTitle = NSLocalizedString("Title", tableName: "PinsSettings", comment: "")
       let ignoreTitle = NSLocalizedString("Title", tableName: "IgnoreSettings", comment: "")
       let advancedTitle = NSLocalizedString("Title", tableName: "AdvancedSettings", comment: "")
-      let toolbarTitles = [generalTitle, storageTitle, appearanceTitle, pinsTitle, ignoreTitle, advancedTitle]
+      let toolbarTitles = [generalTitle, storageTitle, appearanceTitle, ignoreTitle, advancedTitle]
       let titleAttributes: [NSAttributedString.Key: Any] = [.font: NSFont.systemFont(ofSize: NSFont.systemFontSize)]
       let titleWidth = toolbarTitles.reduce(CGFloat.zero) {
         $0 + ($1 as NSString).size(withAttributes: titleAttributes).width
@@ -152,16 +151,6 @@ class AppState: Sendable {
             toolbarIcon: NSImage.paintpalette!
           ) {
             AppearanceSettingsPane()
-              .frame(minWidth: minimumWidth)
-          },
-          Settings.Pane(
-            identifier: Settings.PaneIdentifier.pins,
-            title: pinsTitle,
-            toolbarIcon: NSImage.pincircle!
-          ) {
-            PinsSettingsPane()
-              .environment(self)
-              .modelContainer(Storage.shared.container)
               .frame(minWidth: minimumWidth)
           },
           Settings.Pane(

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -19,7 +19,7 @@ class AppState: Sendable {
 
   var isEditingItem: Bool = false
   var suppressPopupAutoClose: Bool {
-    return isEditingItem
+    return navigator.isDragAndDropInProgress || isEditingItem
   }
 
   var searchVisible: Bool {

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -16,6 +16,11 @@ class AppState: Sendable {
   var footer: Footer
   var navigator: NavigationManager
   var preview: SlideoutController
+  
+  var isEditingItem: Bool = false
+  var suppressPopupAutoClose: Bool {
+    return isEditingItem
+  }
 
   var searchVisible: Bool {
     if !Defaults[.showSearch] { return false }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -13,18 +13,29 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   static let shared = History()
   let logger = Logger(label: "org.p0deje.Maccy")
 
-  var items: [HistoryItemDecorator] = []
   var pasteStack: PasteStack?
 
-  var pinnedItems: [HistoryItemDecorator] { items.filter(\.isPinned) }
-  var unpinnedItems: [HistoryItemDecorator] { items.filter(\.isUnpinned) }
+  var items: [HistoryItemDecorator] {
+    switch Defaults[.pinTo] {
+    case .top:
+      pinnedItems + unpinnedItems
+    case .bottom:
+      unpinnedItems + pinnedItems
+    }
+  }
+  var pinnedItems: [HistoryItemDecorator] {
+    searchQuery.isEmpty ? allPinnedItems : filteredPinnedItems
+  }
+  var unpinnedItems: [HistoryItemDecorator] {
+    searchQuery.isEmpty ? allUnpinnedItems : filteredUnpinnedItems
+  }
   var availablePins: [String] { pinManager.availablePins }
 
   var searchQuery: String = "" {
     didSet(previousSearchQuery) {
       guard searchQuery != previousSearchQuery else { return }
       throttler.throttle { [self] in
-        updateItems(search.search(string: searchQuery, within: all))
+        updateSearchResults()
 
         if searchQuery.isEmpty {
           AppState.shared.navigator.select(item: unpinnedItems.first)
@@ -58,15 +69,13 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   private let sorter = Sorter()
   private let throttler = Throttler(minimumDelay: 0.2)
   private let pinManager = PinManager()
+  private var allPinnedItems: [HistoryItemDecorator] { pinManager.pinnedItems }
+  private var allUnpinnedItems: [HistoryItemDecorator] = []
+  private var filteredPinnedItems: [HistoryItemDecorator] = []
+  private var filteredUnpinnedItems: [HistoryItemDecorator] = []
 
   @ObservationIgnored
   private var sessionLog: [Int: HistoryItem] = [:]
-
-  // The distinction between `all` and `items` is the following:
-  // - `all` stores all history items, even the ones that are currently hidden by a search
-  // - `items` stores only visible history items, updated during a search
-  @ObservationIgnored
-  var all: [HistoryItemDecorator] = []
 
   init() {
     Task {
@@ -108,9 +117,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   func load() async throws {
     let descriptor = FetchDescriptor<HistoryItem>()
     let results = try Storage.shared.context.fetch(descriptor)
-    all = sorter.sort(results).map { HistoryItemDecorator($0) }
-    pinManager.load(from: all)
-    items = all
+    let decorators = sorter.sort(results).map { HistoryItemDecorator($0) }
+    pinManager.load(from: decorators)
+    allUnpinnedItems = decorators.filter(\.isUnpinned)
+    filteredPinnedItems = allPinnedItems
+    filteredUnpinnedItems = allUnpinnedItems
 
     limitHistorySize(to: Defaults[.size])
 
@@ -123,9 +134,8 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   @MainActor
   private func limitHistorySize(to maxSize: Int) {
-    let unpinned = all.filter(\.isUnpinned)
-    if unpinned.count >= maxSize {
-      unpinned[maxSize...].forEach(delete)
+    if allUnpinnedItems.count >= maxSize {
+      allUnpinnedItems[maxSize...].forEach(delete)
     }
   }
 
@@ -147,7 +157,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       // It was already inserted after creation in Clipboard.swift
     }
 
-    var removedItemIndex: Int?
+    var replacedPinnedItem: HistoryItemDecorator?
     if let existingHistoryItem = findSimilarItem(item) {
       if isModified(item) == nil {
         transferContents(from: existingHistoryItem, to: item)
@@ -160,14 +170,14 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         item.application = existingHistoryItem.application
       }
       logger.info("Removing duplicate item '\(item.title)'")
-      removedItemIndex = all.firstIndex(where: { $0.item == existingHistoryItem })
-      if let removedItemIndex {
-        cleanup(all[removedItemIndex])
+      if let existingDecorator = firstStoredItem(where: { $0.item == existingHistoryItem }) {
+        cleanup(existingDecorator)
+        allUnpinnedItems.removeAll { $0 == existingDecorator }
+        if existingDecorator.isPinned {
+          replacedPinnedItem = existingDecorator
+        }
       }
       deleteFromStorage(existingHistoryItem)
-      if let removedItemIndex {
-        all.remove(at: removedItemIndex)
-      }
     } else {
       Task {
         Notifier.notify(body: item.title, sound: .write)
@@ -176,33 +186,29 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
     // Remove exceeding items. Do this after the item is added to avoid removing something
     // if a duplicate was found as then the size already stayed the same.
-    limitHistorySize(to: Defaults[.size] - 1)
+    limitHistorySize(to: item.pin == nil ? Defaults[.size] - 1 : Defaults[.size])
 
     sessionLog[Clipboard.shared.changeCount] = item
 
-    var itemDecorator: HistoryItemDecorator
+    let itemDecorator: HistoryItemDecorator
     if let pin = item.pin {
       itemDecorator = HistoryItemDecorator(item, shortcuts: KeyShortcut.create(character: pin))
-      if let removedItemIndex {
-        // If pin to bottom -> last element should be inserted to the removedItemIndex - 1
-        // Or to the last all array place.
-        all.insert(itemDecorator, at: min(removedItemIndex, all.count))
+      if let replacedPinnedItem {
+        pinManager.replace(replacedPinnedItem, with: itemDecorator)
+      } else {
+        pinManager.add(itemDecorator)
       }
-      pinManager.load(from: all)
-      items = all
     } else {
       itemDecorator = HistoryItemDecorator(item)
-
-      let sortedItems = sorter.sort(all.map(\.item) + [item])
-      if let index = sortedItems.firstIndex(of: item) {
-        all.insert(itemDecorator, at: index)
-      }
-
-      items = all
-      updateUnpinnedShortcuts()
-      AppState.shared.popup.needsResize = true
+      insertUnpinned(itemDecorator)
     }
 
+    if searchQuery.isEmpty {
+      updateUnpinnedShortcuts()
+    } else {
+      updateSearchResults()
+    }
+    AppState.shared.popup.needsResize = true
     return itemDecorator
   }
 
@@ -222,15 +228,10 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @MainActor
   func clear() {
     withLogging("Clearing history") {
-      all.forEach { item in
-        if item.isUnpinned {
-          cleanup(item)
-        }
-      }
-      all.removeAll(where: \.isUnpinned)
+      allUnpinnedItems.forEach(cleanup)
+      allUnpinnedItems.removeAll()
+      filteredUnpinnedItems.removeAll()
       sessionLog.removeValues { $0.pin == nil }
-      pinManager.load(from: all)
-      items = all
 
       try? Storage.shared.context.transaction {
         try? Storage.shared.context.delete(
@@ -256,13 +257,13 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @MainActor
   func clearAll() {
     withLogging("Clearing all history") {
-      all.forEach { item in
-        cleanup(item)
-      }
-      all.removeAll()
+      allPinnedItems.forEach(cleanup)
+      allUnpinnedItems.forEach(cleanup)
+      allUnpinnedItems.removeAll()
+      filteredPinnedItems.removeAll()
+      filteredUnpinnedItems.removeAll()
       pinManager.removeAll()
       sessionLog.removeAll()
-      items = all
 
       do {
         let context = Storage.shared.context
@@ -301,8 +302,9 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     }
 
     pinManager.remove(item)
-    all.removeAll { $0 == item }
-    items.removeAll { $0 == item }
+    allUnpinnedItems.removeAll { $0 == item }
+    filteredPinnedItems.removeAll { $0 == item }
+    filteredUnpinnedItems.removeAll { $0 == item }
     sessionLog.removeValues { $0 == item.item }
 
     updateUnpinnedShortcuts()
@@ -463,14 +465,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     pinManager.toggle(item)
     guard item.isPinned != wasPinned else { return }
 
-    let sortedItems = sorter.sort(all.map(\.item))
-    if let currentIndex = all.firstIndex(of: item),
-       let newIndex = sortedItems.firstIndex(of: item.item) {
-      all.remove(at: currentIndex)
-      all.insert(item, at: newIndex)
+    if wasPinned {
+      insertUnpinned(item)
+    } else {
+      allUnpinnedItems.removeAll { $0 == item }
     }
-
-    items = all
 
     searchQuery = ""
     updateUnpinnedShortcuts()
@@ -483,30 +482,23 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   func movePin(from source: IndexSet, to destination: Int) {
     guard searchQuery.isEmpty else { return }
     pinManager.move(from: source, to: destination)
-    recomputeItemsAfterReordering()
-  }
-
-  @MainActor
-  func recomputeItemsAfterReordering() {
-    guard searchQuery.isEmpty else { return }
-    let sortedItems = sorter.sort(all.map(\.item))
-    let decoratorsByItem = Dictionary(uniqueKeysWithValues: all.map { (ObjectIdentifier($0.item), $0) })
-
-    all = sortedItems.compactMap { decoratorsByItem[ObjectIdentifier($0)] }
-    items = all
   }
 
   @MainActor
   func updatePin(_ item: HistoryItem, to pin: String) {
-    guard let itemDecorator = all.first(where: { $0.item.id == item.id }) else { return }
+    guard let itemDecorator = firstStoredItem(where: { $0.item.id == item.id }) else { return }
 
+    let wasPinned = itemDecorator.isPinned
     pinManager.updatePin(of: itemDecorator, to: pin)
+    if !wasPinned && itemDecorator.isPinned {
+      allUnpinnedItems.removeAll { $0 == itemDecorator }
+    }
     updateShortcuts()
   }
 
   @MainActor
   private func findSimilarItem(_ item: HistoryItem) -> HistoryItem? {
-    if let duplicate = all.first(where: { $0.item != item && $0.item.supersedes(item) }) {
+    if let duplicate = firstStoredItem(where: { $0.item != item && $0.item.supersedes(item) }) {
       return duplicate.item
     }
 
@@ -521,15 +513,36 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     return nil
   }
 
-  private func updateItems(_ newItems: [Search.SearchResult]) {
-    items = newItems.map { result in
+  private func updateSearchResults() {
+    filteredPinnedItems = filteredItems(
+      from: search.search(string: searchQuery, within: allPinnedItems)
+    )
+    filteredUnpinnedItems = filteredItems(
+      from: search.search(string: searchQuery, within: allUnpinnedItems)
+    )
+
+    updateUnpinnedShortcuts()
+  }
+
+  private func filteredItems(from results: [Search.SearchResult]) -> [HistoryItemDecorator] {
+    results.map { result in
       let item = result.object
       item.highlight(searchQuery, result.ranges)
 
       return item
     }
+  }
 
-    updateUnpinnedShortcuts()
+  private func firstStoredItem(
+    where predicate: (HistoryItemDecorator) -> Bool
+  ) -> HistoryItemDecorator? {
+    allPinnedItems.first(where: predicate) ?? allUnpinnedItems.first(where: predicate)
+  }
+
+  private func insertUnpinned(_ item: HistoryItemDecorator) {
+    let sortedItems = sorter.sort(allUnpinnedItems.map(\.item) + [item.item])
+    guard let index = sortedItems.firstIndex(of: item.item) else { return }
+    allUnpinnedItems.insert(item, at: index)
   }
 
   private func updateShortcuts() {
@@ -549,13 +562,13 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   }
 
   private func updateUnpinnedShortcuts() {
-    let visibleUnpinnedItems = unpinnedItems.filter(\.isVisible)
-    for item in visibleUnpinnedItems {
+    let shortcutItems = unpinnedItems.filter(\.isVisible)
+    for item in shortcutItems {
       item.shortcuts = []
     }
 
     var index = 1
-    for item in visibleUnpinnedItems.prefix(9) {
+    for item in shortcutItems.prefix(9) {
       item.shortcuts = KeyShortcut.create(character: String(index))
       index += 1
     }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -15,12 +15,12 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   var pasteStack: PasteStack?
 
-  var items: [HistoryItemDecorator] {
+  var items: ConcatenatedCollection<HistoryItemDecorator> {
     switch Defaults[.pinTo] {
     case .top:
-      pinnedItems + unpinnedItems
+      ConcatenatedCollection(pinnedItems, unpinnedItems)
     case .bottom:
-      unpinnedItems + pinnedItems
+      ConcatenatedCollection(unpinnedItems, pinnedItems)
     }
   }
   var pinnedItems: [HistoryItemDecorator] {

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -82,12 +82,6 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     }
 
     Task {
-      for await _ in Defaults.updates(.pinSortBy, initial: false) {
-        try? await load()
-      }
-    }
-
-    Task {
       for await _ in Defaults.updates(.pinTo, initial: false) {
         try? await load()
       }
@@ -487,24 +481,8 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   @MainActor
   func movePin(from source: IndexSet, to destination: Int) {
-    guard searchQuery.isEmpty, Defaults[.pinSortBy] == .custom else { return }
+    guard searchQuery.isEmpty else { return }
     pinManager.move(from: source, to: destination)
-  }
-
-  @MainActor
-  func setPinSorting(_ pinSortBy: Sorter.PinBy) {
-    let previousPinSortBy = Defaults[.pinSortBy]
-    guard pinSortBy != previousPinSortBy else { return }
-
-    if pinSortBy == .custom {
-      pinManager.adoptSortingForCustomOrder(previousPinSortBy)
-    }
-    Defaults[.pinSortBy] = pinSortBy
-  }
-
-  @MainActor
-  func pinSortingWouldChangeCurrentOrder(_ pinSortBy: Sorter.PinBy) -> Bool {
-    pinManager.sortingWouldChangeCurrentOrder(pinSortBy)
   }
 
   @MainActor

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -82,6 +82,12 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     }
 
     Task {
+      for await _ in Defaults.updates(.pinSortBy, initial: false) {
+        try? await load()
+      }
+    }
+
+    Task {
       for await _ in Defaults.updates(.pinTo, initial: false) {
         try? await load()
       }
@@ -481,8 +487,24 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   @MainActor
   func movePin(from source: IndexSet, to destination: Int) {
-    guard searchQuery.isEmpty else { return }
+    guard searchQuery.isEmpty, Defaults[.pinSortBy] == .custom else { return }
     pinManager.move(from: source, to: destination)
+  }
+
+  @MainActor
+  func setPinSorting(_ pinSortBy: Sorter.PinBy) {
+    let previousPinSortBy = Defaults[.pinSortBy]
+    guard pinSortBy != previousPinSortBy else { return }
+
+    if pinSortBy == .custom {
+      pinManager.adoptSortingForCustomOrder(previousPinSortBy)
+    }
+    Defaults[.pinSortBy] = pinSortBy
+  }
+
+  @MainActor
+  func pinSortingWouldChangeCurrentOrder(_ pinSortBy: Sorter.PinBy) -> Bool {
+    pinManager.sortingWouldChangeCurrentOrder(pinSortBy)
   }
 
   @MainActor

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -21,7 +21,8 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   var availablePins: [String] { pinManager.availablePins }
 
   var searchQuery: String = "" {
-    didSet {
+    didSet(previousSearchQuery) {
+      guard searchQuery != previousSearchQuery else { return }
       throttler.throttle { [self] in
         updateItems(search.search(string: searchQuery, within: all))
 

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -18,6 +18,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
   var pinnedItems: [HistoryItemDecorator] { items.filter(\.isPinned) }
   var unpinnedItems: [HistoryItemDecorator] { items.filter(\.isUnpinned) }
+  var availablePins: [String] { pinManager.availablePins }
 
   var searchQuery: String = "" {
     didSet {
@@ -55,6 +56,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   private let search = Search()
   private let sorter = Sorter()
   private let throttler = Throttler(minimumDelay: 0.2)
+  private let pinManager = PinManager()
 
   @ObservationIgnored
   private var sessionLog: [Int: HistoryItem] = [:]
@@ -106,6 +108,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     let descriptor = FetchDescriptor<HistoryItem>()
     let results = try Storage.shared.context.fetch(descriptor)
     all = sorter.sort(results).map { HistoryItemDecorator($0) }
+    pinManager.load(from: all)
     items = all
 
     limitHistorySize(to: Defaults[.size])
@@ -184,6 +187,8 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         // Or to the last all array place.
         all.insert(itemDecorator, at: min(removedItemIndex, all.count))
       }
+      pinManager.load(from: all)
+      items = all
     } else {
       itemDecorator = HistoryItemDecorator(item)
 
@@ -223,6 +228,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       }
       all.removeAll(where: \.isUnpinned)
       sessionLog.removeValues { $0.pin == nil }
+      pinManager.load(from: all)
       items = all
 
       try? Storage.shared.context.transaction {
@@ -253,6 +259,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
         cleanup(item)
       }
       all.removeAll()
+      pinManager.removeAll()
       sessionLog.removeAll()
       items = all
 
@@ -292,6 +299,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       try? Storage.shared.context.save()
     }
 
+    pinManager.remove(item)
     all.removeAll { $0 == item }
     items.removeAll { $0 == item }
     sessionLog.removeValues { $0 == item.item }
@@ -450,7 +458,9 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   func togglePin(_ item: HistoryItemDecorator?) {
     guard let item else { return }
 
-    item.togglePin()
+    let wasPinned = item.isPinned
+    pinManager.toggle(item)
+    guard item.isPinned != wasPinned else { return }
 
     let sortedItems = sorter.sort(all.map(\.item))
     if let currentIndex = all.firstIndex(of: item),
@@ -466,6 +476,30 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     if item.isUnpinned {
       AppState.shared.navigator.scrollTarget = item.id
     }
+  }
+
+  @MainActor
+  func movePin(from source: IndexSet, to destination: Int) {
+    guard searchQuery.isEmpty else { return }
+    pinManager.move(from: source, to: destination)
+  }
+
+  @MainActor
+  func recomputeItemsAfterReordering() {
+    guard searchQuery.isEmpty else { return }
+    let sortedItems = sorter.sort(all.map(\.item))
+    let decoratorsByItem = Dictionary(uniqueKeysWithValues: all.map { (ObjectIdentifier($0.item), $0) })
+
+    all = sortedItems.compactMap { decoratorsByItem[ObjectIdentifier($0)] }
+    items = all
+  }
+
+  @MainActor
+  func updatePin(_ item: HistoryItem, to pin: String) {
+    guard let itemDecorator = all.first(where: { $0.item.id == item.id }) else { return }
+
+    pinManager.updatePin(of: itemDecorator, to: pin)
+    updateShortcuts()
   }
 
   @MainActor
@@ -497,7 +531,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   }
 
   private func updateShortcuts() {
-    for item in pinnedItems {
+    for item in pinManager.pinnedItems {
       if let pin = item.item.pin {
         item.shortcuts = KeyShortcut.create(character: pin)
       }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -483,6 +483,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   func movePin(from source: IndexSet, to destination: Int) {
     guard searchQuery.isEmpty else { return }
     pinManager.move(from: source, to: destination)
+    recomputeItemsAfterReordering()
   }
 
   @MainActor

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -208,16 +208,6 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     attributedTitle = attributedString
   }
 
-  @MainActor
-  func togglePin() {
-    if item.pin != nil {
-      item.pin = nil
-    } else {
-      let pin = HistoryItem.randomAvailablePin
-      item.pin = pin
-    }
-  }
-
   private func synchronizeItemPin() {
     _ = withObservationTracking {
       item.pin
@@ -225,6 +215,8 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
       DispatchQueue.main.async {
         if let pin = self.item.pin {
           self.shortcuts = KeyShortcut.create(character: pin)
+        } else {
+          self.shortcuts = []
         }
         self.synchronizeItemPin()
       }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -40,6 +40,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   }
 
   var hasImage: Bool { item.image != nil }
+  var hasFileURLs: Bool { !item.fileURLs.isEmpty }
+  var hasPlainText: Bool { item.text != nil }
+  var hasRichText: Bool { item.rtf != nil || item.html != nil }
 
   var previewImageGenerationTask: Task<(), Error>?
   var thumbnailImageGenerationTask: Task<(), Error>?

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -136,7 +136,7 @@ class NavigationManager { // swiftlint:disable:this type_body_length
     var newSelectionState = selection
 
     if isRange {
-      if let itemRange = history.visibleItems.between(
+      if let itemRange = history.visibleBetween(
         from: fromItem,
         to: toItem,
         inOrder: false

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -64,15 +64,24 @@ class NavigationManager { // swiftlint:disable:this type_body_length
   var isMultiSelectInProgress: Bool {
     return isManualMultiSelect || selection.count > 1
   }
+  var isDragAndDropInProgress: Bool = false {
+    didSet {
+      updateSelectionState()
+    }
+  }
 
   var hoverSelectionWhileKeyboardNavigating: UUID?
   var isKeyboardNavigating: Bool = true {
     didSet {
-      if !isKeyboardNavigating && !isMultiSelectInProgress,
-         let hoverSelection = hoverSelectionWhileKeyboardNavigating {
-        hoverSelectionWhileKeyboardNavigating = nil
-        select(id: hoverSelection)
-      }
+      updateSelectionState()
+    }
+  }
+  
+  private func updateSelectionState() {
+    if !isKeyboardNavigating && !isMultiSelectInProgress && !isDragAndDropInProgress,
+       let hoverSelection = hoverSelectionWhileKeyboardNavigating {
+      hoverSelectionWhileKeyboardNavigating = nil
+      select(id: hoverSelection)
     }
   }
 

--- a/Maccy/Observables/PinManager.swift
+++ b/Maccy/Observables/PinManager.swift
@@ -71,6 +71,22 @@ final class PinManager {
     }
   }
 
+  func add(_ item: HistoryItemDecorator) {
+    guard item.isPinned, !pinnedItems.contains(item) else { return }
+    pinnedItems.append(item)
+    reconcileOrder()
+    sortPinnedItems()
+  }
+
+  func replace(_ oldItem: HistoryItemDecorator, with newItem: HistoryItemDecorator) {
+    guard newItem.isPinned else { return }
+    guard let index = pinnedItems.firstIndex(of: oldItem) else {
+      add(newItem)
+      return
+    }
+    pinnedItems[index] = newItem
+  }
+
   func updatePin(of item: HistoryItemDecorator, to pin: String) {
     guard HistoryItem.supportedPins.contains(pin) else { return }
     guard item.item.pin != pin else { return }
@@ -166,4 +182,3 @@ final class PinManager {
     }
   }
 }
-

--- a/Maccy/Observables/PinManager.swift
+++ b/Maccy/Observables/PinManager.swift
@@ -1,0 +1,193 @@
+import Defaults
+import Observation
+import SwiftUI
+
+struct PinOrder: Codable, Equatable, Defaults.Serializable {
+  var pins: [String]
+
+  init(pins: [String] = []) {
+    self.pins = Self.uniquePins(pins)
+  }
+
+  mutating func reconcile(with assignedPins: [String]) {
+    let assignedPins = Self.uniquePins(assignedPins)
+    let assignedPinSet = Set(assignedPins)
+    pins = Self.uniquePins(pins).filter { assignedPinSet.contains($0) }
+
+    for pin in assignedPins where !pins.contains(pin) {
+      pins.append(pin)
+    }
+  }
+
+  mutating func append(_ pin: String) {
+    guard !pin.isEmpty, !pins.contains(pin) else { return }
+    pins.append(pin)
+  }
+
+  mutating func remove(_ pin: String) {
+    pins.removeAll { $0 == pin }
+  }
+
+  mutating func replace(_ oldPin: String?, with newPin: String) {
+    guard !newPin.isEmpty else { return }
+
+    pins.removeAll { $0 == newPin }
+    if let oldPin, let index = pins.firstIndex(of: oldPin) {
+      pins[index] = newPin
+    } else {
+      pins.append(newPin)
+    }
+  }
+
+  private static func uniquePins(_ pins: [String]) -> [String] {
+    var uniquePins: [String] = []
+    for pin in pins where !pin.isEmpty && !uniquePins.contains(pin) {
+      uniquePins.append(pin)
+    }
+    return uniquePins
+  }
+}
+
+@Observable
+final class PinManager {
+  private(set) var pinnedItems: [HistoryItemDecorator] = []
+
+  var availablePins: [String] {
+    let assignedPins = Set(pinnedItems.compactMap(\.item.pin))
+    return HistoryItem.supportedPins.subtracting(assignedPins).sorted()
+  }
+
+  func load(from items: [HistoryItemDecorator]) {
+    pinnedItems = items.filter(\.isPinned)
+    reconcileOrder()
+    sortPinnedItems()
+  }
+
+  func toggle(_ item: HistoryItemDecorator) {
+    if item.isPinned {
+      unpin(item)
+    } else {
+      pin(item)
+    }
+  }
+
+  func updatePin(of item: HistoryItemDecorator, to pin: String) {
+    guard HistoryItem.supportedPins.contains(pin) else { return }
+    guard item.item.pin != pin else { return }
+    guard !pinnedItems.contains(where: { $0 != item && $0.item.pin == pin })
+    else { return }
+
+    let oldPin = item.item.pin
+    item.item.pin = pin
+
+    if !pinnedItems.contains(item) {
+      pinnedItems.append(item)
+    }
+
+    var order = Defaults[.pinOrder]
+    order.replace(oldPin, with: pin)
+    Defaults[.pinOrder] = order
+    sortPinnedItems()
+  }
+
+  func remove(_ item: HistoryItemDecorator) {
+    guard let pin = item.item.pin else { return }
+
+    pinnedItems.removeAll { $0 == item }
+    if !pinnedItems.contains(where: { $0.item.pin == pin }) {
+      var order = Defaults[.pinOrder]
+      order.remove(pin)
+      Defaults[.pinOrder] = order
+    }
+  }
+
+  func removeAll() {
+    pinnedItems.removeAll()
+    Defaults[.pinOrder] = PinOrder()
+  }
+
+  func move(from source: IndexSet, to destination: Int) {
+    pinnedItems.moveElements(from: source, to: destination)
+    Defaults[.pinOrder] = PinOrder(pins: pinnedItems.compactMap(\.item.pin))
+  }
+
+  private func pin(_ item: HistoryItemDecorator) {
+    guard item.isUnpinned, let pin = availablePins.randomElement() else {
+      return
+    }
+
+    item.item.pin = pin
+    pinnedItems.append(item)
+
+    var order = Defaults[.pinOrder]
+    order.append(pin)
+    Defaults[.pinOrder] = order
+    sortPinnedItems()
+  }
+
+  private func unpin(_ item: HistoryItemDecorator) {
+    guard let pin = item.item.pin else { return }
+
+    item.item.pin = nil
+    pinnedItems.removeAll { $0 == item }
+
+    if !pinnedItems.contains(where: { $0.item.pin == pin }) {
+      var order = Defaults[.pinOrder]
+      order.remove(pin)
+      Defaults[.pinOrder] = order
+    }
+  }
+
+  private func reconcileOrder() {
+    var order = Defaults[.pinOrder]
+    order.reconcile(with: pinnedItems.compactMap(\.item.pin))
+    Defaults[.pinOrder] = order
+  }
+
+  private func sortPinnedItems() {
+    let originalIndexes = Dictionary(
+      uniqueKeysWithValues: pinnedItems.enumerated().map {
+        ($0.element.id, $0.offset)
+      }
+    )
+    let order = Defaults[.pinOrder].pins
+
+    pinnedItems.sort { lhs, rhs in
+      let lhsIndex =
+        lhs.item.pin.flatMap { order.firstIndex(of: $0) } ?? Int.max
+      let rhsIndex =
+        rhs.item.pin.flatMap { order.firstIndex(of: $0) } ?? Int.max
+
+      if lhsIndex != rhsIndex {
+        return lhsIndex < rhsIndex
+      }
+
+      return (originalIndexes[lhs.id] ?? 0) < (originalIndexes[rhs.id] ?? 0)
+    }
+  }
+}
+
+extension Array where Element == HistoryItemDecorator {
+  fileprivate mutating func moveElements(
+    from source: IndexSet,
+    to destination: Int
+  ) {
+    let movingIndexes = source.sorted()
+    let movingElements = movingIndexes.compactMap {
+      indices.contains($0) ? self[$0] : nil
+    }
+    guard !movingElements.isEmpty else { return }
+
+    for index in movingIndexes.reversed() where indices.contains(index) {
+      remove(at: index)
+    }
+
+    let removedBeforeDestination = movingIndexes.filter { $0 < destination }
+      .count
+    let insertionIndex = Swift.max(
+      0,
+      Swift.min(destination - removedBeforeDestination, count)
+    )
+    insert(contentsOf: movingElements, at: insertionIndex)
+  }
+}

--- a/Maccy/Observables/PinManager.swift
+++ b/Maccy/Observables/PinManager.swift
@@ -52,8 +52,6 @@ struct PinOrder: Codable, Equatable, Defaults.Serializable {
 final class PinManager {
   private(set) var pinnedItems: [HistoryItemDecorator] = []
 
-  private let sorter = Sorter()
-
   var availablePins: [String] {
     let assignedPins = Set(pinnedItems.compactMap(\.item.pin))
     return HistoryItem.supportedPins.subtracting(assignedPins).sorted()
@@ -109,19 +107,8 @@ final class PinManager {
   }
 
   func move(from source: IndexSet, to destination: Int) {
-    guard Defaults[.pinSortBy] == .custom else { return }
     pinnedItems.moveElements(from: source, to: destination)
     Defaults[.pinOrder] = PinOrder(pins: pinnedItems.compactMap(\.item.pin))
-  }
-
-  func adoptSortingForCustomOrder(_ pinSortBy: Sorter.PinBy) {
-    let sortedPins = sorter.sortPins(pinnedItems, key: \.item, by: pinSortBy)
-    Defaults[.pinOrder] = PinOrder(pins: sortedPins.compactMap(\.item.pin))
-  }
-
-  func sortingWouldChangeCurrentOrder(_ pinSortBy: Sorter.PinBy) -> Bool {
-    sorter.sortPins(pinnedItems, key: \.item, by: pinSortBy).map(\.id)
-      != pinnedItems.map(\.id)
   }
 
   private func pin(_ item: HistoryItemDecorator) {
@@ -158,7 +145,25 @@ final class PinManager {
   }
 
   private func sortPinnedItems() {
-    pinnedItems = sorter.sortPins(pinnedItems, key: \.item)
+    let originalIndexes = Dictionary(
+      uniqueKeysWithValues: pinnedItems.enumerated().map {
+        ($0.element.id, $0.offset)
+      }
+    )
+    let order = Defaults[.pinOrder].pins
+
+    pinnedItems.sort { lhs, rhs in
+      let lhsIndex =
+        lhs.item.pin.flatMap { order.firstIndex(of: $0) } ?? Int.max
+      let rhsIndex =
+        rhs.item.pin.flatMap { order.firstIndex(of: $0) } ?? Int.max
+
+      if lhsIndex != rhsIndex {
+        return lhsIndex < rhsIndex
+      }
+
+      return (originalIndexes[lhs.id] ?? 0) < (originalIndexes[rhs.id] ?? 0)
+    }
   }
 }
 

--- a/Maccy/Observables/PinManager.swift
+++ b/Maccy/Observables/PinManager.swift
@@ -52,6 +52,8 @@ struct PinOrder: Codable, Equatable, Defaults.Serializable {
 final class PinManager {
   private(set) var pinnedItems: [HistoryItemDecorator] = []
 
+  private let sorter = Sorter()
+
   var availablePins: [String] {
     let assignedPins = Set(pinnedItems.compactMap(\.item.pin))
     return HistoryItem.supportedPins.subtracting(assignedPins).sorted()
@@ -107,8 +109,19 @@ final class PinManager {
   }
 
   func move(from source: IndexSet, to destination: Int) {
+    guard Defaults[.pinSortBy] == .custom else { return }
     pinnedItems.moveElements(from: source, to: destination)
     Defaults[.pinOrder] = PinOrder(pins: pinnedItems.compactMap(\.item.pin))
+  }
+
+  func adoptSortingForCustomOrder(_ pinSortBy: Sorter.PinBy) {
+    let sortedPins = sorter.sortPins(pinnedItems, key: \.item, by: pinSortBy)
+    Defaults[.pinOrder] = PinOrder(pins: sortedPins.compactMap(\.item.pin))
+  }
+
+  func sortingWouldChangeCurrentOrder(_ pinSortBy: Sorter.PinBy) -> Bool {
+    sorter.sortPins(pinnedItems, key: \.item, by: pinSortBy).map(\.id)
+      != pinnedItems.map(\.id)
   }
 
   private func pin(_ item: HistoryItemDecorator) {
@@ -145,25 +158,7 @@ final class PinManager {
   }
 
   private func sortPinnedItems() {
-    let originalIndexes = Dictionary(
-      uniqueKeysWithValues: pinnedItems.enumerated().map {
-        ($0.element.id, $0.offset)
-      }
-    )
-    let order = Defaults[.pinOrder].pins
-
-    pinnedItems.sort { lhs, rhs in
-      let lhsIndex =
-        lhs.item.pin.flatMap { order.firstIndex(of: $0) } ?? Int.max
-      let rhsIndex =
-        rhs.item.pin.flatMap { order.firstIndex(of: $0) } ?? Int.max
-
-      if lhsIndex != rhsIndex {
-        return lhsIndex < rhsIndex
-      }
-
-      return (originalIndexes[lhs.id] ?? 0) < (originalIndexes[rhs.id] ?? 0)
-    }
+    pinnedItems = sorter.sortPins(pinnedItems, key: \.item)
   }
 }
 

--- a/Maccy/Observables/PinManager.swift
+++ b/Maccy/Observables/PinManager.swift
@@ -167,27 +167,3 @@ final class PinManager {
   }
 }
 
-extension Array where Element == HistoryItemDecorator {
-  fileprivate mutating func moveElements(
-    from source: IndexSet,
-    to destination: Int
-  ) {
-    let movingIndexes = source.sorted()
-    let movingElements = movingIndexes.compactMap {
-      indices.contains($0) ? self[$0] : nil
-    }
-    guard !movingElements.isEmpty else { return }
-
-    for index in movingIndexes.reversed() where indices.contains(index) {
-      remove(at: index)
-    }
-
-    let removedBeforeDestination = movingIndexes.filter { $0 < destination }
-      .count
-    let insertionIndex = Swift.max(
-      0,
-      Swift.min(destination - removedBeforeDestination, count)
-    )
-    insert(contentsOf: movingElements, at: insertionIndex)
-  }
-}

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -58,11 +58,9 @@ struct StorageSettingsPane: View {
 
   @Default(.size) private var size
   @Default(.sortBy) private var sortBy
-  @Default(.pinSortBy) private var pinSortBy
 
   @State private var viewModel = ViewModel()
   @State private var storageSize = Storage.shared.size
-  @State private var pendingPinSortBy: Sorter.PinBy?
 
   private let sizeFormatter: NumberFormatter = {
     let formatter = NumberFormatter()
@@ -124,70 +122,7 @@ struct StorageSettingsPane: View {
         .help(Text("SortByTooltip", tableName: "StorageSettings"))
         .accessibilityLabel(Text("SortBy", tableName: "StorageSettings"))
       }
-
-      Settings.Section(label: { Text("SortPinsBy", tableName: "StorageSettings") }) {
-        Picker("", selection: pinSortBySelection) {
-          ForEach(Sorter.PinBy.allCases) { mode in
-            Text(mode.description)
-          }
-        }
-        .labelsHidden()
-        .frame(width: 160, alignment: .leading)
-
-        Text("SortPinsByDescription", tableName: "StorageSettings")
-          .fixedSize(horizontal: false, vertical: true)
-          .controlSize(.small)
-          .foregroundStyle(.gray)
-      }
     }
-    .alert(
-      Text("PinSortWarningTitle", tableName: "StorageSettings"),
-      isPresented: isShowingPinSortWarning,
-      presenting: pendingPinSortBy
-    ) { pendingPinSortBy in
-      Button(role: .destructive) {
-        applyPinSorting(pendingPinSortBy)
-      } label: {
-        Text("PinSortWarningConfirm", tableName: "StorageSettings")
-      }
-      Button(role: .cancel) {
-      } label: {
-        Text("PinSortWarningCancel", tableName: "StorageSettings")
-      }
-    } message: { _ in
-      Text("PinSortWarningMessage", tableName: "StorageSettings")
-    }
-  }
-
-  private var pinSortBySelection: Binding<Sorter.PinBy> {
-    Binding(
-      get: { pinSortBy },
-      set: { newValue in
-        if pinSortBy == .custom,
-           newValue != .custom,
-           History.shared.pinSortingWouldChangeCurrentOrder(newValue) {
-          pendingPinSortBy = newValue
-        } else {
-          applyPinSorting(newValue)
-        }
-      }
-    )
-  }
-
-  private var isShowingPinSortWarning: Binding<Bool> {
-    Binding(
-      get: { pendingPinSortBy != nil },
-      set: { isPresented in
-        if !isPresented {
-          pendingPinSortBy = nil
-        }
-      }
-    )
-  }
-
-  private func applyPinSorting(_ pinSortBy: Sorter.PinBy) {
-    History.shared.setPinSorting(pinSortBy)
-    pendingPinSortBy = nil
   }
 }
 

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -58,9 +58,11 @@ struct StorageSettingsPane: View {
 
   @Default(.size) private var size
   @Default(.sortBy) private var sortBy
+  @Default(.pinSortBy) private var pinSortBy
 
   @State private var viewModel = ViewModel()
   @State private var storageSize = Storage.shared.size
+  @State private var pendingPinSortBy: Sorter.PinBy?
 
   private let sizeFormatter: NumberFormatter = {
     let formatter = NumberFormatter()
@@ -122,7 +124,70 @@ struct StorageSettingsPane: View {
         .help(Text("SortByTooltip", tableName: "StorageSettings"))
         .accessibilityLabel(Text("SortBy", tableName: "StorageSettings"))
       }
+
+      Settings.Section(label: { Text("SortPinsBy", tableName: "StorageSettings") }) {
+        Picker("", selection: pinSortBySelection) {
+          ForEach(Sorter.PinBy.allCases) { mode in
+            Text(mode.description)
+          }
+        }
+        .labelsHidden()
+        .frame(width: 160, alignment: .leading)
+
+        Text("SortPinsByDescription", tableName: "StorageSettings")
+          .fixedSize(horizontal: false, vertical: true)
+          .controlSize(.small)
+          .foregroundStyle(.gray)
+      }
     }
+    .alert(
+      Text("PinSortWarningTitle", tableName: "StorageSettings"),
+      isPresented: isShowingPinSortWarning,
+      presenting: pendingPinSortBy
+    ) { pendingPinSortBy in
+      Button(role: .destructive) {
+        applyPinSorting(pendingPinSortBy)
+      } label: {
+        Text("PinSortWarningConfirm", tableName: "StorageSettings")
+      }
+      Button(role: .cancel) {
+      } label: {
+        Text("PinSortWarningCancel", tableName: "StorageSettings")
+      }
+    } message: { _ in
+      Text("PinSortWarningMessage", tableName: "StorageSettings")
+    }
+  }
+
+  private var pinSortBySelection: Binding<Sorter.PinBy> {
+    Binding(
+      get: { pinSortBy },
+      set: { newValue in
+        if pinSortBy == .custom,
+           newValue != .custom,
+           History.shared.pinSortingWouldChangeCurrentOrder(newValue) {
+          pendingPinSortBy = newValue
+        } else {
+          applyPinSorting(newValue)
+        }
+      }
+    )
+  }
+
+  private var isShowingPinSortWarning: Binding<Bool> {
+    Binding(
+      get: { pendingPinSortBy != nil },
+      set: { isPresented in
+        if !isPresented {
+          pendingPinSortBy = nil
+        }
+      }
+    )
+  }
+
+  private func applyPinSorting(_ pinSortBy: Sorter.PinBy) {
+    History.shared.setPinSorting(pinSortBy)
+    pendingPinSortBy = nil
   }
 }
 

--- a/Maccy/Settings/en.lproj/StorageSettings.strings
+++ b/Maccy/Settings/en.lproj/StorageSettings.strings
@@ -12,11 +12,3 @@
 "FirstCopiedAt" = "Time of first copy";
 "NumberOfCopies" = "Number of copies";
 "SortByTooltip" = "Default: Time of last copy.";
-"SortPinsBy" = "Sort pins by:";
-"PinLetter" = "Pin letter";
-"Custom" = "Custom";
-"SortPinsByDescription" = "Pins can be reordered by drag and drop when Custom is selected.";
-"PinSortWarningTitle" = "Change pin sorting?";
-"PinSortWarningMessage" = "Your custom pin order will be lost.";
-"PinSortWarningConfirm" = "Change Sorting";
-"PinSortWarningCancel" = "Cancel";

--- a/Maccy/Settings/en.lproj/StorageSettings.strings
+++ b/Maccy/Settings/en.lproj/StorageSettings.strings
@@ -12,3 +12,11 @@
 "FirstCopiedAt" = "Time of first copy";
 "NumberOfCopies" = "Number of copies";
 "SortByTooltip" = "Default: Time of last copy.";
+"SortPinsBy" = "Sort pins by:";
+"PinLetter" = "Pin letter";
+"Custom" = "Custom";
+"SortPinsByDescription" = "Pins can be reordered by drag and drop when Custom is selected.";
+"PinSortWarningTitle" = "Change pin sorting?";
+"PinSortWarningMessage" = "Your custom pin order will be lost.";
+"PinSortWarningConfirm" = "Change Sorting";
+"PinSortWarningCancel" = "Cancel";

--- a/Maccy/Sorter.swift
+++ b/Maccy/Sorter.swift
@@ -23,33 +23,78 @@ class Sorter {
     }
   }
 
+  enum PinBy: String, CaseIterable, Identifiable, CustomStringConvertible, Defaults.Serializable {
+    case lastCopiedAt
+    case firstCopiedAt
+    case numberOfCopies
+    case pinLetter
+    case custom
+
+    var id: Self { self }
+
+    var description: String {
+      if let by = By(rawValue: rawValue) {
+        return by.description
+      }
+
+      switch self {
+      case .pinLetter:
+        return NSLocalizedString("PinLetter", tableName: "StorageSettings", comment: "")
+      case .custom:
+        return NSLocalizedString("Custom", tableName: "StorageSettings", comment: "")
+      default:
+        return rawValue
+      }
+    }
+  }
+
   func sort(_ items: [HistoryItem], by: By = Defaults[.sortBy]) -> [HistoryItem] {
     let sortedUnpinned = items
       .filter { $0.pin == nil }
       .sorted(by: { bySortingAlgorithm($0, $1, by) })
 
     let pinnedItems = items.filter { $0.pin != nil }
-    let pinOrder = Defaults[.pinOrder].pins
-
-    var pinnedByPin: [String: HistoryItem] = [:]
-    for item in pinnedItems {
-      if let pin = item.pin {
-        pinnedByPin[pin] = item
-      }
-    }
-
-    var orderedPinned: [HistoryItem] = pinOrder.compactMap { pinnedByPin[$0] }
-    let orderedPinSet = Set(pinOrder)
-    orderedPinned += pinnedItems.filter {
-      guard let pin = $0.pin else { return false }
-      return !orderedPinSet.contains(pin)
-    }
+    let sortedPinned = sortPins(pinnedItems, key: \.self)
 
     switch Defaults[.pinTo] {
     case .top:
-      return orderedPinned + sortedUnpinned
+      return sortedPinned + sortedUnpinned
     case .bottom:
-      return sortedUnpinned + orderedPinned
+      return sortedUnpinned + sortedPinned
+    }
+  }
+
+  func sortPins(
+    _ items: [HistoryItem],
+    by: PinBy = Defaults[.pinSortBy]
+  ) -> [HistoryItem] {
+    return sortPins(items, key: \.self, by: by)
+  }
+
+  func sortPins<T>(
+    _ items: [T],
+    key: (T) -> HistoryItem,
+    by: PinBy = Defaults[.pinSortBy]
+  ) -> [T] {
+    if let by = By(rawValue: by.rawValue) {
+      return stableSort(items, key: key) { bySortingAlgorithm($0, $1, by) }
+    }
+
+    switch by {
+    case .pinLetter:
+      return stableSort(items, key: key) { ($0.pin ?? "") < ($1.pin ?? "") }
+    case .custom:
+      let indexes = Dictionary(
+        uniqueKeysWithValues: Defaults[.pinOrder].pins.enumerated().map {
+          ($0.element, $0.offset)
+        }
+      )
+      return stableSort(items, key: key) {
+        ($0.pin.flatMap { indexes[$0] } ?? Int.max)
+          < ($1.pin.flatMap { indexes[$0] } ?? Int.max)
+      }
+    default:
+      return items
     }
   }
 
@@ -62,6 +107,24 @@ class Sorter {
     default:
       return lhs.lastCopiedAt > rhs.lastCopiedAt
     }
+  }
+
+  private func stableSort<T>(
+    _ items: [T],
+    key: (T) -> HistoryItem,
+    by areInIncreasingOrder: (HistoryItem, HistoryItem) -> Bool
+  ) -> [T] {
+    items.enumerated().sorted { lhs, rhs in
+      let lhsItem = key(lhs.element)
+      let rhsItem = key(rhs.element)
+      if areInIncreasingOrder(lhsItem, rhsItem) {
+        return true
+      }
+      if areInIncreasingOrder(rhsItem, lhsItem) {
+        return false
+      }
+      return lhs.offset < rhs.offset
+    }.map(\.element)
   }
 
 }

--- a/Maccy/Sorter.swift
+++ b/Maccy/Sorter.swift
@@ -23,78 +23,33 @@ class Sorter {
     }
   }
 
-  enum PinBy: String, CaseIterable, Identifiable, CustomStringConvertible, Defaults.Serializable {
-    case lastCopiedAt
-    case firstCopiedAt
-    case numberOfCopies
-    case pinLetter
-    case custom
-
-    var id: Self { self }
-
-    var description: String {
-      if let by = By(rawValue: rawValue) {
-        return by.description
-      }
-
-      switch self {
-      case .pinLetter:
-        return NSLocalizedString("PinLetter", tableName: "StorageSettings", comment: "")
-      case .custom:
-        return NSLocalizedString("Custom", tableName: "StorageSettings", comment: "")
-      default:
-        return rawValue
-      }
-    }
-  }
-
   func sort(_ items: [HistoryItem], by: By = Defaults[.sortBy]) -> [HistoryItem] {
     let sortedUnpinned = items
       .filter { $0.pin == nil }
       .sorted(by: { bySortingAlgorithm($0, $1, by) })
 
     let pinnedItems = items.filter { $0.pin != nil }
-    let sortedPinned = sortPins(pinnedItems, key: \.self)
+    let pinOrder = Defaults[.pinOrder].pins
+
+    var pinnedByPin: [String: HistoryItem] = [:]
+    for item in pinnedItems {
+      if let pin = item.pin {
+        pinnedByPin[pin] = item
+      }
+    }
+
+    var orderedPinned: [HistoryItem] = pinOrder.compactMap { pinnedByPin[$0] }
+    let orderedPinSet = Set(pinOrder)
+    orderedPinned += pinnedItems.filter {
+      guard let pin = $0.pin else { return false }
+      return !orderedPinSet.contains(pin)
+    }
 
     switch Defaults[.pinTo] {
     case .top:
-      return sortedPinned + sortedUnpinned
+      return orderedPinned + sortedUnpinned
     case .bottom:
-      return sortedUnpinned + sortedPinned
-    }
-  }
-
-  func sortPins(
-    _ items: [HistoryItem],
-    by: PinBy = Defaults[.pinSortBy]
-  ) -> [HistoryItem] {
-    return sortPins(items, key: \.self, by: by)
-  }
-
-  func sortPins<T>(
-    _ items: [T],
-    key: (T) -> HistoryItem,
-    by: PinBy = Defaults[.pinSortBy]
-  ) -> [T] {
-    if let by = By(rawValue: by.rawValue) {
-      return stableSort(items, key: key) { bySortingAlgorithm($0, $1, by) }
-    }
-
-    switch by {
-    case .pinLetter:
-      return stableSort(items, key: key) { ($0.pin ?? "") < ($1.pin ?? "") }
-    case .custom:
-      let indexes = Dictionary(
-        uniqueKeysWithValues: Defaults[.pinOrder].pins.enumerated().map {
-          ($0.element, $0.offset)
-        }
-      )
-      return stableSort(items, key: key) {
-        ($0.pin.flatMap { indexes[$0] } ?? Int.max)
-          < ($1.pin.flatMap { indexes[$0] } ?? Int.max)
-      }
-    default:
-      return items
+      return sortedUnpinned + orderedPinned
     }
   }
 
@@ -107,24 +62,6 @@ class Sorter {
     default:
       return lhs.lastCopiedAt > rhs.lastCopiedAt
     }
-  }
-
-  private func stableSort<T>(
-    _ items: [T],
-    key: (T) -> HistoryItem,
-    by areInIncreasingOrder: (HistoryItem, HistoryItem) -> Bool
-  ) -> [T] {
-    items.enumerated().sorted { lhs, rhs in
-      let lhsItem = key(lhs.element)
-      let rhsItem = key(rhs.element)
-      if areInIncreasingOrder(lhsItem, rhsItem) {
-        return true
-      }
-      if areInIncreasingOrder(rhsItem, lhsItem) {
-        return false
-      }
-      return lhs.offset < rhs.offset
-    }.map(\.element)
   }
 
 }

--- a/Maccy/Sorter.swift
+++ b/Maccy/Sorter.swift
@@ -24,9 +24,33 @@ class Sorter {
   }
 
   func sort(_ items: [HistoryItem], by: By = Defaults[.sortBy]) -> [HistoryItem] {
-    return items
-      .sorted(by: { return bySortingAlgorithm($0, $1, by) })
-      .sorted(by: byPinned)
+    let sortedUnpinned = items
+      .filter { $0.pin == nil }
+      .sorted(by: { bySortingAlgorithm($0, $1, by) })
+
+    let pinnedItems = items.filter { $0.pin != nil }
+    let pinOrder = Defaults[.pinOrder].pins
+
+    var pinnedByPin: [String: HistoryItem] = [:]
+    for item in pinnedItems {
+      if let pin = item.pin {
+        pinnedByPin[pin] = item
+      }
+    }
+
+    var orderedPinned: [HistoryItem] = pinOrder.compactMap { pinnedByPin[$0] }
+    let orderedPinSet = Set(pinOrder)
+    orderedPinned += pinnedItems.filter {
+      guard let pin = $0.pin else { return false }
+      return !orderedPinSet.contains(pin)
+    }
+
+    switch Defaults[.pinTo] {
+    case .top:
+      return orderedPinned + sortedUnpinned
+    case .bottom:
+      return sortedUnpinned + orderedPinned
+    }
   }
 
   private func bySortingAlgorithm(_ lhs: HistoryItem, _ rhs: HistoryItem, _ by: By) -> Bool {
@@ -40,13 +64,6 @@ class Sorter {
     }
   }
 
-  private func byPinned(_ lhs: HistoryItem, _ rhs: HistoryItem) -> Bool {
-    if Defaults[.pinTo] == .bottom {
-      return (lhs.pin == nil) && (rhs.pin != nil)
-    } else {
-      return (lhs.pin != nil) && (rhs.pin == nil)
-    }
-  }
 }
 // swiftlint:enable identifier_name
 // swiftlint:enable type_name

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -60,6 +60,11 @@ struct ContentView: View {
     .environment(appState)
     .environment(modifierFlags)
     .environment(\.scenePhase, scenePhase)
+    .onChange(of: appState.isEditingItem) { _, isEditingItem in
+      // A sheet's text controls otherwise remain the logical focus target after
+      // dismissal, preventing the popup's key handler from receiving shortcuts.
+      searchFocused = !isEditingItem
+    }
     // FloatingPanel is not a scene, so let's implement custom scenePhase..
     .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) {
       guard !appState.isEditingItem else { return }

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -62,6 +62,8 @@ struct ContentView: View {
     .environment(\.scenePhase, scenePhase)
     // FloatingPanel is not a scene, so let's implement custom scenePhase..
     .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) {
+      guard !appState.isEditingItem else { return }
+
       if let window = $0.object as? NSWindow,
          let bundleIdentifier = Bundle.main.bundleIdentifier,
          window.identifier == NSUserInterfaceItemIdentifier(bundleIdentifier) {
@@ -69,6 +71,8 @@ struct ContentView: View {
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)) {
+      guard !appState.isEditingItem else { return }
+
       if let window = $0.object as? NSWindow,
          let bundleIdentifier = Bundle.main.bundleIdentifier,
          window.identifier == NSUserInterfaceItemIdentifier(bundleIdentifier) {

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -14,10 +14,10 @@ struct HistoryListView: View {
   @Default(.showFooter) private var showFooter
 
   private var pinnedItems: [HistoryItemDecorator] {
-    appState.history.pinnedItems.filter(\.isVisible)
+    appState.history.pinnedItems
   }
   private var unpinnedItems: [HistoryItemDecorator] {
-    appState.history.unpinnedItems.filter(\.isVisible)
+    appState.history.unpinnedItems
   }
   private var showPinsSeparator: Bool {
     pinsVisible && !unpinnedItems.isEmpty

--- a/Maccy/Views/HoverSelectionModifier.swift
+++ b/Maccy/Views/HoverSelectionModifier.swift
@@ -6,7 +6,7 @@ private struct HoverSelectionModifier: ViewModifier {
 
   func body(content: Content) -> some View {
     content.onHover { hovering in
-      if hovering {
+      if hovering && !appState.navigator.isDragAndDropInProgress {
         if !appState.navigator.isKeyboardNavigating && !appState.navigator.isMultiSelectInProgress {
           appState.navigator.selectWithoutScrolling(id: id)
         } else {

--- a/Maccy/Views/ItemEditorView.swift
+++ b/Maccy/Views/ItemEditorView.swift
@@ -1,0 +1,177 @@
+import AppKit
+import SwiftUI
+
+struct ItemEditorView: View {
+  @Environment(AppState.self) private var appState
+  @Environment(\.dismiss) private var dismiss
+
+  let item: HistoryItemDecorator
+
+  @State private var editableTitle: String
+  @State private var editableContent: String
+  @State private var selectedPin: String?
+  @State private var availablePins: [String] = []
+  @State private var isTextContent: Bool
+  @State private var isRichText: Bool
+
+  init(for item: HistoryItemDecorator) {
+    self.item = item
+    self._editableTitle = State(initialValue: item.item.title)
+    self._editableContent = State(initialValue: item.item.previewableText)
+    self._selectedPin = State(initialValue: item.item.pin)
+
+    // Content can only be edited safely as plain text.
+    self._isTextContent = State(
+      initialValue: item.hasPlainText && !item.hasImage && !item.hasFileURLs
+    )
+    self._isRichText = State(
+      initialValue: item.hasRichText && !item.hasImage && !item.hasFileURLs
+    )
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 10) {
+        HStack(alignment: .firstTextBaseline) {
+          Text("Alias", tableName: "PinsSettings")
+            .frame(width: 80, alignment: .leading)
+
+          TextField("", text: $editableTitle)
+        }
+
+        if item.isPinned {
+          HStack(alignment: .firstTextBaseline) {
+            Text("Key", tableName: "PinsSettings")
+              .frame(width: 80, alignment: .leading)
+
+            Picker("", selection: $selectedPin) {
+              ForEach(uniquePins, id: \.self) { pin in
+                Text(pin).tag(pin as String?)
+              }
+            }
+            .labelsHidden()
+            .frame(maxWidth: 220, alignment: .leading)
+          }
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Content", tableName: "PinsSettings")
+          .font(.headline)
+
+        contentEditor
+      }
+
+      if isRichText {
+        Label {
+          Text("RichTextEditWarning", tableName: "PinsSettings")
+        } icon: {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundStyle(.orange)
+        }
+        .font(.footnote)
+      }
+
+      HStack {
+        Spacer()
+        Button(Self.cancelButtonTitle, role: .cancel) {
+          dismiss()
+        }
+        .keyboardShortcut(.cancelAction)
+
+        Button(Self.doneButtonTitle) {
+          applyChanges()
+          dismiss()
+        }
+        .keyboardShortcut(.defaultAction)
+      }
+    }
+    .padding(16)
+    .frame(minWidth: 540, minHeight: 360)
+    .onAppear {
+      availablePins = appState.history.availablePins
+    }
+  }
+
+  private static var cancelButtonTitle: String {
+    appKitString("Cancel")
+  }
+
+  private static var doneButtonTitle: String {
+    appKitString("Done")
+  }
+
+  private static func appKitString(_ key: String) -> String {
+    guard let bundle = Bundle(identifier: "com.apple.AppKit") else {
+      return key
+    }
+
+    return NSLocalizedString(key, bundle: bundle, value: key, comment: "")
+  }
+
+  @ViewBuilder
+  private var contentEditor: some View {
+    Group {
+      if isTextContent || isRichText {
+        TextEditor(text: $editableContent)
+          .font(.body)
+          .scrollContentBackground(.hidden)
+          .background(Color.clear)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 6)
+      } else {
+        Text("ContentIsNotText", tableName: "PinsSettings")
+          .foregroundStyle(.secondary)
+          .italic()
+          .frame(
+            maxWidth: .infinity,
+            maxHeight: .infinity,
+            alignment: .topLeading
+          )
+          .padding(12)
+      }
+    }
+    .frame(maxWidth: .infinity, minHeight: 180)
+    .background {
+      RoundedRectangle(cornerRadius: 6, style: .continuous)
+        .fill(Color(nsColor: .textBackgroundColor))
+    }
+    .overlay {
+      RoundedRectangle(cornerRadius: 6, style: .continuous)
+        .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+    }
+    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+  }
+
+  private var uniquePins: [String] {
+    Array(Set(availablePins + [item.item.pin, selectedPin].compactMap { $0 }))
+      .sorted()
+  }
+
+  private func applyChanges() {
+    item.item.title = editableTitle
+    item.title = editableTitle
+
+    if let selectedPin {
+      appState.history.updatePin(item.item, to: selectedPin)
+    }
+
+    guard isTextContent || isRichText else { return }
+
+    let historyItem = item.item
+    let stringType = NSPasteboard.PasteboardType.string.rawValue
+    historyItem.contents.removeAll { $0.type != stringType }
+
+    if let index = historyItem.contents.firstIndex(where: {
+      $0.type == stringType
+    }) {
+      if let data = editableContent.data(using: .utf8) {
+        historyItem.contents[index].value = data
+      }
+    } else if let data = editableContent.data(using: .utf8) {
+      historyItem.contents.append(
+        HistoryItemContent(type: stringType, value: data)
+      )
+    }
+  }
+}

--- a/Maccy/Views/LegacyReorderableContainer.swift
+++ b/Maccy/Views/LegacyReorderableContainer.swift
@@ -61,7 +61,7 @@ private struct LegacyDraggableItemDropDelegate<Item: Reorderable>: DropDelegate 
   }
 
   func performDrop(info: DropInfo) -> Bool {
-    dragContext.resetDragState(true)
+    dragContext.resetDragState()
     return true
   }
 
@@ -106,7 +106,7 @@ private struct LegacyDragSourceView<Item: Reorderable>: NSViewRepresentable {
         dragContext.startDrag(item)
       },
       onDragEnded: {
-        dragContext.resetDragState(true)
+        dragContext.resetDragState()
       }
     )
   }

--- a/Maccy/Views/LegacyReorderableContainer.swift
+++ b/Maccy/Views/LegacyReorderableContainer.swift
@@ -6,6 +6,7 @@ internal struct LegacyDraggableItemModifier<Item: Reorderable>: ViewModifier {
   @Environment(AppState.self) private var appState
   @Environment(ModifierFlags.self) private var modifierFlags
   @Environment(\.reorderableDragContext) private var dragContext
+  @State private var dropTargetSize: CGSize = .zero
 
   let item: Item
 
@@ -14,6 +15,11 @@ internal struct LegacyDraggableItemModifier<Item: Reorderable>: ViewModifier {
     if let dragContext {
       content
         .opacity(dragContext.isDragged(item) ? 0.5 : 1)
+        .onGeometryChange(for: CGSize.self) { proxy in
+          proxy.size
+        } action: { size in
+          dropTargetSize = size
+        }
         .background(
           LegacyDragSourceView(
             item: item,
@@ -26,7 +32,8 @@ internal struct LegacyDraggableItemModifier<Item: Reorderable>: ViewModifier {
           of: [dragContext.contentType],
           delegate: LegacyDraggableItemDropDelegate(
             item: item,
-            dragContext: dragContext
+            dragContext: dragContext,
+            targetSize: dropTargetSize
           )
         )
     } else {
@@ -35,26 +42,32 @@ internal struct LegacyDraggableItemModifier<Item: Reorderable>: ViewModifier {
   }
 }
 
-private struct LegacyDraggableItemDropDelegate<Item: Reorderable>: DropDelegate
-{
+private struct LegacyDraggableItemDropDelegate<Item: Reorderable>: DropDelegate {
   let item: Item
   let dragContext: ReorderableDragContext
+  let targetSize: CGSize
 
   func validateDrop(info: DropInfo) -> Bool {
     info.hasItemsConforming(to: [dragContext.contentType])
   }
 
   func dropEntered(info: DropInfo) {
-    dragContext.move(item)
+    move(info)
   }
 
   func dropUpdated(info: DropInfo) -> DropProposal? {
-    DropProposal(operation: .move)
+    move(info)
+    return DropProposal(operation: .move)
   }
 
   func performDrop(info: DropInfo) -> Bool {
     dragContext.resetDragState(true)
     return true
+  }
+
+  private func move(_ info: DropInfo) {
+    guard targetSize.height > 0 else { return }
+    dragContext.move(item, dropEdge(at: info.location, in: targetSize))
   }
 }
 

--- a/Maccy/Views/LegacyReorderableContainer.swift
+++ b/Maccy/Views/LegacyReorderableContainer.swift
@@ -1,0 +1,249 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+internal struct LegacyDraggableItemModifier<Item: Reorderable>: ViewModifier {
+  @Environment(AppState.self) private var appState
+  @Environment(ModifierFlags.self) private var modifierFlags
+  @Environment(\.reorderableDragContext) private var dragContext
+
+  let item: Item
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if let dragContext {
+      content
+        .opacity(dragContext.isDragged(item) ? 0.5 : 1)
+        .background(
+          LegacyDragSourceView(
+            item: item,
+            dragContext: dragContext,
+            appState: appState,
+            modifierFlags: modifierFlags
+          )
+        )
+        .onDrop(
+          of: [dragContext.contentType],
+          delegate: LegacyDraggableItemDropDelegate(
+            item: item,
+            dragContext: dragContext
+          )
+        )
+    } else {
+      content
+    }
+  }
+}
+
+private struct LegacyDraggableItemDropDelegate<Item: Reorderable>: DropDelegate
+{
+  let item: Item
+  let dragContext: ReorderableDragContext
+
+  func validateDrop(info: DropInfo) -> Bool {
+    info.hasItemsConforming(to: [dragContext.contentType])
+  }
+
+  func dropEntered(info: DropInfo) {
+    dragContext.move(item)
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    DropProposal(operation: .move)
+  }
+
+  func performDrop(info: DropInfo) -> Bool {
+    dragContext.resetDragState(true)
+    return true
+  }
+}
+
+private struct LegacyDragSourceView<Item: Reorderable>: NSViewRepresentable {
+  let item: Item
+  let dragContext: ReorderableDragContext
+  let appState: AppState
+  let modifierFlags: ModifierFlags
+
+  func makeNSView(context: Context) -> DragSourceView {
+    let view = DragSourceView()
+    view.configuration = configuration
+    return view
+  }
+
+  func updateNSView(_ view: DragSourceView, context: Context) {
+    view.configuration = configuration
+  }
+
+  static func dismantleNSView(_ view: DragSourceView, coordinator: ()) {
+    view.removeEventMonitor()
+  }
+
+  private var configuration: LegacyDragSourceConfiguration {
+    LegacyDragSourceConfiguration(
+      contentType: dragContext.contentType,
+      makeDragPreview: { sourceView in
+        dragPreviewImage(
+          for: dragContext.dragPreview(item),
+          sourceView: sourceView,
+          appState: appState,
+          modifierFlags: modifierFlags
+        )
+      },
+      onDragStarted: {
+        dragContext.startDrag(item)
+      },
+      onDragEnded: {
+        dragContext.resetDragState(true)
+      }
+    )
+  }
+}
+
+private struct LegacyDragSourceConfiguration {
+  let contentType: UTType
+  let makeDragPreview: (NSView) -> NSImage
+  let onDragStarted: () -> Void
+  let onDragEnded: () -> Void
+}
+
+private final class DragSourceView: NSView, NSDraggingSource {
+  var configuration: LegacyDragSourceConfiguration? {
+    didSet {
+      updateEventMonitor()
+    }
+  }
+
+  private var localEventMonitor: Any?
+  private var mouseDownEvent: NSEvent?
+  private var isDragging = false
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    updateEventMonitor()
+  }
+
+  override var isFlipped: Bool {
+    true
+  }
+
+  func updateEventMonitor() {
+    if window != nil, configuration != nil, localEventMonitor == nil {
+      localEventMonitor = NSEvent.addLocalMonitorForEvents(
+        matching: [.leftMouseDown, .leftMouseDragged, .leftMouseUp]
+      ) { [weak self] event in
+        self?.handle(event) ?? event
+      }
+    } else if window == nil || configuration == nil {
+      removeEventMonitor()
+    }
+  }
+
+  func removeEventMonitor() {
+    if let localEventMonitor {
+      NSEvent.removeMonitor(localEventMonitor)
+      self.localEventMonitor = nil
+    }
+    mouseDownEvent = nil
+    isDragging = false
+  }
+
+  deinit {
+    removeEventMonitor()
+  }
+
+  private func handle(_ event: NSEvent) -> NSEvent? {
+    switch event.type {
+    case .leftMouseDown:
+      mouseDownEvent = contains(event) ? event : nil
+      return event
+    case .leftMouseDragged:
+      guard mouseDownEvent != nil, !isDragging else { return event }
+      startDragging(with: event)
+      return nil
+    case .leftMouseUp:
+      mouseDownEvent = nil
+      return event
+    default:
+      return event
+    }
+  }
+
+  private func contains(_ event: NSEvent) -> Bool {
+    guard event.window == window else { return false }
+    return bounds.contains(convert(event.locationInWindow, from: nil))
+  }
+
+  private func startDragging(with event: NSEvent) {
+    guard let configuration else { return }
+
+    isDragging = true
+    configuration.onDragStarted()
+
+    let pasteboardItem = NSPasteboardItem()
+    pasteboardItem.setString(
+      UUID().uuidString,
+      forType: NSPasteboard.PasteboardType(configuration.contentType.identifier)
+    )
+
+    let preview = configuration.makeDragPreview(self)
+    let draggingItem = NSDraggingItem(pasteboardWriter: pasteboardItem)
+    draggingItem.setDraggingFrame(
+      NSRect(origin: .zero, size: preview.size),
+      contents: preview
+    )
+
+    beginDraggingSession(with: [draggingItem], event: event, source: self)
+  }
+
+  func draggingSession(
+    _ session: NSDraggingSession,
+    sourceOperationMaskFor context: NSDraggingContext
+  ) -> NSDragOperation {
+    context == .withinApplication ? .move : []
+  }
+
+  func draggingSession(
+    _ session: NSDraggingSession,
+    endedAt screenPoint: NSPoint,
+    operation: NSDragOperation
+  ) {
+    isDragging = false
+    mouseDownEvent = nil
+    configuration?.onDragEnded()
+  }
+}
+
+private func dragPreviewImage(
+  for preview: AnyView,
+  sourceView: NSView,
+  appState: AppState,
+  modifierFlags: ModifierFlags
+) -> NSImage {
+  let hostingView = NSHostingView(
+    rootView:
+      preview
+      .environment(appState)
+      .environment(modifierFlags)
+  )
+  let fittingSize = hostingView.fittingSize
+  let size = NSSize(
+    width: max(sourceView.bounds.width, 1),
+    height: max(sourceView.bounds.height, fittingSize.height, 1)
+  )
+
+  hostingView.frame = NSRect(origin: .zero, size: size)
+  hostingView.layoutSubtreeIfNeeded()
+
+  guard
+    let bitmap = hostingView.bitmapImageRepForCachingDisplay(
+      in: hostingView.bounds
+    )
+  else {
+    return NSImage(size: size)
+  }
+  hostingView.cacheDisplay(in: hostingView.bounds, to: bitmap)
+
+  let image = NSImage(size: size)
+  image.addRepresentation(bitmap)
+  return image
+}

--- a/Maccy/Views/MovableByWindowBackgroundModifier.swift
+++ b/Maccy/Views/MovableByWindowBackgroundModifier.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+private struct ExcludeFromWindowMovableByBackgroundModifier: ViewModifier {
+  @Environment(AppState.self) private var appState
+
+  func body(content: Content) -> some View {
+    content
+      .onHover { inside in
+        if let window = appState.appDelegate?.panel {
+          window.isMovableByWindowBackground = !inside
+        }
+      }
+  }
+}
+
+extension View {
+  func excludeFromWindowMovableByBackground() -> some View {
+    self.modifier(
+      ExcludeFromWindowMovableByBackgroundModifier()
+    )
+  }
+}

--- a/Maccy/Views/MultipleSelectionListView.swift
+++ b/Maccy/Views/MultipleSelectionListView.swift
@@ -1,17 +1,61 @@
 import SwiftUI
 
-struct MultipleSelectionListView<Element, ID, Content>: View
-    where ID: Hashable, Content: View, ID == Element.ID, Element: Identifiable {
+struct IndexedElement<Element: Identifiable & Equatable>: Identifiable, Equatable {
+  let index: Int
+  let element: Element
+
+  var id: Element.ID {
+    element.id
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.element == rhs.element
+  }
+}
+
+struct MultipleSelectionListView<Element, RowContent, ModifiedForEach>: View
+where Element: Identifiable & Equatable, RowContent: View, ModifiedForEach: View {
   var items: [Element]
-  var content: (Element?, Element, Element?, Int) -> Content
+  var content: (Element?, Element, Element?, Int) -> RowContent
+  var forEachModifier: (ForEach<[IndexedElement<Element>], Element.ID, RowContent>) -> ModifiedForEach
+
+  init(
+    items: [Element],
+    @ViewBuilder content: @escaping (Element?, Element, Element?, Int) -> RowContent
+  ) where ModifiedForEach == ForEach<[IndexedElement<Element>], Element.ID, RowContent> {
+    self.items = items
+    self.content = content
+    self.forEachModifier = { $0 }
+  }
+
+  init(
+    items: [Element],
+    @ViewBuilder content: @escaping (Element?, Element, Element?, Int) -> RowContent,
+    @ViewBuilder forEachModifier: @escaping (
+      ForEach<[IndexedElement<Element>], Element.ID, RowContent>
+    ) -> ModifiedForEach
+  ) {
+    self.items = items
+    self.content = content
+    self.forEachModifier = forEachModifier
+  }
 
   var body: some View {
+    let indexedItems = items.enumerated().map {
+      IndexedElement(index: $0.offset, element: $0.element)
+    }
+
     LazyVStack(spacing: 0) {
-      ForEach(Array(items.enumerated()), id: \.element.id) { (index, element) in
-        let previous = index > 0 ? items[index - 1] : nil
-        let next = index < items.count - 1 ? items[index + 1] : nil
-        content(previous, element, next, index)
-      }
+      forEachModifier(
+        ForEach(indexedItems, id: \.id) { indexed in
+          let index = indexed.index
+          let element = indexed.element
+          let previous = index > 0 ? items[index - 1] : nil
+          let next = index < items.count - 1 ? items[index + 1] : nil
+
+          content(previous, element, next, index)
+        }
+      )
     }
   }
 }

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -51,9 +51,6 @@ struct PinsView: View {
             withAnimation(.default.speed(2)) {
               move(from: source, to: destination)
             }
-          },
-          moveCompletedAction: {
-            appState.history.recomputeItemsAfterReordering()
           }
         )
       } else {

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -1,13 +1,76 @@
 import SwiftUI
+import UniformTypeIdentifiers
+
+private enum PinReorderDrag {
+  static let contentType = UTType(exportedAs: "org.p0deje.Maccy.pin-reorder")
+}
 
 struct PinsView: View {
   @Environment(AppState.self) private var appState
 
   var items: [HistoryItemDecorator]
+  @State private var draggedItems: [HistoryItemDecorator] = []
+
+  private var isDragAndDropEnabled: Bool {
+    appState.history.searchQuery.isEmpty
+  }
 
   var body: some View {
-    MultipleSelectionListView(items: items) { previous, item, next, index in
-      HistoryItemView(item: item, previous: previous, next: next, index: index)
+    LazyVStack(spacing: 0) {
+      if isDragAndDropEnabled {
+        MultipleSelectionListView(items: items) { prev, item, next, index in
+          HistoryItemView(
+            item: item,
+            previous: prev,
+            next: next,
+            index: index
+          )
+          .draggableItem(item)
+        }
+        .draggableContainer(
+          items: items,
+          contentType: PinReorderDrag.contentType,
+          dragPreview: { draggedItems in
+            MultipleSelectionListView(items: draggedItems) { prev, item, next, index in
+              HistoryItemView(
+                item: item,
+                previous: prev,
+                next: next,
+                index: index
+              )
+            }
+            .background(.regularMaterial)
+            .clipShape(SelectionAppearance.none.rect(cornerRadius: Popup.cornerRadius))
+          },
+          selection: Binding(
+            get: { appState.navigator.selection },
+            set: { appState.navigator.selection = $0 }
+          ),
+          draggedItems: $draggedItems,
+          moveAction: { from, to in
+            withAnimation(.default.speed(2)) {
+              move(from: from, to: to)
+            }
+          },
+          moveCompletedAction: {
+            appState.history.recomputeItemsAfterReordering()
+          }
+        )
+      } else {
+        MultipleSelectionListView(items: items) { prev, item, next, index in
+          HistoryItemView(
+            item: item,
+            previous: prev,
+            next: prev,
+            index: index
+          )
+        }
+      }
     }
+    .excludeFromWindowMovableByBackground()
+  }
+
+  func move(from source: IndexSet, to destination: Int) {
+    appState.history.movePin(from: source, to: destination)
   }
 }

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -1,4 +1,3 @@
-import Defaults
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -8,13 +7,12 @@ private enum PinReorderDrag {
 
 struct PinsView: View {
   @Environment(AppState.self) private var appState
-  @Default(.pinSortBy) private var pinSortBy
 
   var items: [HistoryItemDecorator]
   @State private var draggedItems: [HistoryItemDecorator] = []
 
   private var isDragAndDropEnabled: Bool {
-    appState.history.searchQuery.isEmpty && pinSortBy == .custom
+    appState.history.searchQuery.isEmpty
   }
 
   var body: some View {

--- a/Maccy/Views/PinsView.swift
+++ b/Maccy/Views/PinsView.swift
@@ -1,3 +1,4 @@
+import Defaults
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -7,12 +8,13 @@ private enum PinReorderDrag {
 
 struct PinsView: View {
   @Environment(AppState.self) private var appState
+  @Default(.pinSortBy) private var pinSortBy
 
   var items: [HistoryItemDecorator]
   @State private var draggedItems: [HistoryItemDecorator] = []
 
   private var isDragAndDropEnabled: Bool {
-    appState.history.searchQuery.isEmpty
+    appState.history.searchQuery.isEmpty && pinSortBy == .custom
   }
 
   var body: some View {
@@ -47,9 +49,9 @@ struct PinsView: View {
             set: { appState.navigator.selection = $0 }
           ),
           draggedItems: $draggedItems,
-          moveAction: { from, to in
+          moveAction: { source, destination in
             withAnimation(.default.speed(2)) {
-              move(from: from, to: to)
+              move(from: source, to: destination)
             }
           },
           moveCompletedAction: {
@@ -61,7 +63,7 @@ struct PinsView: View {
           HistoryItemView(
             item: item,
             previous: prev,
-            next: prev,
+            next: next,
             index: index
           )
         }

--- a/Maccy/Views/ReorderableContainer.swift
+++ b/Maccy/Views/ReorderableContainer.swift
@@ -11,10 +11,8 @@ private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>:
   @Binding var draggedItems: [Item]
 
   let moveAction: (IndexSet, Int) -> Void
-  let moveCompletedAction: () -> Void
 
   @State private var active: Item?
-  @State private var hasChangedLocation = false
 
   func body(content: Content) -> some View {
     content
@@ -58,11 +56,7 @@ private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>:
     AppState.shared.navigator.isDragAndDropInProgress = true
   }
 
-  private func resetDragState(didCompleteMove: Bool = false) {
-    if didCompleteMove && hasChangedLocation {
-      moveCompletedAction()
-    }
-    hasChangedLocation = false
+  private func resetDragState() {
     draggedItems = []
     active = nil
     AppState.shared.navigator.isDragAndDropInProgress = false
@@ -88,7 +82,6 @@ private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>:
       edge: edge
     ) else { return }
 
-    hasChangedLocation = true
     moveAction(source, destinationIndex)
   }
 
@@ -127,13 +120,13 @@ private struct DraggableItemModifier<Item: Reorderable>: ViewModifier {
         .onDragSessionUpdated { session in
           switch session.phase {
           case .ended:
-            dragContext.resetDragState(true)
+            dragContext.resetDragState()
           default:
             break
           }
         }
         .onDrop(of: [dragContext.contentType], isTargeted: nil) { _ in
-          dragContext.resetDragState(true)
+          dragContext.resetDragState()
           return true
         }
         .onDropSessionUpdated { session in
@@ -144,7 +137,7 @@ private struct DraggableItemModifier<Item: Reorderable>: ViewModifier {
               dropEdge(at: session.location, in: session.size)
             )
           case .ended:
-            dragContext.resetDragState(true)
+            dragContext.resetDragState()
           default:
             break
           }
@@ -176,7 +169,7 @@ struct ReorderableDragContext {
   let isDragged: (Any) -> Bool
   let dragPreview: (Any) -> AnyView
   let startDrag: (Any) -> Void
-  let resetDragState: (Bool) -> Void
+  let resetDragState: () -> Void
   let move: (Any, ReorderableDropEdge) -> Void
 }
 
@@ -223,8 +216,7 @@ extension View {
     @ViewBuilder dragPreview: @escaping ([Item]) -> DragPreview,
     selection: Binding<Selection<Item>>,
     draggedItems: Binding<[Item]>,
-    moveAction: @escaping (IndexSet, Int) -> Void,
-    moveCompletedAction: @escaping () -> Void = {}
+    moveAction: @escaping (IndexSet, Int) -> Void
   ) -> some View {
     modifier(
       DraggableContainerModifier(
@@ -233,8 +225,7 @@ extension View {
         dragPreview: dragPreview,
         selection: selection,
         draggedItems: draggedItems,
-        moveAction: moveAction,
-        moveCompletedAction: moveCompletedAction
+        moveAction: moveAction
       )
     )
   }

--- a/Maccy/Views/ReorderableContainer.swift
+++ b/Maccy/Views/ReorderableContainer.swift
@@ -3,9 +3,7 @@ import UniformTypeIdentifiers
 
 typealias Reorderable = Identifiable & Equatable
 
-private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>:
-  ViewModifier
-{
+private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>: ViewModifier {
   let items: [Item]
   let contentType: UTType
   let dragPreview: ([Item]) -> DragPreview
@@ -76,16 +74,22 @@ private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>:
       : [item]
   }
 
-  private func move(to item: Any) {
+  private func move(to item: Any, at edge: ReorderableDropEdge) {
     guard let item = item as? Item else { return }
     guard !draggedItems.contains(item), let current = active else { return }
-    guard let from = items.firstIndex(of: current) else { return }
-    guard let to = items.firstIndex(of: item) else { return }
+    guard let currentIndex = items.firstIndex(of: current) else { return }
+    guard let targetIndex = items.firstIndex(of: item) else { return }
     let source = sourceIndexes
     guard !source.isEmpty else { return }
 
+    guard let destinationIndex = reorderDestination(
+      currentIndex: currentIndex,
+      targetIndex: targetIndex,
+      edge: edge
+    ) else { return }
+
     hasChangedLocation = true
-    moveAction(source, to > from ? to + 1 : to)
+    moveAction(source, destinationIndex)
   }
 
   private var sourceIndexes: IndexSet {
@@ -109,7 +113,8 @@ private struct DraggableItemModifier<Item: Reorderable>: ViewModifier {
       content
         .opacity(dragContext.isDragged(item) ? 0.5 : 1)
         .onDrag {
-          itemProvider(for: item, contentType: dragContext.contentType)
+          dragContext.startDrag(item)
+          return itemProvider(for: item, contentType: dragContext.contentType)
         } preview: {
           dragContext.dragPreview(item)
         }
@@ -121,9 +126,7 @@ private struct DraggableItemModifier<Item: Reorderable>: ViewModifier {
         )
         .onDragSessionUpdated { session in
           switch session.phase {
-          case .initial:
-            dragContext.startDrag(item)
-          case .ended(_):
+          case .ended:
             dragContext.resetDragState(true)
           default:
             break
@@ -135,9 +138,12 @@ private struct DraggableItemModifier<Item: Reorderable>: ViewModifier {
         }
         .onDropSessionUpdated { session in
           switch session.phase {
-          case .entering:
-            dragContext.move(item)
-          case .ended(_):
+          case .entering, .active:
+            dragContext.move(
+              item,
+              dropEdge(at: session.location, in: session.size)
+            )
+          case .ended:
             dragContext.resetDragState(true)
           default:
             break
@@ -171,7 +177,32 @@ struct ReorderableDragContext {
   let dragPreview: (Any) -> AnyView
   let startDrag: (Any) -> Void
   let resetDragState: (Bool) -> Void
-  let move: (Any) -> Void
+  let move: (Any, ReorderableDropEdge) -> Void
+}
+
+enum ReorderableDropEdge {
+  case before
+  case after
+}
+
+func dropEdge(at location: CGPoint, in targetSize: CGSize) -> ReorderableDropEdge {
+  location.y < targetSize.height / 2 ? .before : .after
+}
+
+func reorderDestination(
+  currentIndex: Int,
+  targetIndex: Int,
+  edge: ReorderableDropEdge
+) -> Int? {
+  if currentIndex < targetIndex {
+    // Move destinations use indexes from before the source is removed, so a
+    // downward move needs to insert after the target.
+    return edge == .after ? targetIndex + 1 : nil
+  }
+  if currentIndex > targetIndex {
+    return edge == .before ? targetIndex : nil
+  }
+  return nil
 }
 
 private struct ReorderableDragContextKey: EnvironmentKey {

--- a/Maccy/Views/ReorderableContainer.swift
+++ b/Maccy/Views/ReorderableContainer.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+typealias Reorderable = Identifiable & Equatable
+
+private struct DraggableContainerModifier<Item: Reorderable, DragPreview: View>:
+  ViewModifier
+{
+  let items: [Item]
+  let contentType: UTType
+  let dragPreview: ([Item]) -> DragPreview
+  @Binding var selection: Selection<Item>
+  @Binding var draggedItems: [Item]
+
+  let moveAction: (IndexSet, Int) -> Void
+  let moveCompletedAction: () -> Void
+
+  @State private var active: Item?
+  @State private var hasChangedLocation = false
+
+  func body(content: Content) -> some View {
+    content
+      .environment(\.reorderableDragContext, context)
+      .onChange(of: active) {
+        if active == nil {
+          resetDragState()
+        }
+      }
+      .onDisappear {
+        resetDragState()
+      }
+  }
+
+  private var context: ReorderableDragContext {
+    ReorderableDragContext(
+      contentType: contentType,
+      isDragged: isDragged,
+      dragPreview: preview,
+      startDrag: startDrag,
+      resetDragState: resetDragState,
+      move: move
+    )
+  }
+
+  private func isDragged(_ item: Any) -> Bool {
+    guard let item = item as? Item else { return false }
+    return draggedItems.contains(item)
+  }
+
+  private func preview(for item: Any) -> AnyView {
+    guard let item = item as? Item else { return AnyView(EmptyView()) }
+    return AnyView(dragPreview(itemsBeingDragged(startingWith: item)))
+  }
+
+  private func startDrag(_ item: Any) {
+    guard let item = item as? Item else { return }
+    resetDragState()
+    active = item
+    draggedItems = itemsBeingDragged(startingWith: item)
+    AppState.shared.navigator.isDragAndDropInProgress = true
+  }
+
+  private func resetDragState(didCompleteMove: Bool = false) {
+    if didCompleteMove && hasChangedLocation {
+      moveCompletedAction()
+    }
+    hasChangedLocation = false
+    draggedItems = []
+    active = nil
+    AppState.shared.navigator.isDragAndDropInProgress = false
+  }
+
+  private func itemsBeingDragged(startingWith item: Item) -> [Item] {
+    selection.items.contains(item)
+      ? items.filter { selection.items.contains($0) }
+      : [item]
+  }
+
+  private func move(to item: Any) {
+    guard let item = item as? Item else { return }
+    guard !draggedItems.contains(item), let current = active else { return }
+    guard let from = items.firstIndex(of: current) else { return }
+    guard let to = items.firstIndex(of: item) else { return }
+    let source = sourceIndexes
+    guard !source.isEmpty else { return }
+
+    hasChangedLocation = true
+    moveAction(source, to > from ? to + 1 : to)
+  }
+
+  private var sourceIndexes: IndexSet {
+    var source = IndexSet()
+    for (index, item) in items.enumerated() where draggedItems.contains(item) {
+      source.insert(index)
+    }
+    return source
+  }
+}
+
+@available(macOS 26.0, *)
+private struct DraggableItemModifier<Item: Reorderable>: ViewModifier {
+  @Environment(\.reorderableDragContext) private var dragContext
+
+  let item: Item
+
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    if let dragContext {
+      content
+        .opacity(dragContext.isDragged(item) ? 0.5 : 1)
+        .onDrag {
+          itemProvider(for: item, contentType: dragContext.contentType)
+        } preview: {
+          dragContext.dragPreview(item)
+        }
+        .dragConfiguration(
+          DragConfiguration(
+            operationsWithinApp: .init(allowCopy: false, allowMove: true),
+            operationsOutsideApp: .init(allowCopy: false, allowMove: false)
+          )
+        )
+        .onDragSessionUpdated { session in
+          switch session.phase {
+          case .initial:
+            dragContext.startDrag(item)
+          case .ended(_):
+            dragContext.resetDragState(true)
+          default:
+            break
+          }
+        }
+        .onDrop(of: [dragContext.contentType], isTargeted: nil) { _ in
+          dragContext.resetDragState(true)
+          return true
+        }
+        .onDropSessionUpdated { session in
+          switch session.phase {
+          case .entering:
+            dragContext.move(item)
+          case .ended(_):
+            dragContext.resetDragState(true)
+          default:
+            break
+          }
+        }
+    } else {
+      content
+    }
+  }
+
+}
+
+private func itemProvider<Item: Reorderable>(
+  for item: Item,
+  contentType: UTType
+) -> NSItemProvider {
+  let provider = NSItemProvider()
+  provider.registerDataRepresentation(
+    forTypeIdentifier: contentType.identifier,
+    visibility: .ownProcess
+  ) { completion in
+    completion(String(describing: item.id).data(using: .utf8), nil)
+    return nil
+  }
+  return provider
+}
+
+struct ReorderableDragContext {
+  let contentType: UTType
+  let isDragged: (Any) -> Bool
+  let dragPreview: (Any) -> AnyView
+  let startDrag: (Any) -> Void
+  let resetDragState: (Bool) -> Void
+  let move: (Any) -> Void
+}
+
+private struct ReorderableDragContextKey: EnvironmentKey {
+  static let defaultValue: ReorderableDragContext? = nil
+}
+
+extension EnvironmentValues {
+  var reorderableDragContext: ReorderableDragContext? {
+    get { self[ReorderableDragContextKey.self] }
+    set { self[ReorderableDragContextKey.self] = newValue }
+  }
+}
+
+extension View {
+  func draggableContainer<Item: Reorderable, DragPreview: View>(
+    items: [Item],
+    contentType: UTType,
+    @ViewBuilder dragPreview: @escaping ([Item]) -> DragPreview,
+    selection: Binding<Selection<Item>>,
+    draggedItems: Binding<[Item]>,
+    moveAction: @escaping (IndexSet, Int) -> Void,
+    moveCompletedAction: @escaping () -> Void = {}
+  ) -> some View {
+    modifier(
+      DraggableContainerModifier(
+        items: items,
+        contentType: contentType,
+        dragPreview: dragPreview,
+        selection: selection,
+        draggedItems: draggedItems,
+        moveAction: moveAction,
+        moveCompletedAction: moveCompletedAction
+      )
+    )
+  }
+
+  @ViewBuilder
+  func draggableItem<Item: Reorderable>(_ item: Item) -> some View {
+    if #available(macOS 26.0, *) {
+      modifier(DraggableItemModifier(item: item))
+    } else {
+      modifier(LegacyDraggableItemModifier(item: item))
+    }
+  }
+}

--- a/Maccy/Views/SlideoutView.swift
+++ b/Maccy/Views/SlideoutView.swift
@@ -25,8 +25,6 @@ extension View {
 
 struct SlideoutView<Content, Slideout>: View
 where Content: View, Slideout: View {
-  @Environment(AppState.self) private var appState
-
   let controller: SlideoutController
 
   @ViewBuilder var content: () -> Content
@@ -54,10 +52,8 @@ where Content: View, Slideout: View {
       // macOS 26 broke gestures if no background is present.
       // The slight opcaity white background is a workaround
       .background(Color.white.opacity(0.001))
+      .excludeFromWindowMovableByBackground()
       .onHover(perform: { inside in
-        if let window = appState.appDelegate?.panel {
-          window.isMovableByWindowBackground = !inside
-        }
         if inside {
           if #available(macOS 15.0, *) {
             NSCursor.columnResize.push()

--- a/Maccy/Views/ToolbarView.swift
+++ b/Maccy/Views/ToolbarView.swift
@@ -72,6 +72,7 @@ struct ToolbarButton<Label: View>: View {
 
 struct ToolbarView: View {
   @State private var appState = AppState.shared
+  @State private var editingItem: HistoryItemDecorator?
 
   @Namespace var unionNamespace
 
@@ -105,6 +106,17 @@ struct ToolbarView: View {
 
     let text = item.title.trimmingCharacters(in: .whitespacesAndNewlines)
     return text.isEmpty ? nil : item.title
+  }
+
+  private var editItemEnabled: Bool {
+    guard appState.navigator.selection.count == 1 else { return false }
+    guard let pinned = appState.navigator.selection.first else { return false }
+    return pinned.hasPlainText || pinned.hasRichText
+  }
+
+  private var editableItem: HistoryItemDecorator? {
+    guard editItemEnabled else { return nil }
+    return appState.navigator.selection.first
   }
 
   var body: some View {
@@ -143,6 +155,18 @@ struct ToolbarView: View {
         .disabled(pinActionDisabled)
 
         ToolbarButton {
+          appState.isEditingItem = true
+          editingItem = editableItem
+        } label: {
+          if editItemEnabled {
+            Image(systemName: "pencil")
+          } else {
+            Image(systemName: "pencil.slash")
+          }
+        }
+        .disabled(!editItemEnabled)
+
+        ToolbarButton {
           appState.deleteSelection()
         } label: {
           Image(systemName: "trash")
@@ -164,5 +188,15 @@ struct ToolbarView: View {
         .accessibilityLabel(Text("toolbar_remove_paste_stack_action"))
       }
     }
+    .sheet(item: $editingItem, onDismiss: {
+      finishEditingPinnedItem()
+    }) { item in
+      ItemEditorView(for: item)
+    }
+  }
+
+  private func finishEditingPinnedItem() {
+    editingItem = nil
+    appState.isEditingItem = false
   }
 }

--- a/Maccy/Views/ToolbarView.swift
+++ b/Maccy/Views/ToolbarView.swift
@@ -34,8 +34,6 @@ private struct KeyboardShortcutHelpModifier: ViewModifier {
 }
 
 struct ToolbarButton<Label: View>: View {
-  @Environment(AppState.self) private var appState
-
   let action: @MainActor () -> Void
   let label: () -> Label
 
@@ -45,11 +43,7 @@ struct ToolbarButton<Label: View>: View {
     }
     .buttonStyle(.plain)
     .frame(height: 23)
-    .onHover(perform: { inside in
-      if let window = appState.appDelegate?.panel {
-        window.isMovableByWindowBackground = !inside
-      }
-    })
+    .excludeFromWindowMovableByBackground()
   }
 
   func shortcutKeyHelp(

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -105,21 +105,6 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertFalse(itemDecorator.isPinned)
   }
 
-  func testPin() {
-    let itemDecorator = historyItemDecorator("foo")
-    itemDecorator.togglePin()
-    XCTAssertNotNil(itemDecorator.item.pin)
-    XCTAssertTrue(itemDecorator.isPinned)
-  }
-
-  func testUnpin() {
-    let itemDecorator = historyItemDecorator("foo")
-    itemDecorator.togglePin()
-    itemDecorator.togglePin()
-    XCTAssertNil(itemDecorator.item.pin)
-    XCTAssertFalse(itemDecorator.isPinned)
-  }
-
   func testHighlight() {
     let itemDecorator = historyItemDecorator("foo bar baz")
     itemDecorator.highlight("random", [

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -29,13 +29,13 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
   }
 
   func testDefaultIsEmpty() {
-    XCTAssertEqual(history.items, [])
+    XCTAssertEqual(history.items.toArray(), [])
   }
 
   func testAdding() {
     let first = history.add(historyItem("foo"))
     let second = history.add(historyItem("bar"))
-    XCTAssertEqual(history.items, [second, first])
+    XCTAssertEqual(history.items.toArray(), [second, first])
   }
 
   func testAddingPersistedDuplicate() throws {
@@ -50,7 +50,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let transferredContents = first.contents
     let merged = history.add(third)
 
-    XCTAssertEqual(history.items, [merged])
+    XCTAssertEqual(history.items.toArray(), [merged])
     XCTAssertEqual(Set(merged.item.contents), Set(transferredContents))
     XCTAssertTrue(merged.item.lastCopiedAt > merged.item.firstCopiedAt)
     XCTAssertEqual(merged.item.numberOfCopies, 2)
@@ -76,7 +76,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let transferredContents = first.contents
     let merged = history.add(second)
 
-    XCTAssertEqual(history.items, [merged])
+    XCTAssertEqual(history.items.toArray(), [merged])
     XCTAssertEqual(Set(merged.item.contents), Set(transferredContents))
     XCTAssertTrue(merged.item.lastCopiedAt > merged.item.firstCopiedAt)
     XCTAssertEqual(merged.item.numberOfCopies, 2)
@@ -117,7 +117,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     secondItem.title = secondItem.generateTitle()
     let second = history.add(secondItem)
 
-    XCTAssertEqual(history.items, [second])
+    XCTAssertEqual(history.items.toArray(), [second])
     XCTAssertEqual(Set(history.items[0].item.contents), Set(firstContents))
     try assertStorageCounts(items: 1, contents: firstContents.count)
   }
@@ -153,7 +153,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     secondItem.contents = secondContents
     let second = history.add(secondItem)
 
-    XCTAssertEqual(history.items, [second])
+    XCTAssertEqual(history.items.toArray(), [second])
     XCTAssertEqual(Set(history.items[0].item.contents), Set(firstContents))
   }
 
@@ -186,7 +186,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     second.contents = secondContents
     let secondDecorator = history.add(second)
 
-    XCTAssertEqual(history.items, [secondDecorator])
+    XCTAssertEqual(history.items.toArray(), [secondDecorator])
     XCTAssertEqual(history.items[0].item.application, "Xcode.app")
     XCTAssertEqual(Set(history.items[0].item.contents), Set(firstContents))
   }
@@ -201,7 +201,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     ))
     let modifiedItemDecorator = history.add(modifiedItem)
 
-    XCTAssertEqual(history.items, [modifiedItemDecorator])
+    XCTAssertEqual(history.items.toArray(), [modifiedItemDecorator])
     XCTAssertEqual(history.items[0].text, "bar")
   }
 
@@ -218,7 +218,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     history.clear()
 
-    XCTAssertEqual(history.items, [pinned])
+    XCTAssertEqual(history.items.toArray(), [pinned])
     try assertStorageCounts(items: 1, contents: 1)
   }
 
@@ -234,7 +234,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     history.clearAll()
 
-    XCTAssertEqual(history.items, [])
+    XCTAssertEqual(history.items.toArray(), [])
     try assertStorageCounts(items: 0, contents: 0)
   }
 
@@ -342,7 +342,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let foo = history.add(historyItem("foo"))
     let bar = history.add(historyItem("bar"))
     history.delete(foo)
-    XCTAssertEqual(history.items, [bar])
+    XCTAssertEqual(history.items.toArray(), [bar])
     try assertStorageCounts(items: 1, contents: 1)
   }
 

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -50,7 +50,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let transferredContents = first.contents
     let merged = history.add(third)
 
-    XCTAssertEqual(history.all, [merged])
+    XCTAssertEqual(history.items, [merged])
     XCTAssertEqual(Set(merged.item.contents), Set(transferredContents))
     XCTAssertTrue(merged.item.lastCopiedAt > merged.item.firstCopiedAt)
     XCTAssertEqual(merged.item.numberOfCopies, 2)
@@ -76,7 +76,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let transferredContents = first.contents
     let merged = history.add(second)
 
-    XCTAssertEqual(history.all, [merged])
+    XCTAssertEqual(history.items, [merged])
     XCTAssertEqual(Set(merged.item.contents), Set(transferredContents))
     XCTAssertTrue(merged.item.lastCopiedAt > merged.item.firstCopiedAt)
     XCTAssertEqual(merged.item.numberOfCopies, 2)
@@ -327,15 +327,15 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
       history.add(historyItem(String(index)))
     }
 
-    XCTAssertEqual(history.all.last, pinned)
+    XCTAssertEqual(history.items.last, pinned)
 
     // Re-copy the pinned item. It is detected as a duplicate, removed and
     // re-inserted while `limitHistorySize` trims an exceeding unpinned item.
     // Before the fix this inserted at a stale, out-of-bounds index and crashed.
     let readded = history.add(historyItem("pinned"))
 
-    XCTAssertTrue(history.all.contains(readded))
-    XCTAssertEqual(history.all.filter(\.isPinned).count, 1)
+    XCTAssertTrue(history.items.contains(readded))
+    XCTAssertEqual(history.items.filter(\.isPinned).count, 1)
   }
 
   func testRemoving() throws {

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -225,7 +225,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
   func testClearingAll() throws {
     history.add(historyItem("foo"))
     let pinned = history.add(historyItem("bar"))
-    pinned.togglePin()
+    history.togglePin(pinned)
     Storage.shared.context.insert(HistoryItemContent(
       type: NSPasteboard.PasteboardType.string.rawValue,
       value: "orphan".data(using: .utf8)

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -8,6 +8,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
   let savedSize = Defaults[.size]
   let savedSortBy = Defaults[.sortBy]
   let savedPinOrder = Defaults[.pinOrder]
+  let savedPinSortBy = Defaults[.pinSortBy]
   let savedPinTo = Defaults[.pinTo]
   let history = History.shared
 
@@ -17,6 +18,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     Defaults[.size] = 10
     Defaults[.sortBy] = .firstCopiedAt
     Defaults[.pinOrder] = PinOrder()
+    Defaults[.pinSortBy] = .custom
     Defaults[.pinTo] = .bottom
   }
 
@@ -25,6 +27,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     Defaults[.size] = savedSize
     Defaults[.sortBy] = savedSortBy
     Defaults[.pinOrder] = savedPinOrder
+    Defaults[.pinSortBy] = savedPinSortBy
     Defaults[.pinTo] = savedPinTo
   }
 

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -7,6 +7,7 @@ import SwiftData
 class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
   let savedSize = Defaults[.size]
   let savedSortBy = Defaults[.sortBy]
+  let savedPinOrder = Defaults[.pinOrder]
   let savedPinTo = Defaults[.pinTo]
   let history = History.shared
 
@@ -15,6 +16,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     history.clearAll()
     Defaults[.size] = 10
     Defaults[.sortBy] = .firstCopiedAt
+    Defaults[.pinOrder] = PinOrder()
     Defaults[.pinTo] = .bottom
   }
 
@@ -22,6 +24,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     super.tearDown()
     Defaults[.size] = savedSize
     Defaults[.sortBy] = savedSortBy
+    Defaults[.pinOrder] = savedPinOrder
     Defaults[.pinTo] = savedPinTo
   }
 
@@ -204,7 +207,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
   func testClearingUnpinned() throws {
     let pinned = history.add(historyItem("foo"))
-    pinned.togglePin()
+    history.togglePin(pinned)
     history.add(historyItem("bar"))
     let orphan = HistoryItemContent(
       type: NSPasteboard.PasteboardType.string.rawValue,
@@ -252,7 +255,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     let item = history.add(historyItem("0"))
     items.append(item)
-    item.togglePin()
+    history.togglePin(item)
 
     for index in 1...11 {
       items.append(history.add(historyItem(String(index))))
@@ -262,6 +265,35 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     XCTAssertTrue(history.items.contains(items[10]))
     XCTAssertTrue(history.items.contains(items[0]))
     XCTAssertFalse(history.items.contains(items[1]))
+  }
+
+  func testPinningUpdatesPinOrder() {
+    let item = history.add(historyItem("foo"))
+    history.togglePin(item)
+
+    XCTAssertEqual(history.pinnedItems, [item])
+    XCTAssertEqual(Defaults[.pinOrder].pins, [item.item.pin].compactMap { $0 })
+  }
+
+  func testUnpinningUpdatesPinOrder() {
+    let item = history.add(historyItem("foo"))
+    history.togglePin(item)
+    history.togglePin(item)
+
+    XCTAssertEqual(history.pinnedItems, [])
+    XCTAssertEqual(Defaults[.pinOrder].pins, [])
+  }
+
+  func testMovingPinsUpdatesPinOrder() {
+    let first = history.add(historyItem("foo"))
+    let second = history.add(historyItem("bar"))
+    history.togglePin(first)
+    history.togglePin(second)
+
+    history.movePin(from: IndexSet(integer: 0), to: 2)
+
+    XCTAssertEqual(history.pinnedItems, [second, first])
+    XCTAssertEqual(Defaults[.pinOrder].pins, [second.item.pin, first.item.pin].compactMap { $0 })
   }
 
   func testMaxSizeIsChanged() {

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -8,7 +8,6 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
   let savedSize = Defaults[.size]
   let savedSortBy = Defaults[.sortBy]
   let savedPinOrder = Defaults[.pinOrder]
-  let savedPinSortBy = Defaults[.pinSortBy]
   let savedPinTo = Defaults[.pinTo]
   let history = History.shared
 
@@ -18,7 +17,6 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     Defaults[.size] = 10
     Defaults[.sortBy] = .firstCopiedAt
     Defaults[.pinOrder] = PinOrder()
-    Defaults[.pinSortBy] = .custom
     Defaults[.pinTo] = .bottom
   }
 
@@ -27,7 +25,6 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     Defaults[.size] = savedSize
     Defaults[.sortBy] = savedSortBy
     Defaults[.pinOrder] = savedPinOrder
-    Defaults[.pinSortBy] = savedPinSortBy
     Defaults[.pinTo] = savedPinTo
   }
 

--- a/MaccyTests/SorterTests.swift
+++ b/MaccyTests/SorterTests.swift
@@ -3,6 +3,8 @@ import Defaults
 @testable import Maccy
 
 class SorterTests: XCTestCase {
+  let savedPinOrder = Defaults[.pinOrder]
+  let savedPinSortBy = Defaults[.pinSortBy]
   let savedPinTo = Defaults[.pinTo]
   let sorter = Sorter()
 
@@ -16,10 +18,14 @@ class SorterTests: XCTestCase {
     item1 = historyItem(value: "foo", firstCopiedAt: -300, lastCopiedAt: -100, numberOfCopies: 3)
     item2 = historyItem(value: "bar", firstCopiedAt: -400, lastCopiedAt: -300, numberOfCopies: 2)
     item3 = historyItem(value: "bar", firstCopiedAt: -200, lastCopiedAt: -200, numberOfCopies: 1)
+    Defaults[.pinOrder] = PinOrder()
+    Defaults[.pinSortBy] = .custom
   }
 
   override func tearDown() {
     super.tearDown()
+    Defaults[.pinOrder] = savedPinOrder
+    Defaults[.pinSortBy] = savedPinSortBy
     Defaults[.pinTo] = savedPinTo
   }
 
@@ -33,6 +39,44 @@ class SorterTests: XCTestCase {
 
   func testSortByNumberOfCopies() {
     XCTAssertEqual(sorter.sort([item1, item2, item3], by: .numberOfCopies), [item1, item2, item3])
+  }
+
+  func testSortPinsByLastCopiedAt() {
+    pinItems()
+
+    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .lastCopiedAt), [item1, item3, item2])
+  }
+
+  func testSortPinsByFirstCopiedAt() {
+    pinItems()
+
+    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .firstCopiedAt), [item3, item1, item2])
+  }
+
+  func testSortPinsByNumberOfCopies() {
+    pinItems()
+
+    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .numberOfCopies), [item1, item2, item3])
+  }
+
+  func testSortPinsByPinLetter() {
+    pinItems()
+
+    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .pinLetter), [item1, item3, item2])
+  }
+
+  func testSortPinsByCustomOrder() {
+    pinItems()
+    Defaults[.pinOrder] = PinOrder(pins: ["c", "a", "b"])
+
+    XCTAssertEqual(sorter.sortPins([item1, item2, item3], by: .custom), [item2, item1, item3])
+  }
+
+  func testCustomPinSortAppendsPinsMissingFromOrder() {
+    pinItems()
+    Defaults[.pinOrder] = PinOrder(pins: ["b"])
+
+    XCTAssertEqual(sorter.sortPins([item3, item2, item1], by: .custom), [item3, item2, item1])
   }
 
   func testSortByPinToTop() {
@@ -51,6 +95,12 @@ class SorterTests: XCTestCase {
     XCTAssertEqual(sorter.sort([item1, item2, item3], by: .lastCopiedAt), [item2, item1, item3])
   }
 
+  private func pinItems() {
+    item1.pin = "a"
+    item2.pin = "c"
+    item3.pin = "b"
+  }
+
   @MainActor
   private func historyItem(
     value: String,
@@ -66,5 +116,67 @@ class SorterTests: XCTestCase {
     item.lastCopiedAt = Date(timeIntervalSinceNow: TimeInterval(lastCopiedAt))
     item.numberOfCopies = numberOfCopies
     return item
+  }
+}
+
+@MainActor
+class PinManagerTests: XCTestCase {
+  let savedPinOrder = Defaults[.pinOrder]
+  let savedPinSortBy = Defaults[.pinSortBy]
+
+  override func setUp() {
+    super.setUp()
+    Defaults[.pinOrder] = PinOrder()
+    Defaults[.pinSortBy] = .custom
+  }
+
+  override func tearDown() {
+    super.tearDown()
+    Defaults[.pinOrder] = savedPinOrder
+    Defaults[.pinSortBy] = savedPinSortBy
+  }
+
+  func testMovingPinsIsDisabledForAutomaticSorting() {
+    let manager = pinManager()
+    Defaults[.pinSortBy] = .pinLetter
+    let originalPins = manager.pinnedItems
+    let originalOrder = Defaults[.pinOrder]
+
+    manager.move(from: IndexSet(integer: 0), to: 3)
+
+    XCTAssertEqual(manager.pinnedItems, originalPins)
+    XCTAssertEqual(Defaults[.pinOrder], originalOrder)
+  }
+
+  func testAutomaticSortingCanBeUsedAsCustomOrder() {
+    let manager = pinManager()
+
+    manager.adoptSortingForCustomOrder(.pinLetter)
+
+    XCTAssertEqual(Defaults[.pinOrder].pins, ["a", "b", "c"])
+  }
+
+  func testAutomaticSortingWouldChangeDifferentCustomOrder() {
+    let manager = pinManager()
+
+    XCTAssertTrue(manager.sortingWouldChangeCurrentOrder(.pinLetter))
+  }
+
+  func testAutomaticSortingWouldNotChangeMatchingCustomOrder() {
+    let manager = pinManager(pins: ["a", "b", "c"])
+
+    XCTAssertFalse(manager.sortingWouldChangeCurrentOrder(.pinLetter))
+  }
+
+  private func pinManager(pins: [String] = ["c", "a", "b"]) -> PinManager {
+    let items = pins.map { pin in
+      let item = HistoryItem()
+      Storage.shared.context.insert(item)
+      item.pin = pin
+      return HistoryItemDecorator(item)
+    }
+    let manager = PinManager()
+    manager.load(from: items)
+    return manager
   }
 }

--- a/MaccyTests/SorterTests.swift
+++ b/MaccyTests/SorterTests.swift
@@ -4,7 +4,6 @@ import Defaults
 
 class SorterTests: XCTestCase {
   let savedPinOrder = Defaults[.pinOrder]
-  let savedPinSortBy = Defaults[.pinSortBy]
   let savedPinTo = Defaults[.pinTo]
   let sorter = Sorter()
 
@@ -19,13 +18,11 @@ class SorterTests: XCTestCase {
     item2 = historyItem(value: "bar", firstCopiedAt: -400, lastCopiedAt: -300, numberOfCopies: 2)
     item3 = historyItem(value: "bar", firstCopiedAt: -200, lastCopiedAt: -200, numberOfCopies: 1)
     Defaults[.pinOrder] = PinOrder()
-    Defaults[.pinSortBy] = .custom
   }
 
   override func tearDown() {
     super.tearDown()
     Defaults[.pinOrder] = savedPinOrder
-    Defaults[.pinSortBy] = savedPinSortBy
     Defaults[.pinTo] = savedPinTo
   }
 
@@ -39,44 +36,6 @@ class SorterTests: XCTestCase {
 
   func testSortByNumberOfCopies() {
     XCTAssertEqual(sorter.sort([item1, item2, item3], by: .numberOfCopies), [item1, item2, item3])
-  }
-
-  func testSortPinsByLastCopiedAt() {
-    pinItems()
-
-    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .lastCopiedAt), [item1, item3, item2])
-  }
-
-  func testSortPinsByFirstCopiedAt() {
-    pinItems()
-
-    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .firstCopiedAt), [item3, item1, item2])
-  }
-
-  func testSortPinsByNumberOfCopies() {
-    pinItems()
-
-    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .numberOfCopies), [item1, item2, item3])
-  }
-
-  func testSortPinsByPinLetter() {
-    pinItems()
-
-    XCTAssertEqual(sorter.sortPins([item2, item3, item1], by: .pinLetter), [item1, item3, item2])
-  }
-
-  func testSortPinsByCustomOrder() {
-    pinItems()
-    Defaults[.pinOrder] = PinOrder(pins: ["c", "a", "b"])
-
-    XCTAssertEqual(sorter.sortPins([item1, item2, item3], by: .custom), [item2, item1, item3])
-  }
-
-  func testCustomPinSortAppendsPinsMissingFromOrder() {
-    pinItems()
-    Defaults[.pinOrder] = PinOrder(pins: ["b"])
-
-    XCTAssertEqual(sorter.sortPins([item3, item2, item1], by: .custom), [item3, item2, item1])
   }
 
   func testSortByPinToTop() {
@@ -95,12 +54,6 @@ class SorterTests: XCTestCase {
     XCTAssertEqual(sorter.sort([item1, item2, item3], by: .lastCopiedAt), [item2, item1, item3])
   }
 
-  private func pinItems() {
-    item1.pin = "a"
-    item2.pin = "c"
-    item3.pin = "b"
-  }
-
   @MainActor
   private func historyItem(
     value: String,
@@ -116,67 +69,5 @@ class SorterTests: XCTestCase {
     item.lastCopiedAt = Date(timeIntervalSinceNow: TimeInterval(lastCopiedAt))
     item.numberOfCopies = numberOfCopies
     return item
-  }
-}
-
-@MainActor
-class PinManagerTests: XCTestCase {
-  let savedPinOrder = Defaults[.pinOrder]
-  let savedPinSortBy = Defaults[.pinSortBy]
-
-  override func setUp() {
-    super.setUp()
-    Defaults[.pinOrder] = PinOrder()
-    Defaults[.pinSortBy] = .custom
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    Defaults[.pinOrder] = savedPinOrder
-    Defaults[.pinSortBy] = savedPinSortBy
-  }
-
-  func testMovingPinsIsDisabledForAutomaticSorting() {
-    let manager = pinManager()
-    Defaults[.pinSortBy] = .pinLetter
-    let originalPins = manager.pinnedItems
-    let originalOrder = Defaults[.pinOrder]
-
-    manager.move(from: IndexSet(integer: 0), to: 3)
-
-    XCTAssertEqual(manager.pinnedItems, originalPins)
-    XCTAssertEqual(Defaults[.pinOrder], originalOrder)
-  }
-
-  func testAutomaticSortingCanBeUsedAsCustomOrder() {
-    let manager = pinManager()
-
-    manager.adoptSortingForCustomOrder(.pinLetter)
-
-    XCTAssertEqual(Defaults[.pinOrder].pins, ["a", "b", "c"])
-  }
-
-  func testAutomaticSortingWouldChangeDifferentCustomOrder() {
-    let manager = pinManager()
-
-    XCTAssertTrue(manager.sortingWouldChangeCurrentOrder(.pinLetter))
-  }
-
-  func testAutomaticSortingWouldNotChangeMatchingCustomOrder() {
-    let manager = pinManager(pins: ["a", "b", "c"])
-
-    XCTAssertFalse(manager.sortingWouldChangeCurrentOrder(.pinLetter))
-  }
-
-  private func pinManager(pins: [String] = ["c", "a", "b"]) -> PinManager {
-    let items = pins.map { pin in
-      let item = HistoryItem()
-      Storage.shared.context.insert(item)
-      item.pin = pin
-      return HistoryItemDecorator(item)
-    }
-    let manager = PinManager()
-    manager.load(from: items)
-    return manager
   }
 }


### PR DESCRIPTION
Allows reordering pins through drag and drop inside the history list.

https://github.com/user-attachments/assets/f1d7ffde-c9e9-4a10-b6fd-8f87b2305d5e

By default pins are added to the end of the list of pines. Note that with this change pins are no longer sorted automatically by last used etc as the rest of the history. An option would be to have a separate setting for how pins are sorted with a `Manual` mode, in which case drag and drop is enabled (and disabled for all other modes).

This is already compatible with the multi-selection mechanism which is currently still disabled.

Add an edit button to the toolbar which opens a modal dialog for editing items. This replaces the editing mechanism from the settings and removes `PinsSettingsPane`.

<img width="1014" height="618" alt="image" src="https://github.com/user-attachments/assets/b6ef07e9-0c26-4483-be51-50e11387e81e" />

The pin section is only available for pinned items, but every item can be edited.