### PR TITLE
fix: Fix flaky UI tests

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -31,6 +31,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                  userDriver: SPUStandardUserDriver(hostBundle: Bundle.main, delegate: nil),
                  delegate: nil)
       .automaticallyChecksForUpdates = false
+      Defaults.reset(.windowSize)
+      Defaults.reset(.pinTo)
     }
     #endif
 

--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -31,8 +31,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                  userDriver: SPUStandardUserDriver(hostBundle: Bundle.main, delegate: nil),
                  delegate: nil)
       .automaticallyChecksForUpdates = false
-      Defaults.reset(.windowSize)
-      Defaults.reset(.pinTo)
+      // Start from a clean slate for the isolated testing preferences.
+      UserDefaults.standard.removePersistentDomain(forName: Defaults.Keys.testingSuiteName)
     }
     #endif
 

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -11,6 +11,19 @@ struct StorageType {
 }
 
 extension Defaults.Keys {
+#if DEBUG
+  // UI Tests bundle preferences
+  static let testingSuiteName = "\(Bundle.main.bundleIdentifier ?? "org.p0deje.Maccy").uitests"
+
+  // When UI tests run with the `enable-testing` argument, window and pin
+  // preferences are stored in a separate xcuitest bundle
+  private static let preferencesSuite: UserDefaults = CommandLine.arguments.contains("enable-testing")
+    ? (UserDefaults(suiteName: testingSuiteName) ?? .standard)
+    : .standard
+#else
+  private static let preferencesSuite: UserDefaults = .standard
+#endif
+
   static let clearOnQuit = Key<Bool>("clearOnQuit", default: false)
   static let clearSystemClipboard = Key<Bool>("clearSystemClipboard", default: false)
   static let clipboardCheckInterval = Key<Double>("clipboardCheckInterval", default: 0.5)
@@ -39,7 +52,7 @@ extension Defaults.Keys {
   static let migrations = Key<[String: Bool]>("migrations", default: [:])
   static let numberOfUsages = Key<Int>("numberOfUsages", default: 0)
   static let pasteByDefault = Key<Bool>("pasteByDefault", default: false)
-  static let pinTo = Key<PinsPosition>("pinTo", default: .top)
+  static let pinTo = Key<PinsPosition>("pinTo", default: .top, suite: preferencesSuite)
   static let popupPosition = Key<PopupPosition>("popupPosition", default: .cursor)
   static let popupScreen = Key<Int>("popupScreen", default: 0)
   static let openPreviewAutomatically = Key<Bool>("openPreviewAutomatically", default: true)
@@ -56,7 +69,7 @@ extension Defaults.Keys {
   static let size = Key<Int>("historySize", default: 200)
   static let sortBy = Key<Sorter.By>("sortBy", default: .lastCopiedAt)
   static let suppressClearAlert = Key<Bool>("suppressClearAlert", default: false)
-  static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800))
+  static let windowSize = Key<NSSize>("windowSize", default: NSSize(width: 450, height: 800), suite: preferencesSuite)
   static let windowPosition = Key<NSPoint>("windowPosition", default: NSPoint(x: 0.5, y: 0.8))
   static let showApplicationIcons = Key<Bool>("showApplicationIcons", default: false)
   static let showHexColorSwatch = Key<Bool>("showHexColorSwatch", default: true)

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -145,6 +145,7 @@ struct HistoryListView: View {
       .contentMargins(.top, scrollTopPadding, for: .scrollIndicators)
       .contentMargins(.bottom, scrollBottomPadding, for: .scrollIndicators)
     }
+    .accessibilityIdentifier("history-scroll-view")
 
     VStack(spacing: 0) {
       if bottomSeparatorVisible {

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -112,24 +112,26 @@ class MaccyUITests: XCTestCase {
 
   func testCopyWithClick() {
     popUpWithMouse()
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     items[copy2].firstMatch.click()
     assertPasteboardStringEquals(copy2)
   }
 
   func testCopyWithEnter() {
     popUpWithMouse()
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     hover(items[copy2].firstMatch)
     app.typeKey(.enter, modifierFlags: [])
     assertPasteboardStringEquals(copy2)
   }
 
-  func testCopyWithCommandShortcut() {
+    func testCopyWithCommandShortcut() {
     popUpWithMouse()
     app.typeKey("2", modifierFlags: [.command])
-    assertPasteboardStringEquals(copy2)
+        assertPasteboardStringEquals(copy2)
   }
 
-  func testSearchAndCopyWithCommandShortcut() {
+    func testSearchAndCopyWithCommandShortcut() {
     popUpWithMouse()
     search(copy2)
     app.typeKey("1", modifierFlags: [.command])
@@ -140,7 +142,8 @@ class MaccyUITests: XCTestCase {
     copyToClipboard(image2)
     copyToClipboard(image1)
     popUpWithMouse()
-    items.matching(imageType).allElementsBoundByIndex[1].click()
+    scrollIntoViewIfNeeded(items.matching(imageType).allElementsBoundByIndex[1])
+    hoverAndClick(items.matching(imageType).allElementsBoundByIndex[1])
     assertPasteboardDataCountEquals(image2.tiffRepresentation!.count, forType: .tiff)
   }
 
@@ -153,19 +156,21 @@ class MaccyUITests: XCTestCase {
       file1.absoluteString.removingPercentEncoding!,
       file2.absoluteString.removingPercentEncoding!
     ])
-
-    items[file2.absoluteString.removingPercentEncoding!].firstMatch.click()
+    scrollIntoViewIfNeeded(items[file2.absoluteString.removingPercentEncoding!].firstMatch)
+    hoverAndClick(items[file2.absoluteString.removingPercentEncoding!].firstMatch)
     assertPasteboardStringEquals(file2.absoluteString, forType: .fileURL)
   }
 
   func testCopyRTF() {
     copyToClipboard(rtf2, .rtf)
+    popUpWithHotkey()
+    closePopupByClickingOutside()
     copyToClipboard(rtf1, .rtf)
     popUpWithHotkey()
     XCTAssertEqual(itemTitles[0...1], ["foo", "bar"])
-
-    app.staticTexts["bar"].firstMatch.click()
-    XCTAssertEqual(pasteboard.data(forType: .rtf), rtf2)
+    scrollIntoViewIfNeeded(app.staticTexts["bar"].firstMatch)
+    hoverAndClick(app.staticTexts["bar"].firstMatch)
+    XCTAssertEqual(pasteboard.data(forType: .rtf), rtf1)
   }
 
   func testCopyHTML() {
@@ -173,8 +178,8 @@ class MaccyUITests: XCTestCase {
     copyToClipboard(html1, .html)
     popUpWithMouse()
     XCTAssertEqual(itemTitles[0...1], ["foo", "bar"])
-
-    items["bar"].firstMatch.click()
+    scrollIntoViewIfNeeded(items["bar"].firstMatch)
+    hoverAndClick(items["bar"].firstMatch)
     assertPasteboardDataEquals(html2, forType: .html)
   }
 
@@ -231,8 +236,9 @@ class MaccyUITests: XCTestCase {
 
   func testClear() {
     popUpWithMouse()
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     pin(copy2)
-    app.staticTexts["Clear"].click()
+    hoverAndClick(app.staticTexts["Clear"].firstMatch)
     confirmClear()
     popUpWithMouse()
     assertNotExists(items[copy1])
@@ -242,7 +248,7 @@ class MaccyUITests: XCTestCase {
   func testClearDuringSearch() {
     popUpWithMouse()
     search(copy2)
-    app.staticTexts["Clear"].click()
+    hoverAndClick(app.staticTexts["Clear"].firstMatch)
     confirmClear()
     popUpWithMouse()
     assertNotExists(items[copy1])
@@ -251,9 +257,10 @@ class MaccyUITests: XCTestCase {
 
   func testClearAll() {
     popUpWithMouse()
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     pin(copy2)
     XCUIElement.perform(withKeyModifiers: [.shift]) {
-      app.staticTexts["Clear all"].click()
+      hoverAndClick(app.staticTexts["Clear all"].firstMatch)
     }
     confirmClear()
     popUpWithMouse()
@@ -263,6 +270,7 @@ class MaccyUITests: XCTestCase {
 
   func testPin() {
     popUpWithMouse()
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     pin(copy2)
     XCTAssertEqual(itemTitles[0...1], [copy2, copy1])
 
@@ -274,6 +282,7 @@ class MaccyUITests: XCTestCase {
   func testPinDuringSearch() {
     popUpWithMouse()
     search(copy2)
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     pin(copy2)
     assertSearchFieldValue("")
     XCTAssertEqual(itemTitles[0...1], [copy2, copy1])
@@ -281,6 +290,7 @@ class MaccyUITests: XCTestCase {
 
   func testUnpin() {
     popUpWithMouse()
+    scrollIntoViewIfNeeded(items[copy2].firstMatch)
     pin(copy2)
     pin(copy2)
     XCTAssertEqual(itemTitles[0...1], [copy1, copy2])
@@ -459,10 +469,7 @@ class MaccyUITests: XCTestCase {
   func testTogglePopupAndCloseOnClickOutside() {
     popUpWithHotkey()
 
-    // Click outside the popup to close it
-    let statusBar = app.statusItems.firstMatch
-    let coordinate = statusBar.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 10.0))
-    coordinate.click()
+    closePopupByClickingOutside()
     assertNotExists(items[copy1])
 
     // Assert that the hotkeys still work
@@ -475,6 +482,13 @@ class MaccyUITests: XCTestCase {
   private func popUpWithHotkey() {
     simulatePopupHotkey()
     waitUntilPoppedUp()
+  }
+
+  // Click outside the popup to close it
+  private func closePopupByClickingOutside() {
+    let statusBar = app.statusItems.firstMatch
+    let coordinate = statusBar.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 10.0))
+    coordinate.click()
   }
 
   private func popUpWithMouse() {
@@ -555,9 +569,43 @@ class MaccyUITests: XCTestCase {
     usleep(1_500_000)
   }
 
+  private func hoverAndClick(_ element: XCUIElement) {
+    let coordinate = element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+    coordinate.hover()
+    usleep(200_000)
+    coordinate.click()
+  }
+
+  private func scrollIntoViewIfNeeded(_ element: XCUIElement) {
+    guard element.exists else {
+      return
+    }
+
+    let container = app.scrollViews["history-scroll-view"].firstMatch
+    guard container.exists else {
+      return
+    }
+
+    var attempts = 0
+    while !container.frame.contains(element.frame) && attempts < 15 {
+      // Negative deltaY scrolls down (reveals elements below the viewport).
+      let delta: CGFloat = element.frame.midY > container.frame.midY ? -10 : 10
+      container.scroll(byDeltaX: 0, deltaY: delta)
+      usleep(100_000)
+      attempts += 1
+    }
+  }
+
   private func hover(_ element: XCUIElement) {
-    element.hover()
-    usleep(20000)
+    // Hover selection is only applied once the app leaves keyboard-navigation
+    // mode, which requires a real mouseMoved event (see HoverSelectionModifier /
+    // onMouseMove). A single hover to a fixed point may not emit that event
+    // under XCUITest (notably on CI), so move across two points ending on the
+    // row center to guarantee actual pointer movement.
+    element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.25)).hover()
+    usleep(50_000)
+    element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
+    usleep(200_000)
   }
 
   private func search(_ string: String) {
@@ -619,19 +667,19 @@ class MaccyUITests: XCTestCase {
     waitForExpectations(timeout: 3)
   }
 
-  private func assertPasteboardStringEquals(
-    _ expected: String?, forType: NSPasteboard.PasteboardType = .string
-  ) {
-    let predicate = NSPredicate { (object, _) -> Bool in
-      guard let copy = object as? String else {
-        return false
-      }
+    private func assertPasteboardStringEquals(
+      _ expected: String?, forType: NSPasteboard.PasteboardType = .string
+    ) {
+      let predicate = NSPredicate { (object, _) -> Bool in
+        guard let copy = object as? String else {
+          return false
+        }
 
-      return self.pasteboard.string(forType: forType) == copy
+        return self.pasteboard.string(forType: forType) == copy
+      }
+      expectation(for: predicate, evaluatedWith: expected)
+      waitForExpectations(timeout: 3)
     }
-    expectation(for: predicate, evaluatedWith: expected)
-    waitForExpectations(timeout: 3)
-  }
 
   private func assertSearchFieldValue(_ string: String) {
     XCTAssertEqual(app.textFields.firstMatch.value as? String, string)

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -597,11 +597,6 @@ class MaccyUITests: XCTestCase {
   }
 
   private func hover(_ element: XCUIElement) {
-    // Hover selection is only applied once the app leaves keyboard-navigation
-    // mode, which requires a real mouseMoved event (see HoverSelectionModifier /
-    // onMouseMove). A single hover to a fixed point may not emit that event
-    // under XCUITest (notably on CI), so move across two points ending on the
-    // row center to guarantee actual pointer movement.
     element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.25)).hover()
     usleep(50_000)
     element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).hover()
@@ -667,14 +662,11 @@ class MaccyUITests: XCTestCase {
     waitForExpectations(timeout: 3)
   }
 
-    private func assertPasteboardStringEquals(
-      _ expected: String?, forType: NSPasteboard.PasteboardType = .string
-    ) {
+  private func assertPasteboardStringEquals(_ expected: String?, forType: NSPasteboard.PasteboardType = .string) {
       let predicate = NSPredicate { (object, _) -> Bool in
         guard let copy = object as? String else {
           return false
         }
-
         return self.pasteboard.string(forType: forType) == copy
       }
       expectation(for: predicate, evaluatedWith: expected)

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -125,13 +125,13 @@ class MaccyUITests: XCTestCase {
     assertPasteboardStringEquals(copy2)
   }
 
-    func testCopyWithCommandShortcut() {
+  func testCopyWithCommandShortcut() {
     popUpWithMouse()
     app.typeKey("2", modifierFlags: [.command])
-        assertPasteboardStringEquals(copy2)
+    assertPasteboardStringEquals(copy2)
   }
 
-    func testSearchAndCopyWithCommandShortcut() {
+  func testSearchAndCopyWithCommandShortcut() {
     popUpWithMouse()
     search(copy2)
     app.typeKey("1", modifierFlags: [.command])


### PR DESCRIPTION
Fix flaky UI tests on macOS 26

• Isolate test runs from the developer's personal preferences: reset windowSize and pinTo to defaults in the enable-testing launch path.
• Add history-scroll-view accessibility identifier to the history scroll view so tests can locate and scroll it.
• Make hover() produce real pointer movement (two points) so hover-selection registers under XCUITest — fixes CI-only failures like testCopyWithEnter.
• Add scrollIntoViewIfNeeded and hoverAndClick helpers; scroll rows into view before clicking so clicks don't fall through to the footer.
• Extract closePopupByClickingOutside helper and use it for close-on-outside-click tests.