### PR TITLE
fix: keep evaluating ignore-regex rules after a malformed pattern

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -255,7 +255,10 @@ class Clipboard {
             return true
           }
         } catch {
-          return false
+          // A malformed pattern (e.g. an unclosed character class such as "[")
+          // must not abort the whole ignore decision; skip it and keep
+          // evaluating the remaining rules so a valid sibling can still match.
+          continue
         }
       }
     }

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -25,6 +25,7 @@ class ClipboardTests: XCTestCase {
   let savedIgnoreAllAppsExceptListed = Defaults[.ignoreAllAppsExceptListed]
   let savedIgnoredApps = Defaults[.ignoredApps]
   let savedIgnoredPasteboardTypes = Defaults[.ignoredPasteboardTypes]
+  let savedIgnoreRegexp = Defaults[.ignoreRegexp]
 
   override func setUp() {
     super.setUp()
@@ -40,6 +41,7 @@ class ClipboardTests: XCTestCase {
     Defaults[.ignoreAllAppsExceptListed] = savedIgnoreAllAppsExceptListed
     Defaults[.ignoredApps] = savedIgnoredApps
     Defaults[.ignoredPasteboardTypes] = savedIgnoredPasteboardTypes
+    Defaults[.ignoreRegexp] = savedIgnoreRegexp
     clipboard.clearHooks()
   }
 
@@ -187,6 +189,20 @@ class ClipboardTests: XCTestCase {
     clipboard.start()
     pasteboard.declareTypes([.string, customType], owner: nil)
     pasteboard.setString("bar", forType: .string)
+    waitForExpectations(timeout: 2)
+  }
+
+  func testIgnoreRegexpContinuesAfterInvalidPattern() {
+    Defaults[.ignoreRegexp] = ["[", "sec.*"]
+
+    let hookExpectation = expectation(description: "Hook is called")
+    hookExpectation.isInverted = true
+    clipboard.onNewCopy({ (_: HistoryItem) in
+      hookExpectation.fulfill()
+    })
+    clipboard.start()
+    pasteboard.declareTypes([.string], owner: nil)
+    pasteboard.setString("secret", forType: .string)
     waitForExpectations(timeout: 2)
   }
 


### PR DESCRIPTION
A single malformed entry in **Ignore → Regexp** silently disabled the entire ignore-regex
feature. When `NSRegularExpression(pattern:)` threw on a bad pattern, `Clipboard.shouldIgnore(_:)`
caught the error and `return false`, aborting the whole ignore decision: it stopped checking
every later rule _and_ returned "do not ignore" even when a valid sibling rule would have matched.

### Steps to reproduce
1. Maccy → Settings → Ignore → add two regexp rules: `[` (malformed, unclosed character class) and `sec.*` (valid).
2. Copy the string `secret`.
3. `secret` is recorded into history — but it should be ignored, because `sec.*` matches `secret`.

`defaults read org.p0deje.Maccy ignoreRegexp`:
    ignoreRegexp = ("[", "sec.*");

### Fix is
In `Clipboard.shouldIgnore(_:)`, change the malformed-pattern `catch` from `return false` to
`continue`, so the remaining rules are still evaluated and a valid sibling can still match.
(A pattern that throws can never have matched anyway, so skipping it loses nothing.)

### Regression test
`MaccyTests/ClipboardTests.testIgnoreRegexpContinuesAfterInvalidPattern` — sets
`ignoreRegexp = ["[", "sec.*"]`, copies `"secret"`, asserts the `onNewCopy` hook does **not**
fire (the item is ignored via `sec.*`). Fails on unpatched `master` (hook fires, `secret`
inserted), passes with the fix. Also adds save/restore of `Defaults[.ignoreRegexp]` in
setUp/tearDown (it was not previously saved/restored).

Scope is intentionally limited to the regex loop's malformed-pattern handling.