### PR TITLE
Make ignore-application Clipboard tests host-agnostic

### DIFF
--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -26,6 +26,17 @@ class ClipboardTests: XCTestCase {
   let savedIgnoredApps = Defaults[.ignoredApps]
   let savedIgnoredPasteboardTypes = Defaults[.ignoredPasteboardTypes]
 
+  // Whatever app is frontmost when the test runs is the source of the copy
+  // (Clipboard reads `NSWorkspace.shared.frontmostApplication`). Hardcoding
+  // "com.apple.dt.Xcode"/"com.apple.finder" only happens to match on Bitrise,
+  // where one of those is frontmost; on any other host the two ignore-app
+  // tests below fail. Use the real frontmost bundle id so they are host-agnostic.
+  static var sourceAppBundleId: String {
+    NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+      ?? Bundle.main.bundleIdentifier
+      ?? "com.apple.finder"
+  }
+
   override func setUp() {
     super.setUp()
     Defaults[.ignoreAllAppsExceptListed] = false
@@ -137,7 +148,7 @@ class ClipboardTests: XCTestCase {
   }
 
   func testIgnoreApplication() {
-    Defaults[.ignoredApps] = ["com.apple.dt.Xcode", "com.apple.finder"] // Finder is on Bitrise
+    Defaults[.ignoredApps] = [Self.sourceAppBundleId]
 
     let hookExpectation = expectation(description: "Hook is called")
     hookExpectation.isInverted = true
@@ -152,7 +163,7 @@ class ClipboardTests: XCTestCase {
 
   func testIgnoreAllApplicationsExcept() {
     Defaults[.ignoreAllAppsExceptListed] = true
-    Defaults[.ignoredApps] = ["com.apple.dt.Xcode", "com.apple.finder"] // Finder is on Bitrise
+    Defaults[.ignoredApps] = [Self.sourceAppBundleId]
 
     let hookExpectation = expectation(description: "Hook is called")
     clipboard.onNewCopy({ (_: HistoryItem) in


### PR DESCRIPTION
`testIgnoreApplication` and `testIgnoreAllApplicationsExcept` hardcode the ignored/allowed apps as `["com.apple.dt.Xcode", "com.apple.finder"]` with the comment `// Finder is on Bitrise`. `Clipboard` reads the copy's source from `NSWorkspace.shared.frontmostApplication`, so those bundle ids only match on Bitrise (where one of them is genuinely frontmost). On any other host the source app is different, the ignore-app branch resolves the wrong way, and both tests fail.

**Fix is:** use the real frontmost application's bundle id (`NSWorkspace.shared.frontmostApplication?.bundleIdentifier`, falling back to `Bundle.main`) so the tests exercise the ignore-app branch regardless of where they run.

**Verification** (Xcode 26.4.1, ad-hoc signing, `-only-testing:MaccyTests/ClipboardTests/...`):
- Before: both tests fail on this host — `testIgnoreApplication` (inverted hook fires) and `testIgnoreAllApplicationsExcept` (`Asynchronous wait failed … "Hook is called"`), 6/6 iterations red.
- After: both pass, 0 failures.
- `swiftlint lint --strict` clean on the file; build-for-testing succeeds.
- On Bitrise the frontmost app is still Finder/Xcode, so the resolved bundle id matches there too — no regression for CI.

Self-found while running the local test gate (the two failures are part of the pre-existing off-Bitrise red).