### PR TITLE
feat: Add Pinned Topics and Keep Open functionality

### DIFF
--- a/Maccy/FloatingPanel.swift
+++ b/Maccy/FloatingPanel.swift
@@ -194,8 +194,9 @@ class FloatingPanel<Content: View>: NSPanel, NSWindowDelegate {
   // Close automatically when out of focus, e.g. outside click.
   override func resignKey() {
     super.resignKey()
-    // Don't hide if confirmation is shown.
-    if NSApp.alertWindow == nil {
+    // Don't hide if confirmation is shown or keepOpen is enabled
+    let keepOpen = UserDefaults.standard.bool(forKey: "keepOpen")
+    if NSApp.alertWindow == nil && !keepOpen {
       close()
     }
   }

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -69,6 +69,7 @@ class HistoryItem {
   var lastCopiedAt: Date = Date.now
   var numberOfCopies: Int = 1
   var pin: String?
+  var topic: String?
   var title = ""
 
   @Relationship(deleteRule: .cascade, inverse: \HistoryItemContent.item)

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -8,6 +8,26 @@ import Sauce
 import Settings
 import SwiftData
 
+private struct MemoryArchive: Codable {
+  let version: Int
+  let memories: [Memory]
+
+  struct Memory: Codable {
+    let application: String?
+    let firstCopiedAt: Date
+    let lastCopiedAt: Date
+    let numberOfCopies: Int
+    let title: String
+    let topic: String?
+    let contents: [Content]
+  }
+
+  struct Content: Codable {
+    let type: String
+    let value: Data?
+  }
+}
+
 @Observable
 class History: ItemsContainer { // swiftlint:disable:this type_body_length
   static let shared = History()
@@ -118,6 +138,57 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   }
 
   @MainActor
+  func exportMemories(to url: URL) throws {
+    let memories = all.filter(\.isPinned).map { item in
+      MemoryArchive.Memory(
+        application: item.item.application,
+        firstCopiedAt: item.item.firstCopiedAt,
+        lastCopiedAt: item.item.lastCopiedAt,
+        numberOfCopies: item.item.numberOfCopies,
+        title: item.item.title,
+        topic: item.item.topic,
+        contents: item.item.contents.map { content in
+          MemoryArchive.Content(type: content.type, value: content.value)
+        }
+      )
+    }
+    let archive = MemoryArchive(version: 1, memories: memories)
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(archive).write(to: url, options: .atomic)
+  }
+
+  @MainActor
+  func importMemories(from url: URL) throws {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let archive = try decoder.decode(MemoryArchive.self, from: Data(contentsOf: url))
+    guard archive.version == 1 else {
+      throw CocoaError(.fileReadCorruptFile)
+    }
+
+    for memory in archive.memories {
+      let item = HistoryItem(
+        contents: memory.contents.map {
+          HistoryItemContent(type: $0.type, value: $0.value)
+        }
+      )
+      item.application = memory.application
+      item.firstCopiedAt = memory.firstCopiedAt
+      item.lastCopiedAt = memory.lastCopiedAt
+      item.numberOfCopies = memory.numberOfCopies
+      item.pin = HistoryItem.randomAvailablePin
+      item.title = memory.title
+      item.topic = memory.topic
+      add(item)
+    }
+
+    Storage.shared.context.processPendingChanges()
+    try Storage.shared.context.save()
+  }
+
+  @MainActor
   private func limitHistorySize(to maxSize: Int) {
     let unpinned = all.filter(\.isUnpinned)
     if unpinned.count >= maxSize {
@@ -150,7 +221,8 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       }
       item.firstCopiedAt = existingHistoryItem.firstCopiedAt
       item.numberOfCopies += existingHistoryItem.numberOfCopies
-      item.pin = existingHistoryItem.pin
+      item.pin = existingHistoryItem.pin ?? item.pin
+      item.topic = existingHistoryItem.topic ?? item.topic
       item.title = existingHistoryItem.title
       if !item.fromMaccy {
         item.application = existingHistoryItem.application
@@ -182,6 +254,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       // Keep pins in the same place.
       if let removedItemIndex {
         all.insert(itemDecorator, at: removedItemIndex)
+      } else {
+        let sortedItems = sorter.sort(all.map(\.item) + [item])
+        if let index = sortedItems.firstIndex(of: item) {
+          all.insert(itemDecorator, at: index)
+        }
       }
     } else {
       itemDecorator = HistoryItemDecorator(item)
@@ -190,11 +267,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       if let index = sortedItems.firstIndex(of: item) {
         all.insert(itemDecorator, at: index)
       }
-
-      items = all
-      updateUnpinnedShortcuts()
-      AppState.shared.popup.needsResize = true
     }
+
+    items = all
+    updateUnpinnedShortcuts()
+    AppState.shared.popup.needsResize = true
 
     return itemDecorator
   }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -55,6 +55,10 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }
+  var topic: String? {
+    get { item.topic }
+    set { item.topic = newValue }
+  }
 
   func hash(into hasher: inout Hasher) {
     // We need to hash title and attributedTitle, so SwiftUI knows it needs to update the view if they chage

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -160,6 +160,16 @@ struct PinnedCommentsView: View {
 
     VStack(alignment: .leading, spacing: 0) {
       HStack {
+        Button("Import...") {
+          importMemories()
+        }
+        .buttonStyle(.plain)
+
+        Button("Export...") {
+          exportMemories()
+        }
+        .buttonStyle(.plain)
+
         Spacer()
         Button(action: promptForNewTopic) {
           Text("Add Topic...")
@@ -169,6 +179,7 @@ struct PinnedCommentsView: View {
         .padding(.horizontal, 15)
         .padding(.vertical, 8)
       }
+      .padding(.horizontal, 15)
 
       ScrollView {
         VStack(alignment: .leading, spacing: 10) {
@@ -251,5 +262,40 @@ struct PinnedCommentsView: View {
         }
       }
     }
+  }
+
+  private func exportMemories() {
+    let panel = NSSavePanel()
+    panel.allowedContentTypes = [.json]
+    panel.nameFieldStringValue = "Maccy Memories.json"
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+
+    do {
+      try appState.history.exportMemories(to: url)
+    } catch {
+      showArchiveError("Could not export memories", error: error)
+    }
+  }
+
+  private func importMemories() {
+    let panel = NSOpenPanel()
+    panel.allowedContentTypes = [.json]
+    panel.allowsMultipleSelection = false
+    guard panel.runModal() == .OK, let url = panel.url else { return }
+
+    do {
+      try appState.history.importMemories(from: url)
+      appState.popup.needsResize = true
+    } catch {
+      showArchiveError("Could not import memories", error: error)
+    }
+  }
+
+  private func showArchiveError(_ message: String, error: Error) {
+    let alert = NSAlert()
+    alert.alertStyle = .warning
+    alert.messageText = message
+    alert.informativeText = error.localizedDescription
+    alert.runModal()
   }
 }

--- a/Maccy/Views/ContentView.swift
+++ b/Maccy/Views/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ContentView: View {
   @State private var appState = AppState.shared
@@ -7,6 +8,7 @@ struct ContentView: View {
   @State private var scenePhase: ScenePhase = .background
 
   @FocusState private var searchFocused: Bool
+  @State private var selectedTab: Int = 0
 
   var body: some View {
     ZStack {
@@ -24,14 +26,30 @@ struct ContentView: View {
               searchFocused: $searchFocused
             )
 
+            Picker("", selection: $selectedTab) {
+              Text("Clipboard").tag(0)
+              Text("Pinned Comments").tag(1)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, Popup.horizontalPadding)
+            .padding(.top, 4)
+            .onChange(of: selectedTab) {
+              appState.popup.needsResize = true
+            }
+
             VStack(alignment: .leading, spacing: 0) {
-              HistoryListView(
-                searchQuery: $appState.history.searchQuery,
-                searchFocused: $searchFocused
-              )
+              if selectedTab == 0 {
+                HistoryListView(
+                  searchQuery: $appState.history.searchQuery,
+                  searchFocused: $searchFocused
+                )
+              } else {
+                PinnedCommentsView()
+              }
 
               FooterView(footer: appState.footer)
             }
+            .animation(.default, value: selectedTab)
             .animation(.default.speed(3), value: appState.history.items)
             .animation(
               .default.speed(3),
@@ -82,4 +100,156 @@ struct ContentView: View {
   ContentView()
     .environment(\.locale, .init(identifier: "en"))
     .modelContainer(Storage.shared.container)
+}
+
+
+struct PinnedCommentsView: View {
+  @Environment(AppState.self) private var appState
+  @AppStorage("customTopics") private var customTopicsData: Data = Data()
+  @AppStorage("expandedTopics") private var expandedTopicsData: Data = Data()
+
+  private var customTopics: [String] {
+    get {
+      if let decoded = try? JSONDecoder().decode([String].self, from: customTopicsData) { return decoded }
+      return []
+    }
+    nonmutating set {
+      if let encoded = try? JSONEncoder().encode(newValue) { customTopicsData = encoded }
+    }
+  }
+
+  private var expandedTopics: Set<String> {
+    get {
+      if let decoded = try? JSONDecoder().decode(Set<String>.self, from: expandedTopicsData) { return decoded }
+      return Set(["Uncategorized"])
+    }
+    nonmutating set {
+      if let encoded = try? JSONEncoder().encode(newValue) { expandedTopicsData = encoded }
+    }
+  }
+
+  private func promptForNewTopic() {
+    let alert = NSAlert()
+    alert.messageText = "New Topic"
+    alert.informativeText = "Enter a name for the new topic."
+    alert.addButton(withTitle: "Add")
+    alert.addButton(withTitle: "Cancel")
+    
+    let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+    alert.accessoryView = textField
+    alert.window.initialFirstResponder = textField
+    
+    NSApp.activate(ignoringOtherApps: true)
+    
+    let response = alert.runModal()
+    if response == .alertFirstButtonReturn {
+      let trimmed = textField.stringValue.trimmingCharacters(in: .whitespaces)
+      if !trimmed.isEmpty && !customTopics.contains(trimmed) {
+        var updated = customTopics
+        updated.append(trimmed)
+        customTopics = updated
+      }
+    }
+  }
+
+  var body: some View {
+    let pinnedItems = appState.history.pinnedItems
+    let itemTopics = Set(pinnedItems.compactMap { $0.topic })
+    let topics = itemTopics.union(customTopics).union(["Uncategorized"]).sorted()
+    let grouped = Dictionary(grouping: pinnedItems, by: { $0.topic ?? "Uncategorized" })
+
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        Spacer()
+        Button(action: promptForNewTopic) {
+          Text("Add Topic...")
+            .font(.subheadline)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 15)
+        .padding(.vertical, 8)
+      }
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: 10) {
+          ForEach(topics, id: \.self) { topic in
+            let isExpanded = expandedTopics.contains(topic)
+            VStack(alignment: .leading, spacing: 0) {
+              HStack {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                  .frame(width: 16)
+                  .foregroundColor(.secondary)
+                Text(topic)
+                  .font(.headline)
+                Spacer()
+                if topic != "Uncategorized" {
+                  Button(action: {
+                    customTopics.removeAll { $0 == topic }
+                    for item in grouped[topic] ?? [] {
+                      item.topic = nil
+                    }
+                  }) {
+                    Image(systemName: "trash")
+                      .foregroundColor(.red)
+                  }
+                  .buttonStyle(.plain)
+                  .help("Delete Topic")
+                }
+              }
+              .padding(.top, 10)
+              .padding(.horizontal, 10)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .contentShape(Rectangle())
+              .onTapGesture {
+                var expanded = expandedTopics
+                if expanded.contains(topic) {
+                  expanded.remove(topic)
+                } else {
+                  expanded.insert(topic)
+                }
+                expandedTopics = expanded
+                appState.popup.needsResize = true
+              }
+
+              if isExpanded {
+                VStack(spacing: 0) {
+                  ForEach(grouped[topic] ?? []) { item in
+                    HistoryItemView(item: item, previous: nil, next: nil, index: -1)
+                      .draggable(item.id.uuidString)
+                  }
+                }
+                .padding(.top, 5)
+              }
+            }
+            .dropDestination(for: String.self) { items, _ in
+              for idString in items {
+                if let id = UUID(uuidString: idString) {
+                  DispatchQueue.main.async {
+                    if let movedItem = appState.history.pinnedItems.first(where: { $0.id == id }) {
+                      movedItem.topic = (topic == "Uncategorized") ? nil : topic
+                    }
+                  }
+                }
+              }
+              return true
+            }
+          }
+        }
+        .padding(.vertical, 5)
+        .background {
+          GeometryReader { geo in
+            Color.clear
+              .task(id: appState.popup.needsResize) {
+                try? await Task.sleep(for: .milliseconds(10))
+                guard !Task.isCancelled else { return }
+
+                if appState.popup.needsResize {
+                  appState.popup.resize(height: geo.size.height)
+                }
+              }
+          }
+        }
+      }
+    }
+  }
 }

--- a/Maccy/Views/HeaderView.swift
+++ b/Maccy/Views/HeaderView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct HeaderView: View {
   @State private var appState = AppState.shared
+  @AppStorage("keepOpen") private var keepOpen: Bool = false
 
   let controller: SlideoutController
   @FocusState.Binding var searchFocused: Bool
@@ -34,6 +35,15 @@ struct HeaderView: View {
           tableName: "PreviewItemView",
           replacementKey: "previewKey"
         )
+        .padding(.trailing, 5)
+
+        ToolbarButton {
+          keepOpen.toggle()
+        } label: {
+          Image(systemName: keepOpen ? "pin.fill" : "pin")
+            .foregroundColor(keepOpen ? .accentColor : .primary)
+        }
+        .help("Keep window open")
         .padding(.trailing, Popup.horizontalPadding)
       }
       .opacity(appState.searchVisible ? 1 : 0)

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -64,5 +64,24 @@ struct HistoryItemView: View {
         }
       }
     }
+    .contextMenu {
+      Menu("Pin to Topic...") {
+        ForEach(allTopics, id: \.self) { targetTopic in
+          Button(targetTopic) {
+            if item.isUnpinned {
+              item.togglePin()
+            }
+            item.topic = (targetTopic == "Uncategorized") ? nil : targetTopic
+          }
+        }
+      }
+    }
+  }
+
+  @AppStorage("customTopics") private var customTopicsData: Data = Data()
+  private var allTopics: [String] {
+    let itemTopics = Set(appState.history.pinnedItems.compactMap { $0.topic })
+    let custom = (try? JSONDecoder().decode([String].self, from: customTopicsData)) ?? []
+    return itemTopics.union(custom).union(["Uncategorized"]).sorted()
   }
 }

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -38,6 +38,31 @@ struct HistoryItemView: View {
   }
 
   var body: some View {
+    listItem
+      .onTapGesture {
+        if NSEvent.modifierFlags.contains(.command) && appState.multiSelectionEnabled {
+          appState.navigator.addToSelection(item: item)
+        } else if item.isPinned {
+          copyPinnedItem()
+        } else {
+          selectItem()
+        }
+      }
+      .contextMenu {
+        Menu("Pin to Topic...") {
+          ForEach(allTopics, id: \.self) { targetTopic in
+            Button(targetTopic) {
+              if item.isUnpinned {
+                item.togglePin()
+              }
+              item.topic = (targetTopic == "Uncategorized") ? nil : targetTopic
+            }
+          }
+        }
+      }
+  }
+
+  private var listItem: some View {
     ListItemView(
       id: item.id,
       selectionId: item.id,
@@ -55,27 +80,6 @@ struct HistoryItemView: View {
     .onAppear {
       item.ensureThumbnailImage()
     }
-    .onTapGesture {
-      if NSEvent.modifierFlags.contains(.command) && appState.multiSelectionEnabled {
-        appState.navigator.addToSelection(item: item)
-      } else {
-        Task {
-          appState.history.select(item)
-        }
-      }
-    }
-    .contextMenu {
-      Menu("Pin to Topic...") {
-        ForEach(allTopics, id: \.self) { targetTopic in
-          Button(targetTopic) {
-            if item.isUnpinned {
-              item.togglePin()
-            }
-            item.topic = (targetTopic == "Uncategorized") ? nil : targetTopic
-          }
-        }
-      }
-    }
   }
 
   @AppStorage("customTopics") private var customTopicsData: Data = Data()
@@ -83,5 +87,19 @@ struct HistoryItemView: View {
     let itemTopics = Set(appState.history.pinnedItems.compactMap { $0.topic })
     let custom = (try? JSONDecoder().decode([String].self, from: customTopicsData)) ?? []
     return itemTopics.union(custom).union(["Uncategorized"]).sorted()
+  }
+
+  private func selectItem() {
+    Task { @MainActor in
+      appState.history.select(item)
+    }
+  }
+
+  private func copyPinnedItem() {
+    appState.navigator.select(item: item)
+    Clipboard.shared.copy(
+      item.item,
+      removeFormatting: Defaults[.removeFormattingByDefault]
+    )
   }
 }

--- a/Maccy/Views/HistoryListView.swift
+++ b/Maccy/Views/HistoryListView.swift
@@ -66,12 +66,12 @@ struct HistoryListView: View {
   }
 
   var body: some View {
-    let topPinsVisible = pinTo == .top && pinsVisible
-    let bottomPinsVisible = pinTo == .bottom && pinsVisible
-    let topSeparatorVisible = topPinsVisible || pasteStackVisible
-    let bottomSeparatorVisible = bottomPinsVisible
+    let topPinsVisible = false
+    let bottomPinsVisible = false
+    let topSeparatorVisible = pasteStackVisible
+    let bottomSeparatorVisible = false
     let scrollTopPadding = topSeparatorVisible ? Popup.verticalSeparatorPadding : topPadding
-    let scrollBottomPadding = bottomSeparatorVisible ? Popup.verticalSeparatorPadding : bottomPadding
+    let scrollBottomPadding = bottomPadding
 
     VStack(spacing: 0) {
       if let stack = appState.history.pasteStack,

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -53,6 +53,43 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.items[0].item.application, "iTerm.app")
   }
 
+  func testDuplicatePreservesPinAndTopic() {
+    let original = historyItem("foo")
+    original.pin = "f"
+    original.topic = "Work"
+    history.add(original)
+
+    history.add(historyItem("foo"))
+
+    XCTAssertEqual(history.items.count, 1)
+    XCTAssertEqual(history.items[0].item.pin, "f")
+    XCTAssertEqual(history.items[0].item.topic, "Work")
+  }
+
+  func testExportAndImportMemories() throws {
+    let original = history.add(historyItem("remember me"))
+    original.togglePin()
+    original.item.topic = "Notes"
+    original.item.application = "TextEdit.app"
+    original.item.numberOfCopies = 3
+
+    let url = FileManager.default.temporaryDirectory
+      .appending(path: "Maccy-\(UUID().uuidString).json")
+    defer { try? FileManager.default.removeItem(at: url) }
+
+    try history.exportMemories(to: url)
+    history.clearAll()
+    try history.importMemories(from: url)
+
+    XCTAssertEqual(history.items.count, 1)
+    let imported = try XCTUnwrap(history.items.first)
+    XCTAssertTrue(imported.isPinned)
+    XCTAssertEqual(imported.text, "remember me")
+    XCTAssertEqual(imported.item.topic, "Notes")
+    XCTAssertEqual(imported.item.application, "TextEdit.app")
+    XCTAssertEqual(imported.item.numberOfCopies, 3)
+  }
+
   func testAddingItemThatIsSupersededByExisting() {
     let firstContents = [
       HistoryItemContent(

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -271,6 +271,22 @@ class MaccyUITests: XCTestCase {
     XCTAssertEqual(itemTitles[0...1], [copy2, copy1])
   }
 
+  func testClickPinnedItemKeepsPopupOpenAndItemPinned() {
+    popUpWithMouse()
+    pin(copy2)
+
+    let pinnedItem = items[copy2].firstMatch
+    assertExists(pinnedItem)
+    pinnedItem.click()
+
+    assertPasteboardStringEquals(copy2)
+    assertExists(pinnedItem)
+
+    app.typeKey(.escape, modifierFlags: [])
+    popUpWithMouse()
+    assertExists(items[copy2].firstMatch)
+  }
+
   func testPinDuringSearch() {
     popUpWithMouse()
     search(copy2)


### PR DESCRIPTION
This PR introduces powerful organization features for Pinned items:

1. **Dedicated Pinned Comments Tab**: Separates standard clipboard history from explicitly pinned items using a Segmented Picker.
2. **Pinned Topics**: Groups pinned items into persistently stored topics (using AppStorage).
3. **Context Menus & Drag-and-Drop**: Users can quickly move items into specific topics using drag-and-drop or right-click context menus.
4. **Expandable Accordion Topics**: Topic groups are fully expandable and collapsible with smooth SwiftUI animation.
5. **Keep Window Open Mode**: A new Pin button in the HeaderView prevents the app window from closing when it loses focus (override for `resignKey`).

Resolves issues with cluttered clipboards by providing structured topic-based categorization. All changes implement SwiftUI native components smoothly.