### PR TITLE
Restore macOS ⌃K kill-to-end-of-line at the first item

### DIFF
--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -103,10 +103,9 @@ enum KeyChord: CaseIterable {
     case (.upArrow, []),
          (.p, [.control]):
       self = .moveToPrevious
-    case (.k, [.control]):
-      // With no search results, let the text field keep macOS kill-to-end-of-line (⌃K).
-      // Otherwise keep vim-style navigation. See https://github.com/p0deje/Maccy/issues/1055
-      self = AppState.shared.history.firstVisibleItem == nil ? .ignored : .moveToPrevious
+    case (.k, [.control]) where !AppState.shared.navigator.isFirstItemHighlighted:
+      // See https://github.com/p0deje/Maccy/issues/1055
+      self = .moveToPrevious
     case (.upArrow, [.command, .shift]),
          (.upArrow, [.option, .shift]),
          (.p, [.control, .option, .shift]):

--- a/Maccy/KeyChord.swift
+++ b/Maccy/KeyChord.swift
@@ -101,9 +101,12 @@ enum KeyChord: CaseIterable {
          (.p, [.control, .shift]):
       self = AppState.shared.multiSelectionEnabled ? .extendToPrevious : .moveToPrevious
     case (.upArrow, []),
-         (.p, [.control]),
-         (.k, [.control]):
+         (.p, [.control]):
       self = .moveToPrevious
+    case (.k, [.control]):
+      // With no search results, let the text field keep macOS kill-to-end-of-line (⌃K).
+      // Otherwise keep vim-style navigation. See https://github.com/p0deje/Maccy/issues/1055
+      self = AppState.shared.history.firstVisibleItem == nil ? .ignored : .moveToPrevious
     case (.upArrow, [.command, .shift]),
          (.upArrow, [.option, .shift]),
          (.p, [.control, .option, .shift]):

--- a/Maccy/Observables/NavigationManager.swift
+++ b/Maccy/Observables/NavigationManager.swift
@@ -62,6 +62,8 @@ class NavigationManager { // swiftlint:disable:this type_body_length
     }
   }
 
+  var isFirstItemHighlighted: Bool { history.firstVisibleItem == leadHistoryItem }
+
   private func scroll(to id: UUID?, item: HistoryItemDecorator? = nil) {
     scrollTarget = id
   }

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -96,6 +96,15 @@ struct KeyHandlingView<Content: View>: View {
             return .ignored
           }
 
+          // ⌃K also maps to moveToPrevious (vim-style). When already at the first
+          // item — or when there are no items to move to — keep macOS kill-to-end-of-line.
+          // https://github.com/p0deje/Maccy/issues/1055
+          if isControlK(NSApp.currentEvent), shouldUseControlKForKillToEnd {
+            searchFocused = true
+            deleteSearchTextToEndOfLine()
+            return .handled
+          }
+
           appState.navigator.highlightPrevious()
           return .handled
         case .moveToFirst:
@@ -171,5 +180,77 @@ struct KeyHandlingView<Content: View>: View {
 
         return .ignored
       }
+  }
+
+  private var shouldUseControlKForKillToEnd: Bool {
+    // No visible results: navigation is a no-op, so prefer kill-to-end in search.
+    guard let first = appState.history.firstVisibleItem else {
+      return true
+    }
+
+    return appState.navigator.leadHistoryItem?.id == first.id
+  }
+
+  private func isControlK(_ event: NSEvent?) -> Bool {
+    guard let event else {
+      return false
+    }
+
+    let modifierFlags = event.modifierFlags
+      .intersection(.deviceIndependentFlagsMask)
+      .subtracting([.capsLock, .numericPad, .function])
+    guard modifierFlags == .control else {
+      return false
+    }
+
+    return Sauce.shared.key(for: Int(event.keyCode)) == .k
+  }
+
+  // Mutate `searchQuery` directly (like ⌃H/⌃W). Editing the field editor alone is
+  // overwritten by SwiftUI from the unchanged binding.
+  private func deleteSearchTextToEndOfLine() {
+    guard let text = searchFieldEditor() else {
+      return
+    }
+
+    let string = text.string as NSString
+    let cursor = min(text.selectedRange.location, string.length)
+    searchQuery = string.substring(to: cursor)
+  }
+
+  private func searchFieldEditor() -> NSText? {
+    if let text = NSApp.keyWindow?.firstResponder as? NSText {
+      return text
+    }
+
+    for window in NSApp.windows where window.isVisible {
+      if let text = window.firstResponder as? NSText {
+        return text
+      }
+
+      guard let contentView = window.contentView,
+            let field = findTextField(in: contentView) else {
+        continue
+      }
+
+      window.makeFirstResponder(field)
+      return window.fieldEditor(true, for: field)
+    }
+
+    return nil
+  }
+
+  private func findTextField(in view: NSView) -> NSTextField? {
+    if let textField = view as? NSTextField {
+      return textField
+    }
+
+    for subview in view.subviews {
+      if let textField = findTextField(in: subview) {
+        return textField
+      }
+    }
+
+    return nil
   }
 }

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -156,8 +156,6 @@ struct KeyHandlingView<Content: View>: View {
         case .togglePreview:
           appState.preview.togglePreview()
           return .handled
-        case .ignored:
-          return .ignored
         default:
           ()
         }

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -96,15 +96,6 @@ struct KeyHandlingView<Content: View>: View {
             return .ignored
           }
 
-          // ⌃K also maps to moveToPrevious (vim-style). When already at the first
-          // item — or when there are no items to move to — keep macOS kill-to-end-of-line.
-          // https://github.com/p0deje/Maccy/issues/1055
-          if isControlK(NSApp.currentEvent), shouldUseControlKForKillToEnd {
-            searchFocused = true
-            deleteSearchTextToEndOfLine()
-            return .handled
-          }
-
           appState.navigator.highlightPrevious()
           return .handled
         case .moveToFirst:
@@ -165,6 +156,8 @@ struct KeyHandlingView<Content: View>: View {
         case .togglePreview:
           appState.preview.togglePreview()
           return .handled
+        case .ignored:
+          return .ignored
         default:
           ()
         }
@@ -180,77 +173,5 @@ struct KeyHandlingView<Content: View>: View {
 
         return .ignored
       }
-  }
-
-  private var shouldUseControlKForKillToEnd: Bool {
-    // No visible results: navigation is a no-op, so prefer kill-to-end in search.
-    guard let first = appState.history.firstVisibleItem else {
-      return true
-    }
-
-    return appState.navigator.leadHistoryItem?.id == first.id
-  }
-
-  private func isControlK(_ event: NSEvent?) -> Bool {
-    guard let event else {
-      return false
-    }
-
-    let modifierFlags = event.modifierFlags
-      .intersection(.deviceIndependentFlagsMask)
-      .subtracting([.capsLock, .numericPad, .function])
-    guard modifierFlags == .control else {
-      return false
-    }
-
-    return Sauce.shared.key(for: Int(event.keyCode)) == .k
-  }
-
-  // Mutate `searchQuery` directly (like ⌃H/⌃W). Editing the field editor alone is
-  // overwritten by SwiftUI from the unchanged binding.
-  private func deleteSearchTextToEndOfLine() {
-    guard let text = searchFieldEditor() else {
-      return
-    }
-
-    let string = text.string as NSString
-    let cursor = min(text.selectedRange.location, string.length)
-    searchQuery = string.substring(to: cursor)
-  }
-
-  private func searchFieldEditor() -> NSText? {
-    if let text = NSApp.keyWindow?.firstResponder as? NSText {
-      return text
-    }
-
-    for window in NSApp.windows where window.isVisible {
-      if let text = window.firstResponder as? NSText {
-        return text
-      }
-
-      guard let contentView = window.contentView,
-            let field = findTextField(in: contentView) else {
-        continue
-      }
-
-      window.makeFirstResponder(field)
-      return window.fieldEditor(true, for: field)
-    }
-
-    return nil
-  }
-
-  private func findTextField(in view: NSView) -> NSTextField? {
-    if let textField = view as? NSTextField {
-      return textField
-    }
-
-    for subview in view.subviews {
-      if let textField = findTextField(in: subview) {
-        return textField
-      }
-    }
-
-    return nil
   }
 }


### PR DESCRIPTION
## Problem

Fixes #1055

⌃K was always bound to vim-style “move to previous”, so it swallowed the macOS/readline kill-to-end-of-line behavior in the search field. At the first item (or with no results) that navigation is a no-op, so ⌃K appeared to do nothing while typing.

## Root cause

`KeyChord` maps ⌃K to `moveToPrevious`, and `KeyHandlingView` always handled that path. The search field never received a real kill-to-end action.

## Fix

Middle ground suggested by @p0deje :

- If the first visible history item is selected, or there are no visible items → ⌃K kills from the caret to the end of the search query
- Otherwise → keep navigating up with ⌃K

Kill updates `searchQuery` (same approach as ⌃H/⌃W) so SwiftUI does not revert field-editor edits.

## Verification

- Smoke-built on tag `2.5.1`
- Verified manually:
  - With results, on the first item: ⌃K deletes from caret to end of search
  - With results, not on the first item: ⌃K moves selection up
  - With no search results: ⌃K still kills to end of search