### PR TITLE
Fix orphaned history item content cleanup

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -122,6 +122,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
   }
 
+  @MainActor
   private func migrateUserDefaults() {
     ensureMigration(key: "2024-07-01-version-2") {
       // Start 2.x from scratch.
@@ -144,6 +145,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         types.formUnion(StorageType.images.types)
       }
       Defaults[.enabledPasteboardTypes] = types
+    }
+
+    if Defaults[.migrations]["2026-08-08-cleanup-orphaned-history-item-contents"] != true {
+      if (try? Storage.shared.cleanupOrphanedContents()) != nil {
+        Defaults[.migrations]["2026-08-08-cleanup-orphaned-history-item-contents"] = true
+      }
     }
 
     // The following defaults are not used in Maccy 2.x

--- a/Maccy/Observables/History.swift
+++ b/Maccy/Observables/History.swift
@@ -136,16 +136,10 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
   @discardableResult
   @MainActor
   func add(_ item: HistoryItem) -> HistoryItemDecorator {
-    if #available(macOS 15.0, *) {
-      try? History.shared.insertIntoStorage(item)
-    } else {
-      // On macOS 14 the history item needs to be inserted into storage directly after creating it.
-      // It was already inserted after creation in Clipboard.swift
-    }
-
     var removedItemIndex: Int?
     if let existingHistoryItem = findSimilarItem(item) {
       if isModified(item) == nil {
+        deleteContents(of: item)
         item.contents = existingHistoryItem.contents
       }
       item.firstCopiedAt = existingHistoryItem.firstCopiedAt
@@ -160,7 +154,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       if let removedItemIndex {
         cleanup(all[removedItemIndex])
       }
-      Storage.shared.context.delete(existingHistoryItem)
+      deleteFromStorage(existingHistoryItem)
       if let removedItemIndex {
         all.remove(at: removedItemIndex)
       }
@@ -173,6 +167,13 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     // Remove exceeding items. Do this after the item is added to avoid removing something
     // if a duplicate was found as then the size already stayed the same.
     limitHistorySize(to: Defaults[.size] - 1)
+
+    if #available(macOS 15.0, *) {
+      try? insertIntoStorage(item)
+    } else {
+      // On macOS 14 the history item needs to be inserted into storage directly after creating it.
+      // It was already inserted after creation in Clipboard.swift
+    }
 
     sessionLog[Clipboard.shared.changeCount] = item
 
@@ -225,18 +226,13 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       sessionLog.removeValues { $0.pin == nil }
       items = all
 
-      try? Storage.shared.context.transaction {
-        try? Storage.shared.context.delete(
-          model: HistoryItem.self,
-          where: #Predicate { $0.pin == nil }
-        )
-        try? Storage.shared.context.delete(
-          model: HistoryItemContent.self,
-          where: #Predicate { $0.item?.pin == nil }
-        )
-      }
+      let historyItems = try? Storage.shared.context.fetch(FetchDescriptor<HistoryItem>(
+        predicate: #Predicate { $0.pin == nil }
+      ))
+      historyItems?.forEach(deleteFromStorage)
       Storage.shared.context.processPendingChanges()
       try? Storage.shared.context.save()
+      _ = try? Storage.shared.cleanupOrphanedContents()
     }
 
     Clipboard.shared.clear()
@@ -256,9 +252,11 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
       sessionLog.removeAll()
       items = all
 
-      try? Storage.shared.context.delete(model: HistoryItem.self)
+      let historyItems = try? Storage.shared.context.fetch(FetchDescriptor<HistoryItem>())
+      historyItems?.forEach(deleteFromStorage)
       Storage.shared.context.processPendingChanges()
       try? Storage.shared.context.save()
+      _ = try? Storage.shared.cleanupOrphanedContents()
     }
 
     Clipboard.shared.clear()
@@ -274,7 +272,7 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
 
     cleanup(item)
     withLogging("Removing history item") {
-      Storage.shared.context.delete(item.item)
+      deleteFromStorage(item.item)
       Storage.shared.context.processPendingChanges()
       try? Storage.shared.context.save()
     }
@@ -287,6 +285,17 @@ class History: ItemsContainer { // swiftlint:disable:this type_body_length
     Task {
       AppState.shared.popup.needsResize = true
     }
+  }
+
+  @MainActor
+  private func deleteFromStorage(_ item: HistoryItem) {
+    deleteContents(of: item)
+    Storage.shared.context.delete(item)
+  }
+
+  @MainActor
+  private func deleteContents(of item: HistoryItem) {
+    item.contents.forEach(Storage.shared.context.delete)
   }
 
   @MainActor

--- a/Maccy/Storage.swift
+++ b/Maccy/Storage.swift
@@ -32,4 +32,23 @@ class Storage {
       fatalError("Cannot load database: \(error.localizedDescription).")
     }
   }
+
+  @discardableResult
+  func cleanupOrphanedContents() throws -> Int {
+    let descriptor = FetchDescriptor<HistoryItemContent>(
+      predicate: #Predicate { $0.item == nil }
+    )
+    let count = try context.fetchCount(descriptor)
+    guard count > 0 else {
+      return 0
+    }
+
+    try context.delete(
+      model: HistoryItemContent.self,
+      where: #Predicate { $0.item == nil }
+    )
+    context.processPendingChanges()
+    try context.save()
+    return count
+  }
 }

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Defaults
+import SwiftData
 @testable import Maccy
 
 @MainActor
@@ -56,7 +57,7 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.items[0].item.application, "iTerm.app")
   }
 
-  func testAddingItemThatIsSupersededByExisting() {
+  func testAddingItemThatIsSupersededByExisting() throws {
     let firstContents = [
       HistoryItemContent(
         type: NSPasteboard.PasteboardType.string.rawValue,
@@ -89,6 +90,7 @@ class HistoryTests: XCTestCase {
 
     XCTAssertEqual(history.items, [second])
     XCTAssertEqual(Set(history.items[0].item.contents), Set(firstContents))
+    try assertContentCounts(total: firstContents.count)
   }
 
   func testAddingItemWithDifferentModifiedType() {
@@ -174,21 +176,24 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.items[0].text, "bar")
   }
 
-  func testClearingUnpinned() {
+  func testClearingUnpinned() throws {
     let pinned = history.add(historyItem("foo"))
     pinned.togglePin()
     history.add(historyItem("bar"))
     history.clear()
     XCTAssertEqual(history.items, [pinned])
+    try assertContentCounts(total: 1)
   }
 
-  func testClearingAll() {
+  func testClearingAll() throws {
     history.add(historyItem("foo"))
-    history.clear()
+    history.add(historyItem("bar"))
+    history.clearAll()
     XCTAssertEqual(history.items, [])
+    try assertContentCounts(total: 0)
   }
 
-  func testMaxSize() {
+  func testMaxSize() throws {
     var items: [HistoryItemDecorator] = []
     for index in 0...10 {
       items.append(history.add(historyItem(String(index))))
@@ -197,6 +202,7 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.items.count, 10)
     XCTAssertTrue(history.items.contains(items[10]))
     XCTAssertFalse(history.items.contains(items[0]))
+    try assertContentCounts(total: 10)
   }
 
   func testMaxSizeIgnoresPinned() {
@@ -258,11 +264,46 @@ class HistoryTests: XCTestCase {
     XCTAssertEqual(history.all.filter(\.isPinned).count, 1)
   }
 
-  func testRemoving() {
+  func testRemoving() throws {
     let foo = history.add(historyItem("foo"))
     let bar = history.add(historyItem("bar"))
     history.delete(foo)
     XCTAssertEqual(history.items, [bar])
+    try assertContentCounts(total: 1)
+  }
+
+  func testCleaningUpOrphanedContents() throws {
+    history.add(historyItem("live"))
+    let orphan = HistoryItemContent(
+      type: NSPasteboard.PasteboardType.string.rawValue,
+      value: "orphan".data(using: .utf8)
+    )
+    Storage.shared.context.insert(orphan)
+    try Storage.shared.context.save()
+
+    XCTAssertEqual(try Storage.shared.cleanupOrphanedContents(), 1)
+    try assertContentCounts(total: 1)
+  }
+
+  private func assertContentCounts(
+    total: Int,
+    orphaned: Int = 0,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws {
+    let context = Storage.shared.context
+    XCTAssertEqual(
+      try context.fetchCount(FetchDescriptor<HistoryItemContent>()),
+      total,
+      file: file,
+      line: line
+    )
+    XCTAssertEqual(
+      try context.fetchCount(FetchDescriptor<HistoryItemContent>(predicate: #Predicate { $0.item == nil })),
+      orphaned,
+      file: file,
+      line: line
+    )
   }
 
   private func historyItem(_ value: String) -> HistoryItem {


### PR DESCRIPTION
Fixes #1496

## Summary

- Delete history content explicitly before deleting its parent item, instead of relying on SwiftData cascade behavior.
- Remove all live content during clear operations and purge any pre-existing orphaned content.
- Run a one-time startup cleanup for persisted orphaned rows, retrying on a later launch if it fails.
- Avoid persisting discarded content while resolving duplicate history entries.

## Tests

- Added orphan-count assertions for duplicate merging, size eviction, individual deletion, clearing unpinned history, and clearing all history.
- Added coverage for cleaning an existing orphan without deleting live content.

## Validation

- `xcodebuild test -quiet -project Maccy.xcodeproj -scheme Maccy -destination 'platform=macOS,arch=arm64' -only-testing:MaccyTests/HistoryTests CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=''` — passed (14 tests).
- The full `MaccyTests` suite has two existing system-pasteboard failures in this local environment: `ClipboardTests/testIgnoreAllApplicationsExcept` and `ClipboardTests/testIgnoreApplication`. Both reproduce unchanged on commit `02dd0a3`.
