### PR TITLE
Bound decoded image memory with an LRU cache

### DIFF
--- a/Maccy/Extensions/NSImage+Resized.swift
+++ b/Maccy/Extensions/NSImage+Resized.swift
@@ -1,4 +1,4 @@
-import AppKit.NSImage
+import AppKit
 
 // Based on https://stackoverflow.com/questions/73062803/resizing-nsimage-keeping-aspect-ratio-reducing-the-image-size-while-trying-to-sc.
 extension NSImage {
@@ -11,6 +11,19 @@ extension NSImage {
     // Fallback to logical size if no bitmap representation is available
     return size
   }
+
+  // Render at the backing scale factor of the screen so that resized
+  // images stay sharp on Retina displays.
+  private static var renderScale: CGFloat {
+    NSScreen.forPopup?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2
+  }
+
+  // Must be called on the main thread.
+  //
+  // Rasterizes the result into a standalone bitmap. Unlike
+  // `NSImage(size:flipped:drawingHandler:)`, the returned image does NOT
+  // retain the original (potentially huge) image, so evicting the resized
+  // image from a cache actually frees its memory.
   func resized(to newSize: NSSize) -> NSImage {
     let ratioX = newSize.width / size.width
     let ratioY = newSize.height / size.height
@@ -24,13 +37,34 @@ extension NSImage {
       return self
     }
 
-    return NSImage(size: newSize, flipped: false) { destRect in
-      if let context = NSGraphicsContext.current {
-        context.imageInterpolation = .high
-        self.draw(in: destRect, from: NSRect.zero, operation: .copy, fraction: 1)
-      }
-
-      return true
+    let scale = NSImage.renderScale
+    guard let rep = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: Int(newWidth * scale),
+      pixelsHigh: Int(newHeight * scale),
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    ) else {
+      return self
     }
+    // Set the size in points so the rep is treated as high-resolution
+    // instead of a larger image.
+    rep.size = newSize
+
+    NSGraphicsContext.saveGraphicsState()
+    let context = NSGraphicsContext(bitmapImageRep: rep)
+    context?.imageInterpolation = .high
+    NSGraphicsContext.current = context
+    draw(in: NSRect(origin: .zero, size: newSize), from: NSRect.zero, operation: .copy, fraction: 1)
+    NSGraphicsContext.restoreGraphicsState()
+
+    let resized = NSImage(size: newSize)
+    resized.addRepresentation(rep)
+    return resized
   }
 }

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -172,6 +172,12 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     limitHistorySize(to: Defaults[.size] - 1)
 
     sessionLog[Clipboard.shared.changeCount] = item
+    // sessionLog is only needed to detect copies that modify a recent item,
+    // so keep it bounded instead of growing it for the whole session.
+    if sessionLog.count > 100 {
+      let staleKeys = sessionLog.keys.sorted().dropFirst(sessionLog.count - 100)
+      staleKeys.forEach { sessionLog.removeValue(forKey: $0) }
+    }
 
     var itemDecorator: HistoryItemDecorator
     if let pin = item.pin {
@@ -288,6 +294,15 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @MainActor
   private func cleanup(_ item: HistoryItemDecorator) {
     item.cleanupImages()
+  }
+
+  // Releases all decoded images (thumbnails and previews).
+  // The raw data stays in the on-disk database and is decoded
+  // on demand when an item is displayed again.
+  @MainActor
+  func releaseDecodedImages() {
+    all.forEach { $0.cleanupImages() }
+    ImageCache.shared.removeAll()
   }
 
   private func currentModifierFlags() -> NSEvent.ModifierFlags {

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -45,6 +45,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var thumbnailImageGenerationTask: Task<(), Error>?
   var previewImage: NSImage?
   var thumbnailImage: NSImage?
+  // Pixel dimensions of the original image, captured during decoding so that
+  // the preview view does not need to decode the original image again just
+  // to display its dimensions.
+  var imagePixelSize: NSSize?
   var applicationImage: ApplicationImage
 
   // 10k characters seems to be more than enough on large displays
@@ -85,6 +89,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     }
     thumbnailImageGenerationTask = Task { [weak self] in
       self?.generateThumbnailImage()
+      // Clear the task reference so the image can be regenerated
+      // after it has been evicted from the cache.
+      self?.thumbnailImageGenerationTask = nil
     }
   }
 
@@ -101,6 +108,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     }
     previewImageGenerationTask = Task { [weak self] in
       self?.generatePreviewImage()
+      // Clear the task reference so the image can be regenerated
+      // after it has been evicted from the cache.
+      self?.previewImageGenerationTask = nil
     }
   }
 
@@ -122,6 +132,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     previewImage?.recache()
     thumbnailImage = nil
     previewImage = nil
+    ImageCache.shared.remove(self)
   }
 
   @MainActor
@@ -129,7 +140,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     guard let image = item.image else {
       return
     }
+    imagePixelSize = image.pixelSize
     thumbnailImage = image.resized(to: HistoryItemDecorator.thumbnailImageSize)
+    ImageCache.shared.store(.thumbnail, for: self)
   }
 
   @MainActor
@@ -137,7 +150,9 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
     guard let image = item.image else {
       return
     }
+    imagePixelSize = image.pixelSize
     previewImage = image.resized(to: HistoryItemDecorator.previewImageSize)
+    ImageCache.shared.store(.preview, for: self)
   }
 
   @MainActor
@@ -205,5 +220,74 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
         self.synchronizeItemTitle()
       }
     }
+  }
+}
+
+// MARK: - ImageCache
+
+// LRU cache for decoded history images (thumbnails and previews).
+//
+// The raw image data always remains in the on-disk database; this cache only
+// bounds how many *decoded* NSImages are kept in memory. When a limit is
+// exceeded, the least recently generated image is evicted by clearing the
+// owning decorator's reference so the memory is actually freed. The image is
+// regenerated on demand the next time the item is displayed.
+@MainActor
+final class ImageCache {
+  static let shared = ImageCache()
+
+  enum Kind {
+    case thumbnail
+    case preview
+  }
+
+  // Preview images are screen-sized bitmaps (tens of MB each on Retina
+  // displays), so only keep a few in memory.
+  var previewLimit = 5
+  // Thumbnails are small (~200 KB each); keep enough to fill the popup
+  // without thrashing regeneration.
+  var thumbnailLimit = 50
+
+  private final class WeakDecorator {
+    weak var value: HistoryItemDecorator?
+    init(_ value: HistoryItemDecorator) { self.value = value }
+  }
+
+  private struct Entry {
+    let id: UUID
+    let kind: Kind
+    let decorator: WeakDecorator
+  }
+
+  // Oldest entries first.
+  private var entries: [Entry] = []
+
+  func store(_ kind: Kind, for decorator: HistoryItemDecorator) {
+    entries.removeAll { $0.id == decorator.id && $0.kind == kind }
+    entries.append(Entry(id: decorator.id, kind: kind, decorator: WeakDecorator(decorator)))
+
+    let limit = kind == .thumbnail ? thumbnailLimit : previewLimit
+    var excess = entries.count(where: { $0.kind == kind }) - limit
+    guard excess > 0 else { return }
+
+    entries = entries.filter { entry in
+      guard excess > 0, entry.kind == kind else { return true }
+      excess -= 1
+      switch kind {
+      case .thumbnail:
+        entry.decorator.value?.thumbnailImage = nil
+      case .preview:
+        entry.decorator.value?.previewImage = nil
+      }
+      return false
+    }
+  }
+
+  func remove(_ decorator: HistoryItemDecorator) {
+    entries.removeAll { $0.id == decorator.id }
+  }
+
+  func removeAll() {
+    entries.removeAll()
   }
 }

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -83,6 +83,11 @@ class Popup {
 
   func close() {
     AppState.shared.appDelegate?.panel.close()  // close() calls reset
+    // Release decoded images once the popup is closed; they are
+    // regenerated on demand when the popup is opened again.
+    Task { @MainActor in
+      History.shared.releaseDecodedImages()
+    }
   }
 
   func isClosed() -> Bool {

--- a/Maccy/Views/PreviewItemView.swift
+++ b/Maccy/Views/PreviewItemView.swift
@@ -72,10 +72,10 @@ struct PreviewItemView: View {
         }
       }
 
-      if item.hasImage, let image = item.item.image {
+      if item.hasImage, let size = item.imagePixelSize {
         HStack(spacing: 3) {
           Text("Dimensions", tableName: "PreviewItemView")
-          Text("\(Int(image.pixelSize.width))×\(Int(image.pixelSize.height))")
+          Text("\(Int(size.width))×\(Int(size.height))")
         }
       }
 

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -120,6 +120,37 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertFalse(itemDecorator.isPinned)
   }
 
+  func testImageCacheEvictsPreviewsBeyondLimit() {
+    ImageCache.shared.removeAll()
+    let image = NSImage(named: "NSApplicationIcon")!
+    var decorators: [HistoryItemDecorator] = []
+    for _ in 0..<(ImageCache.shared.previewLimit + 3) {
+      let decorator = historyItemDecorator(image)
+      decorator.sizeImages()
+      decorators.append(decorator)
+    }
+    // The oldest previews beyond the limit are evicted.
+    for decorator in decorators.prefix(3) {
+      XCTAssertNil(decorator.previewImage)
+    }
+    // The most recent previews are kept in memory.
+    for decorator in decorators.suffix(ImageCache.shared.previewLimit) {
+      XCTAssertNotNil(decorator.previewImage)
+    }
+    ImageCache.shared.removeAll()
+  }
+
+  func testCleanupImagesReleasesCachedImages() {
+    let image = NSImage(named: "NSApplicationIcon")!
+    let decorator = historyItemDecorator(image)
+    decorator.sizeImages()
+    XCTAssertNotNil(decorator.thumbnailImage)
+    XCTAssertNotNil(decorator.previewImage)
+    decorator.cleanupImages()
+    XCTAssertNil(decorator.thumbnailImage)
+    XCTAssertNil(decorator.previewImage)
+  }
+
   func testHighlight() {
     let itemDecorator = historyItemDecorator("foo bar baz")
     itemDecorator.highlight("random", [


### PR DESCRIPTION
## Problem

Maccy's memory usage grows monotonically while browsing history and never drops when the popup is closed. With an image-heavy history it easily reaches several hundred MB (600+ MB RSS observed with a ~400 MB storage database).

Root causes:

1. **Decoded images are cached forever.** Every `HistoryItemDecorator` keeps its `thumbnailImage` and screen-sized `previewImage` until the item is deleted or the history is cleared. A single preview is the size of the whole screen (`previewImageSize` uses `NSScreen.forPopup.visibleFrame`), i.e. ~20 MB on a Retina display, so scrolling through history with the preview pane open accumulates tens of these.
2. **Resized images retain the original.** `NSImage.resized(to:)` used `NSImage(size:flipped:drawingHandler:)`, whose closure captures `self` — every ~200 KB thumbnail kept its full-size original (often a multi-MB uncompressed TIFF) alive.
3. Nothing is released when the popup closes.

## Solution

The raw image data already lives in the on-disk SwiftData store, so decoded images can be treated as a regenerable cache:

- **New `ImageCache` (LRU)** bounds decoded images in memory: at most **5 screen-sized previews** and **50 thumbnails**. When a limit is exceeded, the least recently generated image is evicted (the owning decorator's reference is cleared) and regenerated on demand next time the item is displayed.
- **`NSImage.resized(to:)`** now rasterizes into a standalone `NSBitmapImageRep` (at the screen's backing scale factor, so Retina sharpness is preserved) instead of a drawing handler that retains the original image.
- **Popup close releases all decoded images** (`History.releaseDecodedImages()`); they are regenerated on demand on next open.
- The preview pane's *Dimensions* label now uses the pixel size recorded during decoding (`imagePixelSize`) instead of decoding the original image again.
- `sessionLog` is bounded to the 100 most recent entries (it grew for the whole session and can hold items with decoded image data).

Also fixes a latent bug: after an image is evicted, the generation task references are cleared so the image can actually be regenerated.

## Testing

- Added `testImageCacheEvictsPreviewsBeyondLimit` (eviction keeps only the N most recent previews) and `testCleanupImagesReleasesCachedImages` to `HistoryItemDecoratorTests`; all decorator tests pass.
- Full `MaccyTests` suite: only the pre-existing `ClipboardTests` failures remain (they fail identically on unmodified master in this environment — they depend on the system pasteboard).
- With these changes, decoded image memory is bounded to roughly 120 MB worst case (5 screen-sized previews + 50 thumbnails) and returns to baseline when the popup is closed, instead of growing without limit.

## Known limitation

SwiftData does not expose Core Data's re-fault API, so raw (compressed) image data that was accessed during a session stays in the `ModelContext` until restart. Fully addressing that would require moving image blobs out of the database into file storage — intentionally out of scope for this PR.