### PR TITLE
Migrate to swift6 with default main actor isolation

### DIFF
--- a/Maccy.xcodeproj/project.pbxproj
+++ b/Maccy.xcodeproj/project.pbxproj
@@ -39,8 +39,6 @@
 		4762D6972467226100B3A2BA /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4762D6992467226100B3A2BA /* Localizable.strings */; };
 		9B24FC30A093450F29E2CC4A /* View+Invisible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC045710F4F8773D1A5EC87 /* View+Invisible.swift */; };
 		C0FFEE000000000000000003 /* ShortenedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE000000000000000004 /* ShortenedTests.swift */; };
-		FFFC00000000000000000001 /* String+UnsafeForTitleLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFC00000000000000000002 /* String+UnsafeForTitleLayout.swift */; };
-		FFFC00000000000000000003 /* UnsafeForTitleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFC00000000000000000004 /* UnsafeForTitleLayoutTests.swift */; };
 		CA110ED10000000000000001 /* CollectionSurroundingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA110ED10000000000000002 /* CollectionSurroundingTests.swift */; };
 		DA009931256411F90030E697 /* appcast.xml in Resources */ = {isa = PBXBuildFile; fileRef = DA00992C256411F90030E697 /* appcast.xml */; };
 		DA009932256411F90030E697 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = DA00992D256411F90030E697 /* README.md */; };
@@ -154,6 +152,8 @@
 		DAFE2DE9268A9B1B00990986 /* HistoryItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */; };
 		DAFEF0B8249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */; };
 		F18F166970893C503065D056 /* View+ButtonAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2945CD7912BE7C7D330C27 /* View+ButtonAction.swift */; };
+		FFFC00000000000000000001 /* String+UnsafeForTitleLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFC00000000000000000002 /* String+UnsafeForTitleLayout.swift */; };
+		FFFC00000000000000000003 /* UnsafeForTitleLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFC00000000000000000004 /* UnsafeForTitleLayoutTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -236,19 +236,17 @@
 		67B1B7B16C214A9A8146309C /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/GeneralSettings.strings; sourceTree = "<group>"; };
 		72C94C4B662B4F0BBD150C82 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7CEEFDF124F41F8500ECAD2A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		9DC045710F4F8773D1A5EC87 /* View+Invisible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Invisible.swift"; sourceTree = "<group>"; };
 		82BF523B9E3C48AE8C38EB5B /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/GeneralSettings.strings; sourceTree = "<group>"; };
 		9C200975CB6B4E258D86BCA2 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/PreviewItemView.strings; sourceTree = "<group>"; };
+		9DC045710F4F8773D1A5EC87 /* View+Invisible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Invisible.swift"; sourceTree = "<group>"; };
 		ABC72863283A9053001EE086 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B21DCA6C3D17E48D33D6E608 /* VoiceOver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOver.swift; sourceTree = "<group>"; };
 		BA40A81B03FF445A83CCD4E7 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/IgnoreSettings.strings; sourceTree = "<group>"; };
 		BC59C5474269463B8A32BCEF /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AppearanceSettings.strings; sourceTree = "<group>"; };
 		C0FFEE000000000000000004 /* ShortenedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortenedTests.swift; sourceTree = "<group>"; };
-		FFFC00000000000000000002 /* String+UnsafeForTitleLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+UnsafeForTitleLayout.swift"; sourceTree = "<group>"; };
-		FFFC00000000000000000004 /* UnsafeForTitleLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeForTitleLayoutTests.swift; sourceTree = "<group>"; };
 		C2BC0DBD627544668E9BE9C1 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/StorageSettings.strings; sourceTree = "<group>"; };
 		CA110ED10000000000000002 /* CollectionSurroundingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionSurroundingTests.swift; sourceTree = "<group>"; };
 		CF8FD822BE40469D80B10A06 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/AdvancedSettings.strings; sourceTree = "<group>"; };
-		B21DCA6C3D17E48D33D6E608 /* VoiceOver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOver.swift; sourceTree = "<group>"; };
 		DA00992C256411F90030E697 /* appcast.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = appcast.xml; sourceTree = "<group>"; };
 		DA00992D256411F90030E697 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		DA00992F256411F90030E697 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -585,9 +583,11 @@
 		DAFE2DD9268A521A00990986 /* String+Shortened.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Shortened.swift"; sourceTree = "<group>"; };
 		DAFE2DE8268A9B1B00990986 /* HistoryItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItemTests.swift; sourceTree = "<group>"; };
 		DAFEF0B7249D7DEE006029E8 /* KeyboardShortcuts.Name+Shortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyboardShortcuts.Name+Shortcuts.swift"; sourceTree = "<group>"; };
-		EB2945CD7912BE7C7D330C27 /* View+ButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ButtonAction.swift"; sourceTree = "<group>"; };
 		E5885F0587B04A99933245E6 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/AdvancedSettings.strings; sourceTree = "<group>"; };
+		EB2945CD7912BE7C7D330C27 /* View+ButtonAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ButtonAction.swift"; sourceTree = "<group>"; };
 		F2E5FA9061DA4866BCFAFE90 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/AppearanceSettings.strings; sourceTree = "<group>"; };
+		FFFC00000000000000000002 /* String+UnsafeForTitleLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+UnsafeForTitleLayout.swift"; sourceTree = "<group>"; };
+		FFFC00000000000000000004 /* UnsafeForTitleLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeForTitleLayoutTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1593,7 +1593,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.MaccyUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
+				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = Maccy;
 			};
 			name = Debug;
@@ -1620,7 +1621,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.MaccyUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
+				SWIFT_VERSION = 6.0;
 				TEST_TARGET_NAME = Maccy;
 			};
 			name = Release;
@@ -1644,7 +1646,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.MaccyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Maccy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Maccy";
 			};
 			name = Debug;
@@ -1668,7 +1671,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.MaccyTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Maccy.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Maccy";
 			};
 			name = Release;
@@ -1731,8 +1735,11 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -1786,9 +1793,12 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -1824,7 +1834,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -1858,7 +1868,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.p0deje.Maccy;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};

--- a/Maccy/AppDelegate.swift
+++ b/Maccy/AppDelegate.swift
@@ -4,7 +4,7 @@ import Sparkle
 import SwiftUI
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-  static let isTesting = CommandLine.arguments.contains("enable-testing")
+  nonisolated static let isTesting = CommandLine.arguments.contains("enable-testing")
   var panel: FloatingPanel<ContentView>!
 
   @objc

--- a/Maccy/Extensions/Defaults.Keys+Names.swift
+++ b/Maccy/Extensions/Defaults.Keys+Names.swift
@@ -1,27 +1,27 @@
 import AppKit
 import Defaults
 
-struct StorageType {
+nonisolated struct StorageType {
   static let files = StorageType(types: [.fileURL])
   static let images = StorageType(types: [.png, .tiff, .jpeg, .heic])
   static let text = StorageType(types: [.html, .rtf, .string])
   static let all = StorageType(types: files.types + images.types + text.types)
 
-  var types: [NSPasteboard.PasteboardType]
+  let types: [NSPasteboard.PasteboardType]
 }
 
-extension Defaults.Keys {
+nonisolated extension Defaults.Keys {
 #if DEBUG
   // UI Tests bundle preferences
   static let testingSuiteName = "\(Bundle.main.bundleIdentifier ?? "org.p0deje.Maccy").uitests"
 
   // When UI tests run with the `enable-testing` argument, window and pin
   // preferences are stored in a separate xcuitest bundle
-  private static let preferencesSuite: UserDefaults = AppDelegate.isTesting
+  nonisolated(unsafe) private static let preferencesSuite: UserDefaults = AppDelegate.isTesting
     ? (UserDefaults(suiteName: testingSuiteName) ?? .standard)
     : .standard
 #else
-  private static let preferencesSuite: UserDefaults = .standard
+  nonisolated(unsafe) private static let preferencesSuite: UserDefaults = .standard
 #endif
 
   static let clearOnQuit = Key<Bool>("clearOnQuit", default: false, suite: preferencesSuite)

--- a/Maccy/Extensions/NSPasteboard.PasteboardType+Types.swift
+++ b/Maccy/Extensions/NSPasteboard.PasteboardType+Types.swift
@@ -1,7 +1,7 @@
 import AppKit.NSPasteboard
 import Defaults
 
-extension NSPasteboard.PasteboardType: Defaults.Serializable {
+nonisolated extension NSPasteboard.PasteboardType: Defaults.Serializable {
   static let heic = NSPasteboard.PasteboardType(rawValue: "public.heic")
   static let jpeg = NSPasteboard.PasteboardType(rawValue: "public.jpeg")
   static let universalClipboard = NSPasteboard.PasteboardType(rawValue: "com.apple.is-remote-clipboard")

--- a/Maccy/Extensions/NSPoint+DefaultsSerializable.swift
+++ b/Maccy/Extensions/NSPoint+DefaultsSerializable.swift
@@ -2,5 +2,5 @@ import CoreGraphics
 import Defaults
 import Foundation
 
-extension NSPoint: Defaults.Serializable {
+nonisolated extension NSPoint: Defaults.Serializable {
 }

--- a/Maccy/Extensions/NSSize+DefaultsSerializable.swift
+++ b/Maccy/Extensions/NSSize+DefaultsSerializable.swift
@@ -2,5 +2,5 @@ import CoreGraphics
 import Defaults
 import Foundation
 
-extension NSSize: Defaults.Serializable {
+nonisolated extension NSSize: Defaults.Serializable {
 }

--- a/Maccy/Extensions/String+Shortened.swift
+++ b/Maccy/Extensions/String+Shortened.swift
@@ -1,4 +1,4 @@
-extension String {
+nonisolated extension String {
   func shortened(to maxLength: Int) -> String {
     guard count > maxLength else {
       return self

--- a/Maccy/Extensions/String+UnsafeForTitleLayout.swift
+++ b/Maccy/Extensions/String+UnsafeForTitleLayout.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension String {
+nonisolated extension String {
   // Unicode scalars that are known to hang CoreText's line truncation on
   // macOS 26. See https://github.com/p0deje/Maccy/issues/1520.
   //

--- a/Maccy/Intents/Clear.swift
+++ b/Maccy/Intents/Clear.swift
@@ -4,8 +4,8 @@ import Defaults
 struct Clear: AppIntent, CustomIntentMigratedAppIntent {
   static let intentClassName = "ClearIntent"
 
-  static var title: LocalizedStringResource = "Clear Clipboard History"
-  static var description = IntentDescription("Clears all Maccy clipboard history except for pinned items.")
+  static let title: LocalizedStringResource = "Clear Clipboard History"
+  static let description = IntentDescription("Clears all Maccy clipboard history except for pinned items.")
 
   static var parameterSummary: some ParameterSummary {
     Summary("Clear Clipboard History")

--- a/Maccy/Intents/Delete.swift
+++ b/Maccy/Intents/Delete.swift
@@ -3,8 +3,8 @@ import AppIntents
 struct Delete: AppIntent, CustomIntentMigratedAppIntent {
   static let intentClassName = "DeleteIntent"
 
-  static var title: LocalizedStringResource = "Delete Item from Clipboard History"
-  static var description = IntentDescription("Deletes an item from Maccy clipboard history.")
+  static let title: LocalizedStringResource = "Delete Item from Clipboard History"
+  static let description = IntentDescription("Deletes an item from Maccy clipboard history.")
 
   @Parameter(title: "Number", default: 1)
   var number: Int
@@ -16,13 +16,15 @@ struct Delete: AppIntent, CustomIntentMigratedAppIntent {
   private let positionOffset = 1
 
   func perform() async throws -> some IntentResult {
-    let items = AppState.shared.history.items
-    let index = number - positionOffset
-    guard items.count >= index else {
-      throw AppIntentError.notFound
-    }
+    try await MainActor.run {
+      let items = AppState.shared.history.items
+      let index = number - positionOffset
+      guard items.count >= index else {
+        throw AppIntentError.notFound
+      }
 
-    await AppState.shared.history.delete(items[index])
+      AppState.shared.history.delete(items[index])
+    }
 
     return .result()
   }

--- a/Maccy/Intents/Get.swift
+++ b/Maccy/Intents/Get.swift
@@ -1,11 +1,21 @@
 import Foundation
 import AppIntents
 
+// Sendable snapshot of the item contents read on the main actor, so the
+// non-Sendable HistoryItem never crosses the actor boundary into `perform()`.
+private nonisolated struct ItemContents: Sendable {
+  let text: String?
+  let html: Data?
+  let file: URL?
+  let image: Data?
+  let rtf: Data?
+}
+
 struct Get: AppIntent, CustomIntentMigratedAppIntent {
   static let intentClassName = "GetIntent"
 
-  static var title: LocalizedStringResource = "Get Item from Clipboard History"
-  static var description = IntentDescription("""
+  static let title: LocalizedStringResource = "Get Item from Clipboard History"
+  static let description = IntentDescription("""
   Gets an item from Maccy clipboard history.
   The returned item can be used to access its plain/rich/HTML text, image contents or file location.
   """)
@@ -32,38 +42,50 @@ struct Get: AppIntent, CustomIntentMigratedAppIntent {
   }
 
   func perform() async throws -> some IntentResult & ReturnsValue<HistoryItemAppEntity> {
-    var item: HistoryItem?
-    if selected {
-      item = AppState.shared.navigator.selection.first?.item
-    } else {
-      let index = number - positionOffset
-      if AppState.shared.history.items.count >= index {
-        item = AppState.shared.history.items[index].item
+    // HistoryItem is main actor-isolated and not Sendable, so extract only the
+    // Sendable contents we need while on the main actor.
+    let contents = try await MainActor.run { () -> ItemContents in
+      var item: HistoryItem?
+      if selected {
+        item = AppState.shared.navigator.selection.first?.item
+      } else {
+        let index = number - positionOffset
+        if AppState.shared.history.items.count >= index {
+          item = AppState.shared.history.items[index].item
+        }
       }
-    }
 
-    guard let item else {
-      throw AppIntentError.notFound
+      guard let item else {
+        throw AppIntentError.notFound
+      }
+
+      return ItemContents(
+        text: item.text,
+        html: item.htmlData,
+        file: item.fileURLs.first,
+        image: item.imageData,
+        rtf: item.rtfData
+      )
     }
 
     let intentItem = HistoryItemAppEntity()
-    intentItem.text = item.text
+    intentItem.text = contents.text
 
-    if let html = item.htmlData {
+    if let html = contents.html {
       intentItem.html = String(data: html, encoding: .utf8)
     }
 
-    if let fileURL = item.fileURLs.first {
+    if let fileURL = contents.file {
       intentItem.file = fileURL
     }
 
-    if let imageData = item.imageData {
+    if let imageData = contents.image {
       let file = URL.documentsDirectory.appending(path: "image.png")
       try imageData.write(to: file, options: [.atomic, .completeFileProtection])
       intentItem.image = file
     }
 
-    if let rtf = item.rtfData {
+    if let rtf = contents.rtf {
       intentItem.richText = String(data: rtf, encoding: .utf8)
     }
 

--- a/Maccy/Intents/HistoryItemAppEntity.swift
+++ b/Maccy/Intents/HistoryItemAppEntity.swift
@@ -1,7 +1,7 @@
 import AppIntents
 
 struct HistoryItemAppEntity: TransientAppEntity {
-  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Clipboard item")
+  static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Clipboard item")
 
   @Property(title: "File")
   var file: URL?

--- a/Maccy/Intents/Select.swift
+++ b/Maccy/Intents/Select.swift
@@ -3,8 +3,8 @@ import AppIntents
 struct Select: AppIntent, CustomIntentMigratedAppIntent {
   static let intentClassName = "SelectIntent"
 
-  static var title: LocalizedStringResource = "Select Item in Clipboard History"
-  static var description = IntentDescription("""
+  static let title: LocalizedStringResource = "Select Item in Clipboard History"
+  static let description = IntentDescription("""
   Selects an item in Maccy clipboard history.
   Depending on Maccy settings, it might trigger pasting of the selected item.
   """)
@@ -19,14 +19,18 @@ struct Select: AppIntent, CustomIntentMigratedAppIntent {
   private let positionOffset = 1
 
   func perform() async throws -> some IntentResult & ReturnsValue<String> {
-    let items = AppState.shared.history.items
-    let index = number - positionOffset
-    guard items.count >= index else {
-      throw AppIntentError.notFound
-    }
+    let value = try await MainActor.run { () -> String in
+      let items = AppState.shared.history.items
+      let index = number - positionOffset
+      guard items.count >= index else {
+        throw AppIntentError.notFound
+      }
 
-    let value = items[index].title
-    await AppState.shared.history.select(items[index], flags: .currentModifierFlags)
+      let value = items[index].title
+      AppState.shared.history.select(items[index], flags: .currentModifierFlags)
+
+      return value
+    }
 
     return .result(value: value)
   }

--- a/Maccy/Models/HistoryItem.swift
+++ b/Maccy/Models/HistoryItem.swift
@@ -6,6 +6,7 @@ import Vision
 
 @Model
 class HistoryItem {
+  @MainActor
   static var supportedPins: Set<String> {
     // "a" reserved for select all
     // "q" reserved for quit
@@ -92,6 +93,7 @@ class HistoryItem {
       }
   }
 
+  @MainActor
   func generateTitle() -> String {
     guard image == nil else {
       Task {
@@ -231,6 +233,7 @@ class HistoryItem {
       .compactMap { $0.value }
   }
 
+  @MainActor
   private func performTextRecognition() {
     guard let cgImage = image?.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
       return

--- a/Maccy/Observables/Popup.swift
+++ b/Maccy/Observables/Popup.swift
@@ -58,7 +58,7 @@ class Popup {
     initEventsMonitor()
   }
 
-  deinit {
+  isolated deinit {
     deinitEventsMonitor()
   }
 

--- a/Maccy/Settings/StorageSettingsPane.swift
+++ b/Maccy/Settings/StorageSettingsPane.swift
@@ -51,7 +51,7 @@ struct StorageSettingsPane: View {
       }
     }
 
-    deinit {
+    isolated deinit {
       observer?.invalidate()
     }
   }

--- a/MaccyTests/ClipboardTests.swift
+++ b/MaccyTests/ClipboardTests.swift
@@ -3,6 +3,7 @@ import Defaults
 @testable import Maccy
 
 // swiftlint:disable type_body_length
+@MainActor
 class ClipboardTests: XCTestCase {
   let clipboard = Clipboard.shared
   let pasteboard = NSPasteboard.general
@@ -202,7 +203,6 @@ class ClipboardTests: XCTestCase {
     waitForExpectations(timeout: 2)
   }
 
-  @MainActor
   func testCopy() {
     let imageData = image.tiffRepresentation!
     let contents = [
@@ -222,14 +222,12 @@ class ClipboardTests: XCTestCase {
     XCTAssertEqual(pasteboard.string(forType: .source), "com.foo.bar")
   }
 
-  @MainActor
   func testCopyString() {
     clipboard.copyInMaccy("foo")
     XCTAssertEqual(pasteboard.string(forType: .string), "foo")
     XCTAssertEqual(pasteboard.string(forType: .source), NSPasteboard.PasteboardType.fromMaccy.rawValue)
   }
 
-  @MainActor
   func testCopyWithoutFormatting() {
     let contents = [
       HistoryItemContent(type: stringType.rawValue, value: "foo".data(using: .utf8)!),

--- a/MaccyTests/ColorImageTests.swift
+++ b/MaccyTests/ColorImageTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Maccy
 
+@MainActor
 class ColorImageTests: XCTestCase {
   func testColorImageFromShortHex() {
     XCTAssertNotNil(ColorImage.from("fff"))

--- a/MaccyTests/SearchTests.swift
+++ b/MaccyTests/SearchTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Defaults
 @testable import Maccy
 
+@MainActor
 class SearchTests: XCTestCase {
   let savedSearchMode = Defaults[.searchMode]
   var items: [Search.Searchable]!
@@ -11,7 +12,6 @@ class SearchTests: XCTestCase {
     Defaults[.searchMode] = savedSearchMode
   }
 
-  @MainActor
   func testSimpleSearch() { // swiftlint:disable:this function_body_length
     Defaults[.searchMode] = Search.Mode.exact
     items = [
@@ -72,7 +72,6 @@ class SearchTests: XCTestCase {
     XCTAssertEqual(search("m"), [])
   }
 
-  @MainActor
   func testFuzzySearch() { // swiftlint:disable:this function_body_length
     Defaults[.searchMode] = Search.Mode.fuzzy
     items = [
@@ -157,7 +156,6 @@ class SearchTests: XCTestCase {
     XCTAssertEqual(search("m"), [])
   }
 
-  @MainActor
   func testRegexpSearch() { // swiftlint:disable:this function_body_length
     Defaults[.searchMode] = Search.Mode.regexp
     items = [
@@ -246,7 +244,6 @@ class SearchTests: XCTestCase {
     return lowerBound..<upperBound
   }
 
-  @MainActor
   private func historyItemWithTitle(_ value: String?) -> HistoryItem {
     let contents = [
       HistoryItemContent(

--- a/MaccyTests/SorterTests.swift
+++ b/MaccyTests/SorterTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Defaults
 @testable import Maccy
 
+@MainActor
 class SorterTests: XCTestCase {
   let savedPinTo = Defaults[.pinTo]
   let sorter = Sorter()
@@ -10,9 +11,8 @@ class SorterTests: XCTestCase {
   var item2: HistoryItem!
   var item3: HistoryItem!
 
-  @MainActor
-  override func setUp() {
-    super.setUp()
+  override func setUp() async throws {
+    try await super.setUp()
     item1 = historyItem(value: "foo", firstCopiedAt: -300, lastCopiedAt: -100, numberOfCopies: 3)
     item2 = historyItem(value: "bar", firstCopiedAt: -400, lastCopiedAt: -300, numberOfCopies: 2)
     item3 = historyItem(value: "bar", firstCopiedAt: -200, lastCopiedAt: -200, numberOfCopies: 1)
@@ -51,7 +51,6 @@ class SorterTests: XCTestCase {
     XCTAssertEqual(sorter.sort([item1, item2, item3], by: .lastCopiedAt), [item2, item1, item3])
   }
 
-  @MainActor
   private func historyItem(
     value: String,
     firstCopiedAt: Int,

--- a/MaccyUITests/MaccyUITests.swift
+++ b/MaccyUITests/MaccyUITests.swift
@@ -17,6 +17,7 @@ private struct HistoryItemQuery {
   }
 }
 
+@MainActor
 class MaccyUITests: XCTestCase {
   let app = XCUIApplication()
   let pasteboard = NSPasteboard.general


### PR DESCRIPTION
Migrate to Swift 6 language mode

The project now requires Xcode 26+ to build!

Enable Swift 6 with default main-actor isolation (Approachable
Concurrency) on the app target, which fits Maccy's main-thread-centric
design and resolves most strict-concurrency errors without per-type
annotations. Test targets keep nonisolated default isolation.

- AppIntents: make static title/description let constants; run the
  main-actor History/HistoryItem work inside MainActor.run and return
  only Sendable values (Get uses a Sendable ItemContents snapshot)
- Mark global constants/pure helpers nonisolated: Defaults.Keys,
  NSSize/NSPoint/NSPasteboard.PasteboardType serializable extensions,
  String+Shortened, String+UnsafeForTitleLayout, StorageType,
  AppDelegate.isTesting
- Use isolated deinit in Popup and StorageSettingsPane.ViewModel
- Isolate HistoryItem.supportedPins/generateTitle/performTextRecognition
  to the main actor
- Annotate XCTest classes @MainActor where they touch app state