### PR TITLE
Fix String.shortened(to:) returning one character too many

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		42E9C329301B7F9C00B6B55B /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = 42E9C328301B7F9C00B6B55B /* AppIcon.icon */; };
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA110ED10000000000000002 /* CollectionSurroundingTests.swift */; };
+		C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE000000000000000004 /* ShortenedTests.swift */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
 		DA009934256411F90030E697 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = DA00992F256411F90030E697 /* LICENSE */; };
@@ -224,6 +225,7 @@
 		7CEEFDF124F41F8500ECAD2A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		ABC72863283A9053001EE086 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CA110ED10000000000000002 /* CollectionSurroundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSurroundingTests.swift; sourceTree = "<group>"; };
+		C0FFEE000000000000000004 /* ShortenedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortenedTests.swift; sourceTree = "<group>"; };
 		DA00992C256411F90030E697 /* appcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = appcast.xml; sourceTree = "<group>"; };
 		DA00992D256411F90030E697 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DA00992F256411F90030E697 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -724,6 +726,7 @@
 				DA48AE852A5F0077006D4894 /* Fixtures */,
 				DA3CE7FF1E44A62500B3AA98 /* ClipboardTests.swift */,
 				CA110ED10000000000000002 /* CollectionSurroundingTests.swift */,
+				C0FFEE000000000000000004 /* ShortenedTests.swift */,
 				DAE2850123225BD90080E394 /* ColorImageTests.swift */,
 				DA360DB21E3DF137005C6F6B /* HistoryTests.swift */,
 				DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */,
@@ -1073,6 +1076,7 @@
 				DA384E86232746D800603999 /* SearchTests.swift in Sources */,
 				DA696BD22401EEE900DE80CF /* SorterTests.swift in Sources */,
 				CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */,
+				C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */,
 				DA360DB31E3DF137005C6F6B /* HistoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Maccy/Extensions/String+Shortened.swift
+++ b/Maccy/Extensions/String+Shortened.swift
@@ -4,6 +4,6 @@ extension String {
       return self
     }
 
-    return String(self[...index(startIndex, offsetBy: maxLength)])
+    return String(self[startIndex..<index(startIndex, offsetBy: maxLength)])
   }
 }

--- a/MaccyTests/ShortenedTests.swift
+++ b/MaccyTests/ShortenedTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Maccy
+
+final class ShortenedTests: XCTestCase {
+  func testShortenedReturnsAtMostMaxLength() {
+    XCTAssertEqual("abcdef".shortened(to: 3), "abc")
+  }
+
+  func testShortenedNoOpWhenWithinLimit() {
+    XCTAssertEqual("abc".shortened(to: 3), "abc")
+    XCTAssertEqual("".shortened(to: 3), "")
+  }
+
+  func testShortenedLargeCapIsNoOp() {
+    XCTAssertEqual("abcdefghij".shortened(to: 1_000), "abcdefghij")
+  }
+
+  func testShortenedResultNeverExceedsMaxLength() {
+    let input = "abcdef"
+    for length in 0...8 {
+      let result = input.shortened(to: length)
+      XCTAssertLessThanOrEqual(result.count, length, "shortened(to: \(length)) must be <= \(length) chars")
+      XCTAssertEqual(result.count, min(length, input.count))
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`String.shortened(to:)` returned one character too many. It used a closed range `self[...index(startIndex, offsetBy: maxLength)]`, which includes the end index — so `"abcdef".shortened(to: 3)` returned `"abcd"` (4 characters) instead of `"abc"`.

## Fix

Use a half-open range `self[startIndex..<index(startIndex, offsetBy: maxLength)]`, so the result contains at most `maxLength` characters.

## Test

New `ShortenedTests` covers: returns at most `maxLength`; no-op when within limit; no-op for a large cap; and a loop asserting the result never exceeds `maxLength` for lengths 0…8.
