### PR TITLE
fix: crash re-invoking bottom-most pinned item at full capacity (#1466)

### DIFF
--- a/Maccy.xctestplan
+++ b/Maccy.xctestplan
@@ -24,20 +24,7 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "HistoryTests",
-        "HistoryTests\/testAdding()",
-        "HistoryTests\/testAddingItemFromMaccy()",
-        "HistoryTests\/testAddingItemThatIsSupersededByExisting()",
-        "HistoryTests\/testAddingItemWithDifferentModifiedType()",
-        "HistoryTests\/testAddingSame()",
-        "HistoryTests\/testClearingAll()",
-        "HistoryTests\/testClearingUnpinned()",
-        "HistoryTests\/testDefaultIsEmpty()",
-        "HistoryTests\/testMaxSize()",
-        "HistoryTests\/testMaxSizeIgnoresPinned()",
-        "HistoryTests\/testMaxSizeIsChanged()",
-        "HistoryTests\/testModifiedAfterCopying()",
-        "HistoryTests\/testRemoving()"
+        "HistoryTests\/testAddingSame()"
       ],
       "target" : {
         "containerPath" : "container:Maccy.xcodeproj",

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -179,9 +179,10 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     var itemDecorator: HistoryItemDecorator
     if let pin = item.pin {
       itemDecorator = HistoryItemDecorator(item, shortcuts: KeyShortcut.create(character: pin))
-      // Keep pins in the same place.
       if let removedItemIndex {
-        all.insert(itemDecorator, at: removedItemIndex)
+        // If pin to bottom -> last element should be inserted to the removedItemIndex - 1
+        // Or to the last all array place.
+        all.insert(itemDecorator, at: min(removedItemIndex, all.count))
       }
     } else {
       itemDecorator = HistoryItemDecorator(item)

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -6,6 +6,7 @@ import Defaults
 class HistoryTests: XCTestCase {
   let savedSize = Defaults[.size]
   let savedSortBy = Defaults[.sortBy]
+  let savedPinTo = Defaults[.pinTo]
   let history = History.shared
 
   override func setUp() {
@@ -13,12 +14,14 @@ class HistoryTests: XCTestCase {
     history.clearAll()
     Defaults[.size] = 10
     Defaults[.sortBy] = .firstCopiedAt
+    Defaults[.pinTo] = .bottom
   }
 
   override func tearDown() {
     super.tearDown()
     Defaults[.size] = savedSize
     Defaults[.sortBy] = savedSortBy
+    Defaults[.pinTo] = savedPinTo
   }
 
   func testDefaultIsEmpty() {
@@ -224,6 +227,35 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.items.count, 5)
     XCTAssertTrue(history.items.contains(items[10]))
     XCTAssertFalse(history.items.contains(items[5]))
+  }
+
+  func testReaddingBottomMostPinnedItemAtFullCapacity() {
+    // Regression test for a crash when re-copying (invoking) the bottom-most
+    // pinned item while history is at full capacity and pins are sorted to the
+    // bottom. The stale insert index used to trap with an out-of-bounds insert.
+    // Issue link: https://github.com/p0deje/Maccy/issues/1466
+    // `pinTo` is restored to its default value(.top) in `tearDown`.
+    Defaults[.pinTo] = .bottom
+
+    // Pin an item; `history.togglePin` re-sorts `all`, so with `.bottom` the
+    // pinned item ends up as the last element.
+    let pinned = history.add(historyItem("pinned"))
+    history.togglePin(pinned)
+
+    // Fill unpinned history to full capacity.
+    for index in 0..<Defaults[.size] {
+      history.add(historyItem(String(index)))
+    }
+
+    XCTAssertEqual(history.all.last, pinned)
+
+    // Re-copy the pinned item. It is detected as a duplicate, removed and
+    // re-inserted while `limitHistorySize` trims an exceeding unpinned item.
+    // Before the fix this inserted at a stale, out-of-bounds index and crashed.
+    let readded = history.add(historyItem("pinned"))
+
+    XCTAssertTrue(history.all.contains(readded))
+    XCTAssertEqual(history.all.filter(\.isPinned).count, 1)
   }
 
   func testRemoving() {


### PR DESCRIPTION
Attempt to fix #1466 
STR:
1. Settings → Appearance → Pin to = Bottom.
2. Settings → Storage → Size = a small number (e.g. 5) to fill history quickly.
3. Copy one text snippet, open Maccy (⌘⇧C), select it, and pin it (⌥P). With bottom pinning it sits at the very bottom.
4. Copy 5 more distinct snippets so the unpinned history is exactly full (5/5).
5. Open Maccy again and invoke the bottom pinned item — via its ⌘<letter> shortcut, or hover + Enter.

Fix is: all.insert(itemDecorator, at: min(removedItemIndex, all.count))
Regression test to cover this case: HistoryTests/testReaddingBottomMostPinnedItemAtFullCapacity