### PR TITLE
Clear is_disjoint SwiftLint violation

### DIFF
--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -140,7 +140,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     ensureMigration(key: "2025-07-04-add-jpeg-heic") {
       var types = Defaults[.enabledPasteboardTypes]
-      if !types.intersection(StorageType.images.types).isEmpty {
+      if !types.isDisjoint(with: StorageType.images.types) {
         types.formUnion(StorageType.images.types)
       }
       Defaults[.enabledPasteboardTypes] = types


### PR DESCRIPTION
`swiftlint lint --strict` reports a single violation in the repo, in the `2025-07-04-add-jpeg-heic` migration:

```
Maccy/AppDelegate.swift:143:17 is_disjoint violation: Use isDisjoint(with:) instead of intersection
```

The migration checks whether the enabled pasteboard types already overlap with the image types before adding them:

```swift
if !types.intersection(StorageType.images.types).isEmpty {
  types.formUnion(StorageType.images.types)
}
```

**Fix is:** swap `!types.intersection(...).isEmpty` for the logically identical `!types.isDisjoint(with:)` — "not disjoint" is the same as "intersection non-empty". No behavior change.

**Verification:** `swiftlint lint --strict` goes from `Found 1 violation, 1 serious` to `Found 0 violations`; `xcodebuild build` succeeds. Behavior-equivalent refactor, so no test is added.