### PR TITLE
Fix popup hotkey re-registration leak

### DIFF
--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -61,8 +61,8 @@ class Popup {
     guard eventsMonitor == nil else { return }
 
     self.eventsMonitor = NSEvent.addLocalMonitorForEvents(
-      matching: [.flagsChanged, .keyDown],
-      handler: handleEvent
+      matching: .flagsChanged,
+      handler: handleFlagsChanged
     )
   }
 
@@ -78,7 +78,6 @@ class Popup {
 
   func reset() {
     state = .toggle
-    KeyboardShortcuts.enable(.popup)
   }
 
   func close() {
@@ -114,52 +113,10 @@ class Popup {
     if isClosed() {
       open(height: height)
       state = .opening
-      KeyboardShortcuts.disable(.popup)  // Handle events via eventsMonitor. Re-enable on popup close
       return
     }
 
-    // Maccy was not opened via shortcut. We assume toggle mode and close it
-    close()
-  }
-
-  private func handleEvent(_ event: NSEvent) -> NSEvent? {
-    switch event.type {
-    case .keyDown:
-      return handleKeyDown(event)
-    case .flagsChanged:
-      return handleFlagsChanged(event)
-    default:
-      return event
-    }
-  }
-
-  private func handleKeyDown(_ event: NSEvent) -> NSEvent? {
-    if isHotKeyCode(Int(event.keyCode)) {
-      if let item = History.shared.pressedShortcutItem {
-        AppState.shared.navigator.select(item: item)
-        Task { @MainActor in
-          AppState.shared.history.select(item)
-        }
-        return nil
-      }
-
-      if state == .opening {
-        state = .cycle
-        // Next 'if' will highlight next item and then return nil
-      }
-
-      if state == .cycle {
-        AppState.shared.navigator.highlightNext(allowCycle: true)
-        return nil
-      }
-
-      if state == .toggle && isHotKeyModifiers(event.modifierFlags) {
-        close()
-        return nil
-      }
-    }
-
-    return event
+    handleRepeatedHotKeyDown()
   }
 
   private func handleFlagsChanged(_ event: NSEvent) -> NSEvent? {
@@ -180,24 +137,30 @@ class Popup {
     return event
   }
 
-  private func isHotKeyCode(_ keyCode: Int) -> Bool {
-    guard let shortcut = KeyboardShortcuts.Name.popup.shortcut else {
-      return false
-    }
-
-    return shortcut.key?.rawValue == keyCode
-  }
-
-  private func isHotKeyModifiers(_ modifiers: NSEvent.ModifierFlags) -> Bool {
-    guard let shortcut = KeyboardShortcuts.Name.popup.shortcut else {
-      return false
-    }
-
-    return modifiers.intersection(.deviceIndependentFlagsMask) ==
-      shortcut.modifiers.intersection(.deviceIndependentFlagsMask)
-  }
-
   private func allModifiersReleased(_ event: NSEvent) -> Bool {
     return event.modifierFlags.isDisjoint(with: .deviceIndependentFlagsMask)
+  }
+
+  private func handleRepeatedHotKeyDown() {
+    if let item = History.shared.pressedShortcutItem {
+      AppState.shared.navigator.select(item: item)
+      Task { @MainActor in
+        AppState.shared.history.select(item)
+      }
+      return
+    }
+
+    if state == .opening {
+      state = .cycle
+    }
+
+    if state == .cycle {
+      AppState.shared.navigator.highlightNext(allowCycle: true)
+      return
+    }
+
+    if state == .toggle {
+      close()
+    }
   }
 }


### PR DESCRIPTION
## Summary

- keep the popup global shortcut registered for the process lifetime
- route complete shortcut presses through the existing popup state machine
- keep only the `flagsChanged` monitor needed for release-to-select behavior

## Root cause

Opening the popup disabled `.popup`, and closing it enabled the shortcut again. In KeyboardShortcuts 2.0.2, that pair unregisters the Carbon hotkey and registers a new one. The Carbon backing allocations accumulated across popup open/close cycles.

Keeping the global registration alive removes that allocation cycle. Toggle, ordinary repeated presses, and release-to-select continue to use the existing popup state machine.

## Known test difference

`testOpenAndSelectThirdItemRepeatedPress` posts multiple synthetic key-down events without intervening key-up events. With the Carbon hotkey left registered, those extra raw events do not reach the local AppKit monitor, so that test remains red. The minimal leak fix is intentionally kept here; compatibility with that synthetic repeat sequence can be handled separately if it reflects required runtime behavior.

## Validation

- ported from the fork's measured fix (`04298ab2`), which observed 783 live Carbon hotkey allocations using 43.5 MB after extended use
- verified against the pinned KeyboardShortcuts 2.0.2 source: `disable` unregisters, `enable` calls `RegisterEventHotKey`, and handled hotkey events return `noErr`
- independently AI-reviewed against current upstream `master`
- `git diff --check` passes
- the branch contains one production-code file and no docs or CI changes
