### PR TITLE
Highlight search matches past the 500-character row prefix

### DIFF
--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -156,7 +156,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
       return
     }
 
-    var attributedString = AttributedString(title.shortened(to: 500))
+    var attributedString = AttributedString(title)
     for range in ranges {
       if let lowerBound = AttributedString.Index(range.lowerBound, within: attributedString),
          let upperBound = AttributedString.Index(range.upperBound, within: attributedString) {

--- a/MaccyTests/HistoryDecoratorTests.swift
+++ b/MaccyTests/HistoryDecoratorTests.swift
@@ -134,6 +134,24 @@ class HistoryItemDecoratorTests: XCTestCase {
     XCTAssertEqual(itemDecorator.attributedTitle, nil)
   }
 
+  func testHighlightMatchBeyondFiveHundredChars() {
+    let title = String(repeating: "a", count: 600) + "needle"
+    let itemDecorator = historyItemDecorator(title)
+    XCTAssertEqual(itemDecorator.title.count, 606)
+
+    let needleRange = itemDecorator.title.range(of: "needle")!
+    itemDecorator.highlight("needle", [needleRange])
+
+    // Search ranges index into the full (1000-capped) title, so the row shown
+    // during search must keep every character and the match must be styled.
+    XCTAssertEqual(itemDecorator.attributedTitle?.characters.count, 606)
+
+    var expectedTitle = AttributedString(itemDecorator.title)
+    let expectedRange = expectedTitle.range(of: "needle")!
+    expectedTitle[expectedRange].font = .bold(.body)()
+    XCTAssertEqual(itemDecorator.attributedTitle, expectedTitle)
+  }
+
   private func historyItemDecorator(
     _ value: String?,
     application: String? = "com.apple.finder"


### PR DESCRIPTION
`highlight(_:ranges:)` built the attributed string from a 500-char prefix (`title.shortened(to: 500)`), but the search ranges index the FULL `item.title` (capped at 1000 by generateTitle). For a 500–1000-char item whose first match falls in chars 500–1000, the range is out of bounds for the 500-char string, the AttributedString.Index failable init returns nil, the guard drops it, and the match renders with no highlight — plus the searched row is truncated to 500.

## Fix
Build the attributed string from `title` directly (already capped at 1000, so render cost stays bounded; every search range becomes valid; the searched row no longer truncates).

## Test plan
New `testHighlightMatchBeyondFiveHundredChars` in HistoryDecoratorTests: 600×"a"+"needle" title; before the fix attributedTitle is 500 chars with no bold; after it's the full 606 chars with the bold needle. (Existing ClipboardTests host-env reds and the pre-existing is_disjoint lint red on master are unchanged.)