### PR TITLE
fix: Disable unused global hotkey for preview shortcut

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -188,7 +188,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   private func disableUnusedGlobalHotkeys() {
-    let names: [KeyboardShortcuts.Name] = [.delete, .pin]
+    let names: [KeyboardShortcuts.Name] = [.delete, .pin, .togglePreview]
     KeyboardShortcuts.disable(names)
 
     NotificationCenter.default.addObserver(


### PR DESCRIPTION
The preview shortcut is only ever handled locally inside the popup, but was never added to disableUnusedGlobalHotkeys, so its default ⌃Space was grabbed system-wide and swallowed without doing anything.

Add .togglePreview to the disable list, alongside .pin and .delete which work the same way.