### PR TITLE
Fix off-by-one index bound in clipboard-history Shortcuts actions

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA110ED10000000000000002 /* CollectionSurroundingTests.swift */; };
 		C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE000000000000000004 /* ShortenedTests.swift */; };
+		DECAFB00000000000000000A /* ClipboardHistoryItemIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECAFB00000000000000000B /* ClipboardHistoryItemIntentsTests.swift */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
 		DA009934256411F90030E697 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = DA00992F256411F90030E697 /* LICENSE */; };
@@ -226,6 +227,7 @@
 		ABC72863283A9053001EE086 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CA110ED10000000000000002 /* CollectionSurroundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSurroundingTests.swift; sourceTree = "<group>"; };
 		C0FFEE000000000000000004 /* ShortenedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortenedTests.swift; sourceTree = "<group>"; };
+		DECAFB00000000000000000B /* ClipboardHistoryItemIntentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardHistoryItemIntentsTests.swift; sourceTree = "<group>"; };
 		DA00992C256411F90030E697 /* appcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = appcast.xml; sourceTree = "<group>"; };
 		DA00992D256411F90030E697 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DA00992F256411F90030E697 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 				DA3CE7FF1E44A62500B3AA98 /* ClipboardTests.swift */,
 				CA110ED10000000000000002 /* CollectionSurroundingTests.swift */,
 				C0FFEE000000000000000004 /* ShortenedTests.swift */,
+				DECAFB00000000000000000B /* ClipboardHistoryItemIntentsTests.swift */,
 				DAE2850123225BD90080E394 /* ColorImageTests.swift */,
 				DA360DB21E3DF137005C6F6B /* HistoryTests.swift */,
 				DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */,
@@ -1077,6 +1080,7 @@
 				DA696BD22401EEE900DE80CF /* SorterTests.swift in Sources */,
 				CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */,
 				C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */,
+				DECAFB00000000000000000A /* ClipboardHistoryItemIntentsTests.swift in Sources */,
 				DA360DB31E3DF137005C6F6B /* HistoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Maccy/Intents/Delete.swift
+++ b/Maccy/Intents/Delete.swift
@@ -18,7 +18,7 @@ struct Delete: AppIntent, CustomIntentMigratedAppIntent {
   func perform() async throws -> some IntentResult {
     let items = AppState.shared.history.items
     let index = number - positionOffset
-    guard items.count >= index else {
+    guard index >= 0, items.count > index else {
       throw AppIntentError.notFound
     }
 

--- a/Maccy/Intents/Get.swift
+++ b/Maccy/Intents/Get.swift
@@ -37,7 +37,7 @@ struct Get: AppIntent, CustomIntentMigratedAppIntent {
       item = AppState.shared.navigator.selection.first?.item
     } else {
       let index = number - positionOffset
-      if AppState.shared.history.items.count >= index {
+      if index >= 0, AppState.shared.history.items.count > index {
         item = AppState.shared.history.items[index].item
       }
     }

--- a/Maccy/Intents/Select.swift
+++ b/Maccy/Intents/Select.swift
@@ -21,7 +21,7 @@ struct Select: AppIntent, CustomIntentMigratedAppIntent {
   func perform() async throws -> some IntentResult & ReturnsValue<String> {
     let items = AppState.shared.history.items
     let index = number - positionOffset
-    guard items.count >= index else {
+    guard index >= 0, items.count > index else {
       throw AppIntentError.notFound
     }
 

--- a/MaccyTests/ClipboardHistoryItemIntentsTests.swift
+++ b/MaccyTests/ClipboardHistoryItemIntentsTests.swift
@@ -1,0 +1,150 @@
+import AppIntents
+import XCTest
+import Defaults
+@testable import Maccy
+
+@MainActor
+final class ClipboardHistoryItemIntentsTests: XCTestCase {
+  private let history = History.shared
+  private let savedPasteByDefault = Defaults[.pasteByDefault]
+  private let savedSize = Defaults[.size]
+
+  override func setUp() {
+    super.setUp()
+    history.clearAll()
+    Defaults[.size] = 10
+    // Selecting a valid item copies it to the pasteboard and, when
+    // `pasteByDefault` is on, pastes it; both are unwanted side effects in a
+    // headless unit test, so pasting is suppressed for the success-path check.
+    Defaults[.pasteByDefault] = false
+  }
+
+  override func tearDown() {
+    Defaults[.pasteByDefault] = savedPasteByDefault
+    Defaults[.size] = savedSize
+    // Don't leave inserted items or a mutated pasteboard for downstream test
+    // classes that share the process-wide Storage / Clipboard singletons.
+    history.clearAll()
+    super.tearDown()
+  }
+
+  /// Regression test for an off-by-one bound check in the clipboard-history
+  /// Shortcuts actions (`Delete`, `Select`, `Get`). With `number` set one past
+  /// the last item — or below 1 — the old `items.count >= index` guard let the
+  /// invalid 0-based `index` through and the next `items[index]` access trapped
+  /// with an index-out-of-range crash.
+  func testDeleteItemIntentBounds() async {
+    // `number = 4` with three items (one past the last valid number) must reject.
+    populateHistory(3)
+    let over = Delete()
+    over.number = 4
+    await assertRejectsOutOfRange(over)
+    XCTAssertEqual(history.items.count, 3, "An out-of-range number must not delete anything")
+
+    // `number = 3` (the last valid item) must succeed and delete exactly that item.
+    populateHistory(3)
+    let valid = Delete()
+    valid.number = history.items.count
+    await assertResolves(valid)
+    XCTAssertEqual(history.items.count, 2, "The last valid item should have been deleted")
+
+    // `number = 0` (below the first item) must reject.
+    populateHistory(3)
+    let under = Delete()
+    under.number = 0
+    await assertRejectsOutOfRange(under)
+    XCTAssertEqual(history.items.count, 3, "A number below 1 must not delete anything")
+  }
+
+  func testSelectItemIntentBounds() async throws {
+    populateHistory(3)
+    let over = Select()
+    over.number = 4
+    await assertRejectsOutOfRange(over)
+
+    populateHistory(3)
+    let lastIndex = history.items.count - 1
+    // Capture before perform(): selecting the item copies it and reorders the
+    // history, so reading the expected value afterwards would compare the wrong row.
+    let expectedTitle: String? = history.items[lastIndex].title
+    let valid = Select()
+    valid.number = history.items.count
+    let result = try await valid.perform()
+    XCTAssertEqual(result.value, expectedTitle)
+
+    populateHistory(3)
+    let under = Select()
+    under.number = 0
+    await assertRejectsOutOfRange(under)
+  }
+
+  func testGetItemIntentBounds() async throws {
+    populateHistory(3)
+    let over = Get()
+    over.selected = false
+    over.number = 4
+    await assertRejectsOutOfRange(over)
+
+    populateHistory(3)
+    let lastIndex = history.items.count - 1
+    let expectedText: String? = history.items[lastIndex].item.text
+    let valid = Get()
+    valid.selected = false
+    valid.number = history.items.count
+    let result = try await valid.perform()
+    XCTAssertEqual(result.value?.text, expectedText)
+
+    populateHistory(3)
+    let under = Get()
+    under.selected = false
+    under.number = 0
+    await assertRejectsOutOfRange(under)
+  }
+
+  // MARK: - Helpers
+
+  @discardableResult
+  private func populateHistory(_ count: Int) -> [HistoryItemDecorator] {
+    history.clearAll()
+    return (1...count).map { history.add(historyItem(String($0))) }
+  }
+
+  private func assertRejectsOutOfRange<T: AppIntent>(_ intent: T) async {
+    do {
+      _ = try await intent.perform()
+      XCTFail("Expected AppIntentError.notFound for an out-of-range item number")
+    } catch {
+      // Cast before the case-match: a bare `catch AppIntentError.notFound` is
+      // resolved against `_ErrorCodeProtocol` on the current SDK and won't compile.
+      if let intentError = error as? Maccy.AppIntentError, case .notFound = intentError {
+        // expected — the invalid number is rejected instead of indexing past the end
+      } else {
+        XCTFail("Expected AppIntentError.notFound but got \(error)")
+      }
+    }
+  }
+
+  private func assertResolves<T: AppIntent>(_ intent: T) async {
+    do {
+      _ = try await intent.perform()
+    } catch {
+      XCTFail("Expected the last valid item number to resolve but got \(error)")
+    }
+  }
+
+  private func historyItem(_ value: String) -> HistoryItem {
+    let contents = [
+      HistoryItemContent(
+        type: NSPasteboard.PasteboardType.string.rawValue,
+        value: value.data(using: .utf8)
+      )
+    ]
+    let item = HistoryItem()
+    Storage.shared.context.insert(item)
+    item.contents = contents
+    item.numberOfCopies = 1
+    item.title = item.generateTitle()
+
+    return item
+  }
+}


### PR DESCRIPTION
## Problem

The three clipboard-history Shortcuts actions — **Delete**, **Select**, and **Get Item from Clipboard History** — crash with an index-out-of-range error when `Number` is set to exactly one past the last item (e.g. `Number = 4` when 3 items exist). `Number = 0` (and any value below 1) crashes the same way.

## Root cause

Each intent converts the 1-based `number` to a 0-based `index` (`index = number - 1`) and then guards the subscript with `items.count >= index`. With 3 items and `number = 4` → `index = 3`:

```
items.count(3) >= index(3)  →  true  →  guard passes  →  items[3]  →  Fatal error: Index out of range
```

The largest valid 0-based subscript for a 3-element array is `2`, so the guard is off by one. The lower end is also unprotected: `number = 0` → `index = -1` → `3 >= -1` passes and traps on `items[-1]`.

## Fix

Make the bound reject both ends, using the existing `AppIntentError.notFound` path (no new error and no change to the valid-path behavior):

- `Delete` / `Select`:
  ```swift
  guard index >= 0, items.count > index else { throw AppIntentError.notFound }
  ```
- `Get`:
  ```swift
  if index >= 0, AppState.shared.history.items.count > index { item = … }
  ```
  (out of range leaves `item` nil, so the existing `guard let item else { throw .notFound }` applies)

| `number` (3 items) | result before | result after |
| --- | --- | --- |
| `1`–`3` | resolves the item | resolves the item (unchanged) |
| `4` (one past last) | **crash** (Index out of range) | `.notFound` |
| `0` / negative | **crash** | `.notFound` |

No intent signatures, parameter types, or valid-path behavior are changed.

## Test

Adds `MaccyTests/ClipboardHistoryItemIntentsTests.swift` — a headless XCTest that builds a 3-item history and, for each of the three intents, asserts:

- `number = 4` (one past last) → `AppIntentError.notFound`, no mutation,
- `number = 3` (last valid) → resolves the correct last item,
- `number = 0` → `AppIntentError.notFound`, no mutation.

Verified **RED → GREEN**: on the pre-fix code the `number = 4` case crashes with `Fatal error: Index out of range`; after the fix it throws `.notFound` cleanly and the last valid item resolves.

## Notes for review

- The bound fix is the entire behavior change; the diff in `Maccy/Intents/` is one operator per file.
- The full `MaccyTests` suite has two pre-existing, unrelated failures on this machine (`ClipboardTests.testIgnoreApplication` and `testIgnoreAllApplicationsExcept`) — they depend on the system clipboard-changed hook, which does not fire under the `xcodebuild` test host, and they fail identically on `master` without this change.
