### PR TITLE
Ensure correct modifier flags when selecting items

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2F12271E2E5C932200A1592A /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 2F12271D2E5C932200A1592A /* Logging */; };
 		2F162E802F1E7B30001FBAFF /* PasteStackPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F162E7F2F1E7B28001FBAFF /* PasteStackPreviewView.swift */; };
 		2F1A79C02C6DFB7800C98EBD /* SearchVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */; };
+		2F1B61CD301BCFF2000905F9 /* ModifierFlags+Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1B61CC301BCFD2000905F9 /* ModifierFlags+Current.swift */; };
 		2F39CB042AD9A93C00B749FD /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB032AD9A93C00B749FD /* Sparkle */; };
 		2F39CB0A2AD9AE1F00B749FD /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 2F39CB092AD9AE1F00B749FD /* Settings */; };
 		2F578C3D2EFFE8400088B759 /* ItemsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F578C3C2EFFE8400088B759 /* ItemsProtocol.swift */; };
@@ -193,6 +194,7 @@
 		2F1091D62F2B6E8100F5C454 /* AsyncView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncView.swift; sourceTree = "<group>"; };
 		2F162E7F2F1E7B28001FBAFF /* PasteStackPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteStackPreviewView.swift; sourceTree = "<group>"; };
 		2F1A79BF2C6DFB7800C98EBD /* SearchVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVisibility.swift; sourceTree = "<group>"; };
+		2F1B61CC301BCFD2000905F9 /* ModifierFlags+Current.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModifierFlags+Current.swift"; sourceTree = "<group>"; };
 		2F578C3C2EFFE8400088B759 /* ItemsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemsProtocol.swift; sourceTree = "<group>"; };
 		2F578C3E2EFFE8720088B759 /* SlideoutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutController.swift; sourceTree = "<group>"; };
 		2F578C402EFFE8920088B759 /* SlideoutContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideoutContentView.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 				DAA365E62C4C57E600A394F8 /* KeyEquivalent+Keys.swift */,
 				DA0FFA292C8D0FEC00A66C97 /* ModifierFlags+Description.swift */,
 				DA3EAE0B2AE30F7500F39108 /* NSApplication+Windows.swift */,
+				2F1B61CC301BCFD2000905F9 /* ModifierFlags+Current.swift */,
 				DA7A753D26A52F0F00DC16EF /* NSImage+Names.swift */,
 				DA083A6D2C42E8E8004259A0 /* NSImage+Resized.swift */,
 				DAC929D6297A0E8B00814F19 /* NSPasteboard.PasteboardType+Types.swift */,
@@ -1103,6 +1106,7 @@
 				DA13D7DA2C1A223E00FA9E23 /* Clear.swift in Sources */,
 				DA13D7DB2C1A223E00FA9E23 /* Delete.swift in Sources */,
 				DA19691F2C3F5F0600258481 /* KeyHandlingView.swift in Sources */,
+				2F1B61CD301BCFF2000905F9 /* ModifierFlags+Current.swift in Sources */,
 				DA13D7DC2C1A223E00FA9E23 /* HistoryItemAppEntity.swift in Sources */,
 				DAA072D12C4089D3006DDFD2 /* VisualEffectView.swift in Sources */,
 				DA555F122CF155A8009608BD /* WrappingTextView.swift in Sources */,

--- a/Maccy/Extensions/ModifierFlags+Current.swift
+++ b/Maccy/Extensions/ModifierFlags+Current.swift
@@ -1,0 +1,9 @@
+import AppKit
+
+extension NSEvent.ModifierFlags {
+  static var currentModifierFlags: Self {
+    return NSApp.currentEvent?.modifierFlags
+      .intersection(.deviceIndependentFlagsMask)
+      .subtracting([.capsLock, .numericPad, .function]) ?? []
+  }
+}

--- a/Maccy/Intents/Select.swift
+++ b/Maccy/Intents/Select.swift
@@ -26,7 +26,7 @@ struct Select: AppIntent, CustomIntentMigratedAppIntent {
     }
 
     let value = items[index].title
-    await AppState.shared.history.select(items[index])
+    await AppState.shared.history.select(items[index], flags: .currentModifierFlags)
 
     return .result(value: value)
   }

--- a/Maccy/Observables/AppState.swift
+++ b/Maccy/Observables/AppState.swift
@@ -52,13 +52,13 @@ class AppState: Sendable {
   }
 
   @MainActor
-  func select() {
+  func select(flags modifierFlags: NSEvent.ModifierFlags) {
     if !navigator.selection.isEmpty {
       if navigator.isMultiSelectInProgress {
         navigator.isManualMultiSelect = false
-        history.startPasteStack(selection: &navigator.selection)
+        history.startPasteStack(selection: &navigator.selection, flags: modifierFlags)
       } else {
-        history.select(navigator.selection.first)
+        history.select(navigator.selection.first, flags: modifierFlags)
       }
     } else if let item = footer.selectedItem {
       // TODO: Use item.suppressConfirmation, but it's not updated!

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -293,19 +293,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     item.cleanupImages()
   }
 
-  private func currentModifierFlags() -> NSEvent.ModifierFlags {
-    return NSApp.currentEvent?.modifierFlags
-      .intersection(.deviceIndependentFlagsMask)
-      .subtracting([.capsLock, .numericPad, .function]) ?? []
-  }
-
   @MainActor
-  func select(_ item: HistoryItemDecorator?) {
+  func select(_ item: HistoryItemDecorator?, flags modifierFlags: NSEvent.ModifierFlags) {
     guard let item else {
       return
     }
-
-    let modifierFlags = currentModifierFlags()
 
     if modifierFlags.isEmpty {
       AppState.shared.popup.close()
@@ -337,12 +329,10 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   }
 
   @MainActor
-  func startPasteStack(selection: inout Selection<HistoryItemDecorator>) {
+  func startPasteStack(selection: inout Selection<HistoryItemDecorator>, flags modifierFlags: NSEvent.ModifierFlags) {
     guard AppState.shared.multiSelectionEnabled else { return }
     guard let item = selection.first else { return }
     PasteStack.initializeIfNeeded()
-
-    let modifierFlags = currentModifierFlags()
 
     let stack = PasteStack(items: selection.items, modifierFlags: modifierFlags)
     pasteStack = stack

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -137,8 +137,9 @@ class Popup {
     if isHotKeyCode(Int(event.keyCode)) {
       if let item = History.shared.pressedShortcutItem {
         AppState.shared.navigator.select(item: item)
+        let modifierFlags = NSEvent.ModifierFlags.currentModifierFlags
         Task { @MainActor in
-          AppState.shared.history.select(item)
+          AppState.shared.history.select(item, flags: modifierFlags)
         }
         return nil
       }
@@ -165,8 +166,9 @@ class Popup {
   private func handleFlagsChanged(_ event: NSEvent) -> NSEvent? {
     // If we are in cycle mode, releasing modifiers triggers a selection
     if state == .cycle && allModifiersReleased(event) {
+      let modifierFlags = NSEvent.ModifierFlags.currentModifierFlags
       DispatchQueue.main.async {
-        AppState.shared.select()
+        AppState.shared.select(flags: modifierFlags)
       }
       return nil
     }

--- a/Maccy/Views/HistoryItemView.swift
+++ b/Maccy/Views/HistoryItemView.swift
@@ -59,8 +59,9 @@ struct HistoryItemView: View {
       if NSEvent.modifierFlags.contains(.command) && appState.multiSelectionEnabled {
         appState.navigator.addToSelection(item: item)
       } else {
+        let flags = NSEvent.ModifierFlags.currentModifierFlags
         Task {
-          appState.history.select(item)
+          appState.history.select(item, flags: flags)
         }
       }
     }

--- a/Maccy/Views/KeyHandlingView.swift
+++ b/Maccy/Views/KeyHandlingView.swift
@@ -148,7 +148,7 @@ struct KeyHandlingView<Content: View>: View {
           appState.togglePin()
           return .handled
         case .selectCurrentItem:
-          appState.select()
+          appState.select(flags: .currentModifierFlags)
           return .handled
         case .close:
           appState.popup.close()
@@ -164,7 +164,7 @@ struct KeyHandlingView<Content: View>: View {
           appState.navigator.select(item: item)
           Task {
             try? await Task.sleep(for: .milliseconds(50))
-            appState.history.select(item)
+            appState.history.select(item, flags: .currentModifierFlags)
           }
           return .handled
         }

--- a/Maccy/Views/SearchFieldView.swift
+++ b/Maccy/Views/SearchFieldView.swift
@@ -24,7 +24,7 @@ struct SearchFieldView: View {
           .lineLimit(1)
           .textFieldStyle(.plain)
           .onSubmit {
-            appState.select()
+            appState.select(flags: .currentModifierFlags)
           }
 
         if !query.isEmpty {


### PR DESCRIPTION
Fixes #1473. Because `select` was performed in a `Task` the modifier flags were incorrect as `select` would read them at a later time. This change refactors `select` (and related) to explicitly take the current modifier flags as an argument, so they can be computed at the time the action has been initiated by the user.