### PR TITLE
Fix Throttler delaying the first invocation by minimumDelay

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA110ED10000000000000002 /* CollectionSurroundingTests.swift */; };
 		C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE000000000000000004 /* ShortenedTests.swift */; };
+		C0DECED0000000000000000D /* ThrottlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DECED0000000000000000E /* ThrottlerTests.swift */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
 		DA009934256411F90030E697 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = DA00992F256411F90030E697 /* LICENSE */; };
@@ -226,6 +227,7 @@
 		ABC72863283A9053001EE086 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CA110ED10000000000000002 /* CollectionSurroundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSurroundingTests.swift; sourceTree = "<group>"; };
 		C0FFEE000000000000000004 /* ShortenedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortenedTests.swift; sourceTree = "<group>"; };
+		C0DECED0000000000000000E /* ThrottlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThrottlerTests.swift; sourceTree = "<group>"; };
 		DA00992C256411F90030E697 /* appcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = appcast.xml; sourceTree = "<group>"; };
 		DA00992D256411F90030E697 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DA00992F256411F90030E697 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 				DA3CE7FF1E44A62500B3AA98 /* ClipboardTests.swift */,
 				CA110ED10000000000000002 /* CollectionSurroundingTests.swift */,
 				C0FFEE000000000000000004 /* ShortenedTests.swift */,
+				C0DECED0000000000000000E /* ThrottlerTests.swift */,
 				DAE2850123225BD90080E394 /* ColorImageTests.swift */,
 				DA360DB21E3DF137005C6F6B /* HistoryTests.swift */,
 				DA1EDE422045B35300479723 /* HistoryDecoratorTests.swift */,
@@ -1077,6 +1080,7 @@
 				DA696BD22401EEE900DE80CF /* SorterTests.swift in Sources */,
 				CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */,
 				C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */,
+				C0DECED0000000000000000D /* ThrottlerTests.swift in Sources */,
 				DA360DB31E3DF137005C6F6B /* HistoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Maccy/Throttler.swift
+++ b/Maccy/Throttler.swift
@@ -28,7 +28,7 @@ class Throttler {
     // => execute the workItem immediately
     // else
     // => delay the workItem execution by the minimum delay time
-    let delay = previousRun.timeIntervalSinceNow > minimumDelay ? 0 : minimumDelay
+    let delay = Date().timeIntervalSince(previousRun) > minimumDelay ? 0 : minimumDelay
     queue.asyncAfter(deadline: .now() + Double(delay), execute: workItem)
   }
 

--- a/MaccyTests/ThrottlerTests.swift
+++ b/MaccyTests/ThrottlerTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Maccy
+
+final class ThrottlerTests: XCTestCase {
+  // The very first invocation (no previous run) must execute immediately,
+  // not be delayed by the full minimumDelay.
+  func testFirstInvocationFiresImmediately() {
+    let minimumDelay: TimeInterval = 0.3
+    let throttler = Throttler(minimumDelay: minimumDelay)
+    let fired = expectation(description: "First invocation fires immediately")
+
+    throttler.throttle { fired.fulfill() }
+
+    // If the first call were (incorrectly) delayed by minimumDelay, the block
+    // would only run after 0.3s and this shorter wait would time out.
+    wait(for: [fired], timeout: minimumDelay / 2)
+  }
+
+  // A call made within minimumDelay of the previous run must be deferred.
+  func testSubsequentInvocationWithinMinimumDelayIsDeferred() {
+    let minimumDelay: TimeInterval = 0.3
+    let throttler = Throttler(minimumDelay: minimumDelay)
+
+    // First call fires immediately and records the previous run time.
+    let firstFired = expectation(description: "First invocation fires")
+    throttler.throttle { firstFired.fulfill() }
+    wait(for: [firstFired], timeout: minimumDelay * 2)
+
+    // A second call right away is within minimumDelay, so it must be deferred.
+    let secondFired = expectation(description: "Second invocation fires after delay")
+    let startedAt = Date()
+    throttler.throttle {
+      XCTAssertGreaterThanOrEqual(
+        Date().timeIntervalSince(startedAt),
+        minimumDelay * 0.9,
+        "Call within minimumDelay should be deferred by ~minimumDelay"
+      )
+      secondFired.fulfill()
+    }
+    wait(for: [secondFired], timeout: minimumDelay * 4)
+  }
+
+  // Once enough time has elapsed since the previous run, the next call must fire
+  // immediately again — the repeat-caller immediate path, which compares against
+  // a real previousRun rather than Date.distantPast.
+  func testInvocationAfterMinimumDelayFiresImmediately() {
+    let minimumDelay: TimeInterval = 0.3
+    let throttler = Throttler(minimumDelay: minimumDelay)
+
+    // First call fires immediately and records the previous run time.
+    let firstFired = expectation(description: "First invocation fires")
+    throttler.throttle { firstFired.fulfill() }
+    wait(for: [firstFired], timeout: minimumDelay * 2)
+
+    // Wait past minimumDelay so the elapsed-since-last-run exceeds it.
+    let elapsed = expectation(description: "Waited past minimumDelay")
+    DispatchQueue.main.asyncAfter(deadline: .now() + minimumDelay + 0.1) { elapsed.fulfill() }
+    wait(for: [elapsed], timeout: minimumDelay * 4)
+
+    // A new call should now fire immediately. If the elapsed comparison were
+    // (incorrectly) evaluated backwards, this call would be delayed by the full
+    // minimumDelay and this shorter wait would time out.
+    let refired = expectation(description: "Invocation after delay fires immediately")
+    throttler.throttle { refired.fulfill() }
+    wait(for: [refired], timeout: minimumDelay / 2)
+  }
+}


### PR DESCRIPTION
# Fix Throttler delaying the first invocation by minimumDelay

`Throttler` delayed the very first invocation by the full `minimumDelay` instead of
firing it immediately. Every call — including the first — waited the whole delay, so the
throttled action always lagged on first use.

## Steps to reproduce

1. `Throttler` is used by `History` to throttle search-as-you-type (`History.swift`, `Throttler(minimumDelay: 0.2)`).
2. On the first keystroke the time since the previous run is effectively infinite (`previousRun` starts at `Date.distantPast`), so the search should run immediately.
3. Instead the first search result always lags by the full `0.2s`.

## Root cause

`Maccy/Throttler.swift:31` measured elapsed time in the wrong direction:

```swift
// before — previousRun.timeIntervalSinceNow == (previousRun - now), always negative
let delay = previousRun.timeIntervalSinceNow > minimumDelay ? 0 : minimumDelay
```

`previousRun.timeIntervalSinceNow` is `previousRun − now`, a **negative** number (the previous
run is in the past, or `Date.distantPast` initially). Comparing `negative > minimumDelay` is
always `false`, so `delay` was always `minimumDelay` and the action never fired immediately —
contradicting the method's own comments ("If the time since the previous run is more than the
required minimum delay => execute the workItem immediately").

## Fix is

```swift
let delay = Date().timeIntervalSince(previousRun) > minimumDelay ? 0 : minimumDelay
```

Measure elapsed time since the previous run as `now − previousRun` (positive). On the first call
(`distantPast`) the value is enormous → `delay = 0` (immediate); a call within `minimumDelay` →
`delay = minimumDelay` (deferred). Based on the original craftappco throttler, which negates the
same expression (`-previousRun.timeIntervalSinceNow`); the negation was dropped here.

## Regression test

`MaccyTests/ThrottlerTests.swift`:

- `testFirstInvocationFiresImmediately` — the first call must fire within `minimumDelay / 2`.
  **Failed (RED)** against the old line (the block fired at ~`minimumDelay`, exceeding the 0.15s
  wait, 3 retries); **passes (GREEN, ~0.001s)** after the fix.
- `testSubsequentInvocationWithinMinimumDelayIsDeferred` — a second call made within
  `minimumDelay` of the previous run is deferred by ~`minimumDelay`.
- `testInvocationAfterMinimumDelayFiresImmediately` — a call made after `minimumDelay` has elapsed
  fires immediately again (the repeat-caller immediate path). Also **RED** on the old line, **GREEN**
  after the fix.

## Verification (macOS, ad-hoc signing `CODE_SIGNING_ALLOWED=NO`)

- `xcodebuild test -only-testing:MaccyTests` → 81 tests. The only failures are the pre-existing,
  host-specific `ClipboardTests/testIgnoreApplication` and `ClipboardTests/testIgnoreAllApplicationsExcept`
  (hardcoded `// Finder is on Bitrise`, fail off-Bitrise) — unchanged by this PR.
- `swiftlint lint --strict` on touched files → 0 violations.

## Diff

`Maccy/Throttler.swift` (1 line) + `MaccyTests/ThrottlerTests.swift` (new) + project wiring.
