### PR TITLE
test: un-ignore testAddingSame and assert the merged item's state

### DIFF
--- a/Maccy.xctestplan
+++ b/Maccy.xctestplan
@@ -23,9 +23,6 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "HistoryTests\/testAddingSame()"
-      ],
       "target" : {
         "containerPath" : "container:Maccy.xcodeproj",
         "identifier" : "DA360DAF1E3DF137005C6F6B",

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -38,22 +38,23 @@ class HistoryTests: XCTestCase {
     let first = historyItem("foo")
     first.title = "xyz"
     first.application = "iTerm.app"
-    let firstDecorator = history.add(first)
+    history.add(first)
     first.pin = "f"
 
     let secondDecorator = history.add(historyItem("bar"))
 
     let third = historyItem("foo")
     third.application = "Xcode.app"
-    history.add(third)
+    let merged = history.add(third)
 
-    XCTAssertEqual(history.items, [firstDecorator, secondDecorator])
-    XCTAssertTrue(history.items[0].item.lastCopiedAt > history.items[0].item.firstCopiedAt)
-    // TODO: This works in reality but fails in tests?!
-    // XCTAssertEqual(history.items[0].item.numberOfCopies, 2)
-    XCTAssertEqual(history.items[0].item.pin, "f")
-    XCTAssertEqual(history.items[0].item.title, "xyz")
-    XCTAssertEqual(history.items[0].item.application, "iTerm.app")
+    // The duplicate merges into the existing entry instead of adding a new
+    // one, and the merged item carries the original item's metadata.
+    XCTAssertEqual(history.all, [merged, secondDecorator])
+    XCTAssertTrue(merged.item.lastCopiedAt > merged.item.firstCopiedAt)
+    XCTAssertEqual(merged.item.numberOfCopies, 2)
+    XCTAssertEqual(merged.item.pin, "f")
+    XCTAssertEqual(merged.item.title, "xyz")
+    XCTAssertEqual(merged.item.application, "iTerm.app")
   }
 
   func testAddingItemThatIsSupersededByExisting() {

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -49,7 +49,9 @@ class HistoryTests: XCTestCase {
 
     // The duplicate merges into the existing entry instead of adding a new
     // one, and the merged item carries the original item's metadata.
-    XCTAssertEqual(history.all, [merged, secondDecorator])
+    // With pinTo = .bottom the unpinned bar sorts first and the re-inserted
+    // pinned merged item lands at the end of `all`.
+    XCTAssertEqual(history.all, [secondDecorator, merged])
     XCTAssertTrue(merged.item.lastCopiedAt > merged.item.firstCopiedAt)
     XCTAssertEqual(merged.item.numberOfCopies, 2)
     XCTAssertEqual(merged.item.pin, "f")


### PR DESCRIPTION
testAddingSame was skipped in Maccy.xctestplan because the numberOfCopies assertion targeted `history.items`, which is not refreshed when a pinned duplicate is merged back in, so it kept reading the stale original item.

The test now asserts on the merged item returned by `history.add` instead: it stays in `history.all` at the original position, keeps the original item's pin, title and application, and accumulates numberOfCopies. The test is un-ignored in the test plan.

The branch was also rebuilt on current master; the previous version had accumulated unrelated changes from a stale merge.

Closes #1445
