### PR TITLE
fix: Refresh application icon after the source app is updated

### DIFF
--- a/Maccy/ApplicationImage.swift
+++ b/Maccy/ApplicationImage.swift
@@ -61,6 +61,7 @@ class ApplicationImage {
               print("Deleted", appURL.path)
               source.cancel()
               self.image = nil
+              self.lastChecked = nil
             } else if event.contains(.write) {
               // File was modified. Fetch new icon
               print("Modified", appURL.path)


### PR DESCRIPTION
Fixes #1106.

## Problem
When an application (e.g. Firefox, which updates frequently) is updated, its item icons in the history show the "missing"/prohibitory placeholder until Maccy is restarted.

## Cause
`ApplicationImage` watches each app bundle's path for filesystem events. An app update typically replaces the bundle atomically, which fires a `.delete` on the old inode even though the app still exists at the same path. The `.delete` handler cleared the cached `image` but left `lastChecked` at its recent value, so the next access hit the 1-hour retry throttle and returned the fallback icon.

## Fix
Reset `lastChecked` in the `.delete` handler so the icon is re-resolved on the next access. If the app was genuinely removed, `lastChecked` is re-checked before the lookup.

## Testing
Reproduced manually: copy from Firefox, then delete + replace `/Applications/Firefox.app` to fire the `.delete` event. Before the change the icon showed the placeholder; after the change it resolves correctly on the next popup render.

**Before Fix:**
<img width="647" height="176" alt="before_fix" src="https://github.com/user-attachments/assets/49763199-e7eb-4bae-8fa2-9f1f3f823d36" />

**After Fix:**
<img width="658" height="171" alt="after_fix" src="https://github.com/user-attachments/assets/762ed8c6-71d8-4e93-a63d-29253daaf4a8" />

## Steps to reproduce
1. Install the Firefox browser.
2. Start Maccy.
3. Start Firefox and copy some text from it to the clipboard (intercepted by Maccy).
4. Open the copy-paste item in Maccy and confirm that the Firefox icon is next to the text value (as per screenshots above).
5. Simulate a Firefox update:
```sh
   osascript -e 'quit app "Firefox"'; sleep 1
   cp -R /Applications/Firefox.app /tmp/Firefox.app   # the "new version"
   sudo rm -rf /Applications/Firefox.app              # removes the watched bundle -> fires .delete
   mv /tmp/Firefox.app /Applications/Firefox.app      # put the fresh bundle back
```
6. Reopen Maccy after this "Firefox update" and observe the missing icon (on macOS 26 it shows a question mark instead of the real app icon).