### PR TITLE
Keep popup on the active screen constrained. Fixes #1421

### DIFF
--- a/Maccy/PopupPosition.swift
+++ b/Maccy/PopupPosition.swift
@@ -26,7 +26,6 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
     }
   }
 
-  // swiftlint:disable:next cyclomatic_complexity
   func origin(size: NSSize, statusBarButton: NSStatusBarButton?) -> NSPoint {
     switch self {
     case .center:

--- a/Maccy/PopupPosition.swift
+++ b/Maccy/PopupPosition.swift
@@ -38,16 +38,12 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
         return NSRect.centered(ofSize: size, in: frame).origin
       }
     case .statusItem:
-      if let statusBarButton, let screen = NSScreen.main {
+      if let statusBarButton {
         let rectInWindow = statusBarButton.convert(statusBarButton.bounds, to: nil)
         if let screenRect = statusBarButton.window?.convertToScreen(rectInWindow) {
-          var topLeftPoint = NSPoint(x: screenRect.minX, y: screenRect.minY - size.height)
-          // Ensure that window doesn't spill over to the right screen.
-          if (topLeftPoint.x + size.width) > screen.frame.maxX {
-            topLeftPoint.x = screen.frame.maxX - size.width
-          }
-
-          return topLeftPoint
+          let topLeftPoint = NSPoint(x: screenRect.minX, y: screenRect.minY - size.height)
+          let screen = statusBarButton.window?.screen ?? NSScreen.main
+          return constrained(topLeftPoint, ofSize: size, to: screen)
         }
       }
     case .lastPosition:
@@ -62,8 +58,21 @@ enum PopupPosition: String, CaseIterable, Identifiable, CustomStringConvertible,
       break
     }
 
-    var point = NSEvent.mouseLocation
-    point.y -= size.height
-    return point
+    let mouseLocation = NSEvent.mouseLocation
+    let point = NSPoint(x: mouseLocation.x, y: mouseLocation.y - size.height)
+    let screen = NSScreen.screens.first { NSMouseInRect(mouseLocation, $0.frame, false) }
+    return constrained(point, ofSize: size, to: screen)
+  }
+
+  // Ensure that window doesn't spill over to an adjacent screen.
+  private func constrained(_ origin: NSPoint, ofSize size: NSSize, to screen: NSScreen?) -> NSPoint {
+    guard let frame = screen?.visibleFrame else {
+      return origin
+    }
+
+    return NSPoint(
+      x: min(max(origin.x, frame.minX), frame.maxX - size.width),
+      y: min(max(origin.y, frame.minY), frame.maxY - size.height)
+    )
   }
 }


### PR DESCRIPTION
The popup position for the "at cursor" mode was taken directly from
`NSEvent.mouseLocation` without checking whether the panel fits on the
current screen. When triggered near a shared edge in a multi-monitor
setup, the panel spilled over to the adjacent monitor.

 The existing right-edge check in the
`.statusItem` case is replaced with the same helper, and it now clamps
against the screen actually hosting the status item instead of
`NSScreen.main`. (Lines 74-75)

Tested on a two-display setup with the external monitor arranged to
the right of and above the laptop screen.

Before fix:
<img width="1458" height="501" alt="before fix" src="https://github.com/user-attachments/assets/47578c13-1a55-4cfa-b69e-f6fa6367331a" />

After fix:
<img width="699" height="197" alt="after fix" src="https://github.com/user-attachments/assets/9c774c88-fd08-41cc-9bad-d15b678e5ab2" />


Fixes #1421