### PR TITLE
Raise popup window level above Chrome autofill

### DIFF
--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -37,7 +37,9 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
 
     animationBehavior = .none
     isFloatingPanel = true
-    level = .statusBar
+    // Chrome autofill uses window layer 999; screenSaver (1000) sits just above it
+    // while still covering status items / Spotlight. See #1403.
+    level = .screenSaver
     collectionBehavior = [.auxiliary, .stationary, .moveToActiveSpace, .fullScreenAuxiliary]
     titleVisibility = .hidden
     titlebarAppearsTransparent = true


### PR DESCRIPTION
## Problem

Fixes #1403.

When Chrome’s autofill / suggestion dropdown is open, opening Maccy shows the clipboard popup **underneath** that dropdown, so the history list is partially or fully obscured.

## Root cause

`FloatingPanel` sets `level = .statusBar` (window layer **25**). Chrome’s autofill popup is created at layer **999**, which sits above `.statusBar` and also above `.popUpMenu` (**101**), so Maccy loses the z-order contest while autofill is visible.

`.statusBar` was previously chosen so the panel stays above Spotlight; that still holds for any level ≥ 25.

## Fix

Raise the panel level to `.screenSaver` (**1000**), which sits just above Chrome’s autofill layer (999) while remaining above status items / Spotlight:

```swift
// Chrome autofill uses window layer 999; screenSaver (1000) sits just above it
// while still covering status items / Spotlight. See #1403.
level = .screenSaver
```


## Verification

* Built and ran a Debug build with the change applied
* Reproduced on Chrome autofill (phone input suggestions): Maccy popup now appears **above** the autofill dropdown
* Confirmed popup still appears above Spotlight
* Outside click / resign-key still dismisses the popup