### PR TITLE
Limit large text preview rendering

### DIFF
--- a/Maccy/Clipboard.swift
+++ b/Maccy/Clipboard.swift
@@ -34,8 +34,12 @@ class Clipboard {
   private var disabledTypes: Set<NSPasteboard.PasteboardType> { supportedTypes.subtracting(enabledTypes) }
 
   private var sourceApp: NSRunningApplication? { NSWorkspace.shared.frontmostApplication }
+  private let sourceAppBundleIdentifier: () -> String?
 
-  init() {
+  init(sourceAppBundleIdentifier: @escaping () -> String? = {
+    NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+  }) {
+    self.sourceAppBundleIdentifier = sourceAppBundleIdentifier
     changeCount = pasteboard.changeCount
   }
 
@@ -177,7 +181,8 @@ class Clipboard {
       return
     }
 
-    if let sourceAppBundle = sourceApp?.bundleIdentifier, shouldIgnore(sourceAppBundle) {
+    let sourceAppBundle = sourceAppBundleIdentifier()
+    if let sourceAppBundle, shouldIgnore(sourceAppBundle) {
       return
     }
 
@@ -224,7 +229,7 @@ class Clipboard {
       try? History.shared.insertIntoStorage(historyItem)
     }
 
-    historyItem.application = sourceApp?.bundleIdentifier
+    historyItem.application = sourceAppBundle
     historyItem.title = historyItem.generateTitle()
 
     onNewCopyHooks.forEach({ $0(historyItem) })

--- a/Maccy/Extensions/String+Shortened.swift
+++ b/Maccy/Extensions/String+Shortened.swift
@@ -1,9 +1,5 @@
 extension String {
   func shortened(to maxLength: Int) -> String {
-    guard count > maxLength else {
-      return self
-    }
-
-    return String(self[startIndex..<index(startIndex, offsetBy: maxLength)])
+    String(prefix(maxLength))
   }
 }

--- a/Maccy/Extensions/String+Shortened.swift
+++ b/Maccy/Extensions/String+Shortened.swift
@@ -1,5 +1,5 @@
 extension String {
   func shortened(to maxLength: Int) -> String {
-    String(prefix(maxLength))
+    String(prefix(max(0, maxLength)))
   }
 }

--- a/Maccy/Extensions/String+Shortened.swift
+++ b/Maccy/Extensions/String+Shortened.swift
@@ -1,5 +1,5 @@
 extension String {
   func shortened(to maxLength: Int) -> String {
-    String(prefix(max(0, maxLength)))
+    String(prefix(maxLength))
   }
 }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -44,14 +44,12 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var previewImageGenerationTask: Task<(), Error>?
   var thumbnailImageGenerationTask: Task<(), Error>?
   var previewImage: NSImage?
-  var previewText: String {
-    item.previewableText
-  }
+  // 10k characters seems to be more than enough on large displays
+  var previewText: String { item.previewableText.shortened(to: 10_000) }
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 
-  // 10k characters seems to be more than enough on large displays
-  var text: String { previewText.shortened(to: 10_000) }
+  var text: String { previewText }
 
   var isPinned: Bool { item.pin != nil }
   var isUnpinned: Bool { item.pin == nil }

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -45,7 +45,16 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var thumbnailImageGenerationTask: Task<(), Error>?
   var previewImage: NSImage?
   // 10k characters seems to be more than enough on large displays
-  var previewText: String { item.previewableText.shortened(to: 10_000) }
+  @ObservationIgnored
+  private var cachedPreviewText: String?
+  var previewText: String {
+    if let cached = cachedPreviewText {
+      return cached
+    }
+    let text = item.previewableText.shortened(to: 10_000)
+    cachedPreviewText = text
+    return text
+  }
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 

--- a/Maccy/Observables/HistoryItemDecorator.swift
+++ b/Maccy/Observables/HistoryItemDecorator.swift
@@ -45,16 +45,7 @@ class HistoryItemDecorator: Identifiable, Hashable, HasVisibility {
   var thumbnailImageGenerationTask: Task<(), Error>?
   var previewImage: NSImage?
   // 10k characters seems to be more than enough on large displays
-  @ObservationIgnored
-  private var cachedPreviewText: String?
-  var previewText: String {
-    if let cached = cachedPreviewText {
-      return cached
-    }
-    let text = item.previewableText.shortened(to: 10_000)
-    cachedPreviewText = text
-    return text
-  }
+  var previewText: String { item.previewableText.shortened(to: 10_000) }
   var thumbnailImage: NSImage?
   var applicationImage: ApplicationImage
 

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -136,11 +136,15 @@ class ClipboardTests: XCTestCase {
     XCTAssertFalse(Defaults[.ignoreOnlyNextEvent])
   }
 
-  private var currentSourceApp: String {
-    NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "com.apple.finder"
+  private var currentSourceApp: String? {
+    NSWorkspace.shared.frontmostApplication?.bundleIdentifier
   }
 
-  func testIgnoreApplication() {
+  func testIgnoreApplication() throws {
+    guard let currentSourceApp else {
+      throw XCTSkip("No frontmost application available")
+    }
+
     Defaults[.ignoredApps] = [currentSourceApp, "com.apple.dt.Xcode", "com.apple.finder"]
 
     let hookExpectation = expectation(description: "Hook is called")
@@ -154,7 +158,11 @@ class ClipboardTests: XCTestCase {
     waitForExpectations(timeout: 2)
   }
 
-  func testIgnoreAllApplicationsExcept() {
+  func testIgnoreAllApplicationsExcept() throws {
+    guard let currentSourceApp else {
+      throw XCTSkip("No frontmost application available")
+    }
+
     Defaults[.ignoreAllAppsExceptListed] = true
     Defaults[.ignoredApps] = [currentSourceApp, "com.apple.dt.Xcode", "com.apple.finder"]
 

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -141,7 +141,7 @@ class ClipboardTests: XCTestCase {
   }
 
   func testIgnoreApplication() {
-    Defaults[.ignoredApps] = [currentSourceApp]
+    Defaults[.ignoredApps] = [currentSourceApp, "com.apple.dt.Xcode", "com.apple.finder"]
 
     let hookExpectation = expectation(description: "Hook is called")
     hookExpectation.isInverted = true
@@ -156,7 +156,7 @@ class ClipboardTests: XCTestCase {
 
   func testIgnoreAllApplicationsExcept() {
     Defaults[.ignoreAllAppsExceptListed] = true
-    Defaults[.ignoredApps] = [currentSourceApp]
+    Defaults[.ignoredApps] = [currentSourceApp, "com.apple.dt.Xcode", "com.apple.finder"]
 
     let hookExpectation = expectation(description: "Hook is called")
     clipboard.onNewCopy({ (_: HistoryItem) in

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -136,8 +136,12 @@ class ClipboardTests: XCTestCase {
     XCTAssertFalse(Defaults[.ignoreOnlyNextEvent])
   }
 
+  private var currentSourceApp: String {
+    NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "com.apple.finder"
+  }
+
   func testIgnoreApplication() {
-    Defaults[.ignoredApps] = ["com.apple.dt.Xcode", "com.apple.finder"] // Finder is on Bitrise
+    Defaults[.ignoredApps] = [currentSourceApp]
 
     let hookExpectation = expectation(description: "Hook is called")
     hookExpectation.isInverted = true
@@ -152,7 +156,7 @@ class ClipboardTests: XCTestCase {
 
   func testIgnoreAllApplicationsExcept() {
     Defaults[.ignoreAllAppsExceptListed] = true
-    Defaults[.ignoredApps] = ["com.apple.dt.Xcode", "com.apple.finder"] // Finder is on Bitrise
+    Defaults[.ignoredApps] = [currentSourceApp]
 
     let hookExpectation = expectation(description: "Hook is called")
     clipboard.onNewCopy({ (_: HistoryItem) in

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -136,44 +136,33 @@ class ClipboardTests: XCTestCase {
     XCTAssertFalse(Defaults[.ignoreOnlyNextEvent])
   }
 
-  private var currentSourceApp: String? {
-    NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-  }
+  @MainActor
+  func testIgnoreApplication() {
+    let clipboard = Clipboard(sourceAppBundleIdentifier: { "com.example.ignored" })
+    Defaults[.ignoredApps] = ["com.example.ignored"]
+    var hookCalled = false
+    clipboard.onNewCopy { _ in hookCalled = true }
 
-  func testIgnoreApplication() throws {
-    guard let currentSourceApp else {
-      throw XCTSkip("No frontmost application available")
-    }
-
-    Defaults[.ignoredApps] = [currentSourceApp, "com.apple.dt.Xcode", "com.apple.finder"]
-
-    let hookExpectation = expectation(description: "Hook is called")
-    hookExpectation.isInverted = true
-    clipboard.onNewCopy({ (_: HistoryItem) in
-      hookExpectation.fulfill()
-    })
-    clipboard.start()
     pasteboard.declareTypes([.string], owner: nil)
     pasteboard.setString("bar", forType: .string)
-    waitForExpectations(timeout: 2)
+    clipboard.checkForChangesInPasteboard()
+
+    XCTAssertFalse(hookCalled)
   }
 
-  func testIgnoreAllApplicationsExcept() throws {
-    guard let currentSourceApp else {
-      throw XCTSkip("No frontmost application available")
-    }
-
+  @MainActor
+  func testIgnoreAllApplicationsExcept() {
+    let clipboard = Clipboard(sourceAppBundleIdentifier: { "com.example.allowed" })
     Defaults[.ignoreAllAppsExceptListed] = true
-    Defaults[.ignoredApps] = [currentSourceApp, "com.apple.dt.Xcode", "com.apple.finder"]
+    Defaults[.ignoredApps] = ["com.example.allowed"]
+    var copiedItem: HistoryItem?
+    clipboard.onNewCopy { copiedItem = $0 }
 
-    let hookExpectation = expectation(description: "Hook is called")
-    clipboard.onNewCopy({ (_: HistoryItem) in
-      hookExpectation.fulfill()
-    })
-    clipboard.start()
     pasteboard.declareTypes([.string], owner: nil)
     pasteboard.setString("bar", forType: .string)
-    waitForExpectations(timeout: 2)
+    clipboard.checkForChangesInPasteboard()
+
+    XCTAssertEqual(copiedItem?.application, "com.example.allowed")
   }
 
   func testIgnoreTransientTypes() {

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -206,7 +206,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let text = String(repeating: "a", count: 2 * 1_024 * 1_024)
     let item = history.add(historyItem(text))
 
-    XCTAssertEqual(item.previewText.count, 10_000)
+    XCTAssertEqual(item.previewText, String(text.prefix(10_000)))
     XCTAssertEqual(item.item.text?.count, text.count)
   }
 

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -202,6 +202,14 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     XCTAssertEqual(history.items[0].text, "bar")
   }
 
+  func testLargeTextPreviewIsLimited() {
+    let text = String(repeating: "a", count: 2 * 1_024 * 1_024)
+    let item = history.add(historyItem(text))
+
+    XCTAssertEqual(item.previewText.count, 10_000)
+    XCTAssertEqual(item.item.text?.count, text.count)
+  }
+
   func testClearingUnpinned() throws {
     let pinned = history.add(historyItem("foo"))
     pinned.togglePin()

--- a/MaccyTests/HistoryTests.swift
+++ b/MaccyTests/HistoryTests.swift
@@ -207,7 +207,7 @@ class HistoryTests: XCTestCase { // swiftlint:disable:this type_body_length
     let item = history.add(historyItem(text))
 
     XCTAssertEqual(item.previewText, String(text.prefix(10_000)))
-    XCTAssertEqual(item.item.text?.count, text.count)
+    XCTAssertEqual(item.item.text, text)
   }
 
   func testClearingUnpinned() throws {

--- a/MaccyTests/ShortenedTests.swift
+++ b/MaccyTests/ShortenedTests.swift
@@ -15,6 +15,10 @@ final class ShortenedTests: XCTestCase {
     XCTAssertEqual("abcdefghij".shortened(to: 1_000), "abcdefghij")
   }
 
+  func testShortenedNegativeLengthReturnsEmpty() {
+    XCTAssertEqual("abcdef".shortened(to: -1), "")
+  }
+
   func testShortenedResultNeverExceedsMaxLength() {
     let input = "abcdef"
     for length in 0...8 {

--- a/MaccyTests/ShortenedTests.swift
+++ b/MaccyTests/ShortenedTests.swift
@@ -15,10 +15,6 @@ final class ShortenedTests: XCTestCase {
     XCTAssertEqual("abcdefghij".shortened(to: 1_000), "abcdefghij")
   }
 
-  func testShortenedNegativeLengthReturnsEmpty() {
-    XCTAssertEqual("abcdef".shortened(to: -1), "")
-  }
-
   func testShortenedResultNeverExceedsMaxLength() {
     let input = "abcdef"
     for length in 0...8 {


### PR DESCRIPTION
## Summary

- cap preview text at 10,000 characters before passing it to TextKit
- use `String.prefix` in `shortened(to:)` to avoid a full `String.count` traversal before truncation
- verify the exact preview prefix while preserving the complete stored clipboard text
- make source-application ignore tests deterministic by injecting fixed bundle IDs into the full pasteboard change path

## Motivation

`PreviewItemView` renders `HistoryItemDecorator.previewText`. On the base branch that property bypasses the existing 10,000-character limit on `text`, so multi-megabyte strings can be passed to `LargeTextPreviewView` in full.

The image preview branch uses `AsyncView`, but the large-text branch is an `NSViewRepresentable` path. Bounding the string passed into `NSTextView` avoids giving TextKit the complete clipboard payload for a visual preview.

## Repeated UI reproduction

A temporary XCUITest used the private one-line JSON sample from the original report (2,820,999 UTF-8 bytes, 2,210,051 code points, including 283,189 CJK code points). The sample contents and filename were not uploaded.

On `origin/master` at `39e0ba5`, XCUITest could not query the popup after the status-item click. Three attempts (the initial run plus two automatic retries) were right-censored by accessibility-query timeouts at 125.498, 113.735, and 113.872 seconds; the maximum observed Maccy CPU samples were approximately 100%. The planned explicit hover loop was never reached.

On patched `a7bf4a3`, three independent runs completed successfully in 27.120–28.917 seconds, including ten round trips between the large-text row and an adjacent row.

The UI runs were not randomized or interleaved: patched run 1 was followed by one base invocation containing three attempts (the initial run plus two automatic retries), then patched runs 2 and 3. XCUITest accessibility snapshotting can add overhead, so these are test-path results rather than ordinary UI timings. They show a consistent local association under this setup, not a causal profile. Detailed methodology and repeated standalone TextKit results are in the updated PR comment.

## Behavior boundary

Only the displayed preview is shortened. `HistoryItem.contents` remains unchanged and continues to supply the complete data when an item is copied or pasted.

`item.previewableText` is still fully materialized before truncation. This change limits TextKit input; it does not eliminate full UTF-8 decoding or RTF/HTML parsing.

## Validation

- `xcodebuild test -project Maccy.xcodeproj -scheme Maccy -destination 'platform=macOS' -only-testing:MaccyTests CODE_SIGNING_ALLOWED=NO`: 92 tests passed, 0 failures
- commit `a7bf4a3` passed the complete Bitrise workflow, including 36 UI tests
- the dedicated private-sample XCUITest A/B produced three base timeouts and three successful patched runs as described above
- a tester manually confirmed that a Release build containing the preview changes later committed as `26bf532` no longer stalled in their large-text scenario
